### PR TITLE
Add the JWST FGS image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/outputs/
+/searchcats/

--- a/README.md
+++ b/README.md
@@ -140,9 +140,23 @@ az storage azcopy blob upload -c '$web' -s searchdata_v2.min.js -d data/
 ### `cattool ingest <WTML>`
 
 This reads a WTML file and updates `places/`, and `imagesets/` with its data
-contents. If you have a WTML defining new datasets to include, use this. With
-the `--emit` option, it will also create a new catalog template in `catfiles/`
-mirroring the input WTML's structure.
+contents. If you have a WTML defining new datasets to include, use this.
+
+With the `--prepend-to=FILENAME` option, this command will update an existing
+catalog template file to include the newly-ingested imagery at its beginning.
+For instance, the command:
+
+```sh
+./cattool.py ingest jwst_fgs_preview.wtml --prepend-to=catfiles/jwst.wtml
+```
+
+will take the new images and places defined in the file `jwst_fgs_preview.wtml`,
+incorporate their definitions into the database, and add the new images at the
+beginning of the `jwst` catalog.
+
+With the `--emit` option, this command will create a wholly new catalog template
+in `catfiles/` mirroring the input WTML's structure. You'll only want this
+option if you're importing a substantial, new image collection.
 
 ### `cattool report`
 

--- a/catfiles/jwst.yml
+++ b/catfiles/jwst.yml
@@ -1,5 +1,6 @@
 browseable: true
 children:
+- place 6def518b-6151-4c07-ac9d-b96234240c70
 - place 904fced3-5a43-424c-a458-ec20d4b0d52b
 group: Explorer
 name: JWST

--- a/cattool.py
+++ b/cattool.py
@@ -923,6 +923,15 @@ def do_ingest(settings):
     if settings.emit:
         write_one_yaml(f"catfiles/{catname}.yml", info)
 
+    if settings.prepend_to:
+        print(f"Updating `{settings.prepend_to}`.")
+
+        with open(settings.prepend_to, "rt", encoding="utf-8") as f:
+            existing = yaml.load(f, yaml.SafeLoader)
+
+        existing["children"] = info["children"] + existing["children"]
+        write_one_yaml(settings.prepend_to, existing)
+
 
 # prettify - generic XML prettification
 
@@ -1193,6 +1202,11 @@ def entrypoint():
     _ground_truth = subparsers.add_parser("ground-truth")
 
     ingest = subparsers.add_parser("ingest")
+    ingest.add_argument(
+        "--prepend-to",
+        metavar="YML-PATH",
+        help="Add the new places to the specific, existing catalog file",
+    )
     ingest.add_argument(
         "--emit",
         action="store_true",

--- a/imagesets/sky__visible.xml
+++ b/imagesets/sky__visible.xml
@@ -30455,6 +30455,31 @@
   </ImageSet>
   <ImageSet
     BandPass="Visible"
+    BaseDegreesPerTile="0.0783219477164671"
+    BaseTileLevel="0"
+    BottomsUp="False"
+    CenterX="245.960639475024"
+    CenterY="28.44510984425"
+    DataSetType="Sky"
+    ElevationModel="False"
+    FileType=".png"
+    Generic="False"
+    Name="Webb’s Fine Guidance Sensor Provides a Preview"
+    Projection="Tan"
+    QuadTreeMap=""
+    Rotation="-157.864616609149"
+    Sparse="False"
+    StockSet="False"
+    TileLevels="4"
+    Url="http://data1.wwtassets.org/packages/2022/07_jwst/jwst_fgs_preview/{1}/{3}/{3}_{2}.png"
+    WidthFactor="2"
+  >
+    <Credits>NASA/CSA/FGS Team</Credits>
+    <CreditsUrl>https://blogs.nasa.gov/webb/2022/07/06/webbs-fine-guidance-sensor-provides-a-preview/</CreditsUrl>
+    <ThumbnailUrl>http://data1.wwtassets.org/packages/2022/07_jwst/jwst_fgs_preview/thumb.jpg</ThumbnailUrl>
+  </ImageSet>
+  <ImageSet
+    BandPass="Visible"
     BaseDegreesPerTile="180"
     BaseTileLevel="0"
     BottomsUp="False"

--- a/places/sky_ra16.yml
+++ b/places/sky_ra16.yml
@@ -1036,6 +1036,17 @@ ra_hr: 16.852309528999932
 thumbnail: http://data1.wwtassets.org/packages/2021/08_lofar_17821/HerculesA/thumb.jpg
 zoom_level: 0.45095753587148346
 ---
+_uuid: 6def518b-6151-4c07-ac9d-b96234240c70
+classification: ''
+constellation: CRB
+data_set_type: Sky
+dec_deg: 28.44510984425
+foreground_image_set_url: http://data1.wwtassets.org/packages/2022/07_jwst/jwst_fgs_preview/{1}/{3}/{3}_{2}.png
+name: Webb’s Fine Guidance Sensor Provides a Preview
+ra_hr: 16.3973759650016
+thumbnail: http://data1.wwtassets.org/packages/2022/07_jwst/jwst_fgs_preview/thumb.jpg
+zoom_level: 0.5209518574162532
+---
 _uuid: f65c7098-2d22-4662-bba2-9660ac227621
 angular_size: 1.0
 classification: MultipleStars


### PR DESCRIPTION
CC @astrodavid10

Here we add the new JWST FGS preview image.

I've also updated the tooling to try to make it automatic to incorporate new images to existing collections. The `./cattool.py ingest` command deals with ingesting new imagery from WTML files, and the new `--prepend-to` option will prepend that imagery to an existing collection. In this case, I ran the command:

```
./cattool.py ingest jwst_fgs_preview.wtml  --prepend-to=catfiles/jwst.yml
```

(after editing the WTML to remove the unWISE background imageset definitions). Then all I needed to do was test the catalogs with the `preview` command (see the README) and commit the changes.