### PR TITLE
Rename two Saturn images and move one

### DIFF
--- a/catfiles/studiesspitzer.yml
+++ b/catfiles/studiesspitzer.yml
@@ -249,7 +249,6 @@ children:
 - place 4b4e3b36-d1e1-41ba-83de-6386f2dd2c90
 - place b0724545-0bb5-43b8-8add-492061e75aaf
 - place c4221609-7d02-4886-bf8b-72c33767103e
-- place ceceecb5-5030-488d-b16e-bf5a0a7aa3ff
 - place 7ea0ba50-b93c-4d56-b18b-34c939f129aa
 - place b1f657fb-fa08-4f93-85aa-2556d66260a2
 - place c910ce41-dfc5-4436-a284-4cbef68ca471

--- a/imagesets/sky__visible.xml
+++ b/imagesets/sky__visible.xml
@@ -99327,31 +99327,6 @@ the large galaxy in the lower part of the image,...</Credits>
   </ImageSet>
   <ImageSet
     BandPass="Visible"
-    BaseDegreesPerTile="0.34844672"
-    BaseTileLevel="0"
-    BottomsUp="False"
-    CenterX="174.914069"
-    CenterY="4.456195"
-    DataSetType="Sky"
-    ElevationModel="False"
-    FileType=".png"
-    Generic="False"
-    Name="Saturn"
-    Projection="Tan"
-    QuadTreeMap=""
-    Rotation="23"
-    Sparse="True"
-    StockSet="False"
-    TileLevels="2"
-    Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2009-19a1L{1}X{2}Y{3}.png"
-    WidthFactor="1"
-  >
-    <Credits>NASA/JPL-Caltech/Univ. of Virgin; This picture shows a slice of Saturn's largest ring, as seen in infrared light by NASA's Spitzer Space Telescope. The observator...</Credits>
-    <CreditsUrl>https://www.spitzer.caltech.edu/image/ssc2009-19a1-big-band-of-dust</CreditsUrl>
-    <ThumbnailUrl>http://wwtfiles.blob.core.windows.net/vamp/thumb-Spitzer-ssc2009-19a1.jpg</ThumbnailUrl>
-  </ImageSet>
-  <ImageSet
-    BandPass="Visible"
     BaseDegreesPerTile="0.422201275733333"
     BaseTileLevel="0"
     BottomsUp="False"
@@ -99361,7 +99336,7 @@ the large galaxy in the lower part of the image,...</Credits>
     ElevationModel="False"
     FileType=".png"
     Generic="False"
-    Name="Saturn"
+    Name="Infrared Ring Around Saturn"
     Projection="Tan"
     QuadTreeMap=""
     Rotation="23"

--- a/places/sky_ra11.yml
+++ b/places/sky_ra11.yml
@@ -2312,24 +2312,13 @@ ra_hr: 11.7128828266667
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Spitzer-sig15-013.jpg
 zoom_level: 0.28406874112
 ---
-_uuid: ceceecb5-5030-488d-b16e-bf5a0a7aa3ff
-classification: ''
-constellation: VIR
-data_set_type: Sky
-dec_deg: 4.456195
-foreground_image_set_url: http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2009-19a1L{1}X{2}Y{3}.png
-name: Saturn
-ra_hr: 11.6609379333333
-thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Spitzer-ssc2009-19a1.jpg
-zoom_level: 1.39378688
----
 _uuid: c4221609-7d02-4886-bf8b-72c33767103e
 classification: ''
 constellation: VIR
 data_set_type: Sky
 dec_deg: 4.456195
 foreground_image_set_url: http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2009-19aL{1}X{2}Y{3}.png
-name: Saturn
+name: Infrared Ring Around Saturn
 ra_hr: 11.6609379333333
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Spitzer-ssc2009-19a.jpg
 zoom_level: 1.68880510293333

--- a/sad_imagesets/sky__visible.xml
+++ b/sad_imagesets/sky__visible.xml
@@ -421,4 +421,30 @@
     <CreditsUrl>http://wise.astro.ucla.edu</CreditsUrl>
     <ThumbnailUrl>http://wwtfiles.blob.core.windows.net/vamp/thumb-Wise-WISE2011-015.jpg</ThumbnailUrl>
   </ImageSet>
+  <ImageSet
+    _Reason="Bad astrometry, and mostly not sky imagery anyway; ssc2009-19a is closer"
+    BandPass="Visible"
+    BaseDegreesPerTile="0.34844672"
+    BaseTileLevel="0"
+    BottomsUp="False"
+    CenterX="174.914069"
+    CenterY="4.456195"
+    DataSetType="Sky"
+    ElevationModel="False"
+    FileType=".png"
+    Generic="False"
+    Name="Big Band of Dust"
+    Projection="Tan"
+    QuadTreeMap=""
+    Rotation="23"
+    Sparse="True"
+    StockSet="False"
+    TileLevels="2"
+    Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2009-19a1L{1}X{2}Y{3}.png"
+    WidthFactor="1"
+  >
+    <Credits>NASA/JPL-Caltech/Univ. of Virgin; This picture shows a slice of Saturn's largest ring, as seen in infrared light by NASA's Spitzer Space Telescope. The observator...</Credits>
+    <CreditsUrl>https://www.spitzer.caltech.edu/image/ssc2009-19a1-big-band-of-dust</CreditsUrl>
+    <ThumbnailUrl>http://wwtfiles.blob.core.windows.net/vamp/thumb-Spitzer-ssc2009-19a1.jpg</ThumbnailUrl>
+  </ImageSet>
 </Folder>


### PR DESCRIPTION
These were just named "Saturn", causing problems for the `GotoSaturn` command functionality as reported in WorldWideTelescope/wwt-windows-client#210. I'm pretty sure that a simple rename should fix the issue.

The astrometry for the "Infrared Ring Around Saturn" looks to be ballpark OK -- the top half of the image seems consistent with PS1-3pi, although with a substantial shift. "Big Band of Dust" doesn't agree astrometrically and it is mostly non-sky data, so we archive it.