### PR TITLE
Import Hubble RELICS image of SMACS 0723-73

### DIFF
--- a/catfiles/studieshubble.yml
+++ b/catfiles/studieshubble.yml
@@ -233,6 +233,7 @@ children:
   searchable: true
   thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=galcolfdr
   type: Sky
+- place 64e2af0d-430a-42a2-b0ae-05e59b664912
 # Images from the `hubble` VAMP feed file:
 - place b65bffb4-a568-434c-a713-eb3af5bc7abd
 - place c27c4676-7561-4fe1-a7cf-91116ee8021d

--- a/imagesets/sky__visible.xml
+++ b/imagesets/sky__visible.xml
@@ -30705,6 +30705,33 @@ NIRCam was built by a team at the University of Arizona and Lockheed Martin’s 
   </ImageSet>
   <ImageSet
     BandPass="Visible"
+    BaseDegreesPerTile="0.13653333333333606"
+    BaseTileLevel="0"
+    BottomsUp="False"
+    CenterX="110.83349029316"
+    CenterY="-73.454202659629"
+    DataSetType="Sky"
+    ElevationModel="False"
+    FileType=".png"
+    Generic="False"
+    Name="Hubble RELICS SMACS J0723.3-7327 ACS-WFC3IR"
+    OffsetX="-4e-05"
+    OffsetY="-7e-05"
+    Projection="Tan"
+    QuadTreeMap=""
+    Rotation="0"
+    Sparse="True"
+    StockSet="False"
+    TileLevels="5"
+    Url="http://data1.wwtassets.org/packages/2022/08_hubble/smacs0723-73/{1}/{3}/{3}_{2}.png"
+    WidthFactor="2"
+  >
+    <Credits>ESA/Hubble &amp; NASA, RELICS</Credits>
+    <CreditsUrl>https://archive.stsci.edu/prepds/relics/color_images/smacs0723-73.html</CreditsUrl>
+    <ThumbnailUrl>http://data1.wwtassets.org/packages/2022/08_hubble/smacs0723-73/thumb.jpg</ThumbnailUrl>
+  </ImageSet>
+  <ImageSet
+    BandPass="Visible"
     BaseDegreesPerTile="180"
     BaseTileLevel="0"
     BottomsUp="False"

--- a/places/sky_ra07.yml
+++ b/places/sky_ra07.yml
@@ -483,6 +483,17 @@ ra_hr: 7.388518370448916
 thumbnail: http://data1.wwtassets.org/packages/2022/07_jwst/smacs0723/thumb.jpg
 zoom_level: 0.39337455578028513
 ---
+_uuid: 64e2af0d-430a-42a2-b0ae-05e59b664912
+classification: ''
+constellation: VOL
+data_set_type: Sky
+dec_deg: -73.45419
+foreground_image_set_url: http://data1.wwtassets.org/packages/2022/08_hubble/smacs0723-73/{1}/{3}/{3}_{2}.png
+name: Hubble RELICS SMACS J0723.3-7327 ACS-WFC3IR
+ra_hr: 7.3889
+thumbnail: http://data1.wwtassets.org/packages/2022/08_hubble/smacs0723-73/thumb.jpg
+zoom_level: 0.72
+---
 _uuid: 3b10fd74-4801-49bb-b3fa-88fb3977358f
 angular_size: 1.0
 classification: Galaxy


### PR DESCRIPTION
For nice comparisons with JWST. The astrometry here has been adjusted to line up with the JWST image.