### PR TITLE
Add a JWST toplevel, with just the alignment evaluation image

### DIFF
--- a/catfiles/exploreroot6.yml
+++ b/catfiles/exploreroot6.yml
@@ -35,6 +35,14 @@ children:
 - browseable: true
   children: []
   group: Explorer
+  name: JWST
+  searchable: true
+  thumbnail: http://cdn.worldwidetelescope.org/thumbnails/jwst.jpg
+  type: Sky
+  url: http://www.worldwidetelescope.org/wwtweb/catalog.aspx?W=jwst
+- browseable: true
+  children: []
+  group: Explorer
   name: Spitzer Studies
   searchable: true
   thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=spitzer

--- a/catfiles/jwst.yml
+++ b/catfiles/jwst.yml
@@ -1,0 +1,8 @@
+browseable: true
+children:
+- place 904fced3-5a43-424c-a458-ec20d4b0d52b
+group: Explorer
+name: JWST
+searchable: false
+thumbnail: http://cdn.worldwidetelescope.org/thumbnails/jwst.jpg
+type: Sky

--- a/imagesets/sky__visible.xml
+++ b/imagesets/sky__visible.xml
@@ -30428,6 +30428,33 @@
   </ImageSet>
   <ImageSet
     BandPass="Visible"
+    BaseDegreesPerTile="0.07140166377929005"
+    BaseTileLevel="0"
+    BottomsUp="False"
+    CenterX="268.89940309321"
+    CenterY="65.86811269447"
+    DataSetType="Sky"
+    ElevationModel="False"
+    FileType=".png"
+    Generic="False"
+    Name="JWST Telescope Alignment Evaluation Image"
+    OffsetX="0.009355139575007035"
+    OffsetY="-0.005390190403045801"
+    Projection="Tan"
+    QuadTreeMap=""
+    Rotation="-83.78134847776201"
+    Sparse="True"
+    StockSet="False"
+    TileLevels="5"
+    Url="http://data1.wwtassets.org/packages/2022/03_jwst_taei/{1}/{3}/{3}_{2}.png"
+    WidthFactor="2"
+  >
+    <Credits>NASA/STScI; astrometric solution by Gabe Brammer</Credits>
+    <CreditsUrl>https://github.com/gbrammer/jwst_EERS</CreditsUrl>
+    <ThumbnailUrl>http://data1.wwtassets.org/packages/2022/03_jwst_taei/thumb.jpg</ThumbnailUrl>
+  </ImageSet>
+  <ImageSet
+    BandPass="Visible"
     BaseDegreesPerTile="180"
     BaseTileLevel="0"
     BottomsUp="False"

--- a/places/sky_ra17.yml
+++ b/places/sky_ra17.yml
@@ -1458,6 +1458,25 @@ ra_hr: 17.761274270564297
 thumbnail: http://data1.wwtassets.org/packages/2021/02_sofia/galactic_center_sofia/thumb.jpg
 zoom_level: 10.5672
 ---
+_uuid: 904fced3-5a43-424c-a458-ec20d4b0d52b
+classification: ''
+constellation: DRA
+data_set_type: Sky
+dec_deg: 65.85822835386412
+description: While the purpose of this image was to focus on the bright star
+  at the center for alignment evaluation, Webb's optics and NIRCam are so
+  sensitive that the galaxies and stars seen in the background show up. At this
+  stage of Webb’s mirror alignment, known as “fine phasing,” each of the primary
+  mirror segments have been adjusted to produce one unified image of the same
+  star using only the NIRCam instrument. This image of the star, which is called
+  2MASS J17554042+6551277, uses a red filter to optimize visual contrast. |
+  Astrometric solution by Gabe Brammer.
+foreground_image_set_url: http://data1.wwtassets.org/packages/2022/03_jwst_taei/{1}/{3}/{3}_{2}.png
+name: JWST Telescope Alignment Evaluation Image
+ra_hr: 17.92733512725823
+thumbnail: http://data1.wwtassets.org/packages/2022/03_jwst_taei/thumb.jpg
+zoom_level: 0.5
+---
 _uuid: b8aa745a-f65b-4948-b3c1-4965d00a6012
 angular_size: 1.0
 classification: Galaxy


### PR DESCRIPTION
Just the alignment evaluation image ... for now! The URL of the WTML *will* be (not yet published):

http://www.worldwidetelescope.org/wwtweb/catalog.aspx?W=jwst

CC @astrodavid10 @alexanderbock @ylvaselling