### PR TITLE
Encode the current AstroPix associations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/astropix/
 /outputs/
 /searchcats/

--- a/README.md
+++ b/README.md
@@ -88,6 +88,21 @@ After this is done, the core database is updated with Constellations metadata,
 for posterity and to help make sure that work isn't duplicated.
 
 
+## Approach: AstroPix
+
+We are also integrating with AstroPix, which indexes many of the same images
+that can or should be found in WWT. To use the routines for cross-matching WWT's
+holdings to the AstroPix collection, download the AstroPix database as one big
+JSON file:
+
+```sh
+curl -fsSL "https://www.astropix.org/link/39po?format=json" -o astropix/all.json
+```
+
+(This link goes to a saved search that will match everything in the AstroPix
+database: "publisher ID is not adsdadasdasdas", basically.)
+
+
 ## Driver
 
 Operations are driven from the script `./cattool.py`, which has as Git-like
@@ -215,6 +230,14 @@ beginning of the `jwst` catalog.
 With the `--emit` option, this command will create a wholly new catalog template
 in `catfiles/` mirroring the input WTML's structure. You'll only want this
 option if you're importing a substantial, new image collection.
+
+
+### `cattool update-astropix`
+
+This command updates the `imagesets/` files with automatable cross-matches to
+the AstroPix database, and emits information about AstroPix imagery that
+couldn't be matched to anything in the WWT corpus. In general, anything in
+AstroPix with detailed WCS should be findable *somewhere* in the WWT catalogs.
 
 
 ### `cattool update-cxprep`

--- a/catfiles/studieshubble.yml
+++ b/catfiles/studieshubble.yml
@@ -55,7 +55,6 @@ children:
   - place 1505d98d-1840-473e-99d3-dffbb22ff833
   - place 7be6dd4c-7612-4544-b30e-e9abcd126cbb
   - place 175fd742-44e8-43e2-96ce-64efb9138f25
-  - place 6a0c9089-27d4-4949-83f9-abb1badee694
   - place c15e12cd-4fda-4ef0-ac98-d89ae3a3ed33
   - place 3b7b654b-23a7-4e69-8878-57151275fb28
   - place d50f590d-387b-45ff-88d9-1f8d07c78228

--- a/cattool.py
+++ b/cattool.py
@@ -2100,6 +2100,40 @@ def _astropix_associate_eso(idb: ImagesetDatabase, apimgs: Dict[str, dict]):
             imgset.xmeta.astropix_ids = ",".join(sorted(apids))
 
 
+def _astropix_associate_noirlab(idb: ImagesetDatabase, apimgs: Dict[str, dict]):
+    subset = {}
+    assocs = {}
+
+    for imgset in idb.by_url.values():
+        cr_url = imgset.credits_url
+
+        if "noirlab.edu" in cr_url:
+            subset[cr_url] = imgset
+
+            prev = getattr(imgset.xmeta, "astropix_ids", None)
+            if prev is None:
+                prev_ids = ()
+            else:
+                prev_ids = prev.split(",")
+
+            assocs[cr_url] = set(prev_ids)
+
+    for img_id in list(apimgs.keys()):
+        search = f"/{img_id}"
+
+        for cr_url, imgset in subset.items():
+            if search in cr_url:
+                assocs[cr_url].add(f"noirlab|{img_id}")
+                del apimgs[img_id]  # mark this one as associated
+                break
+
+    for cr_url, apids in assocs.items():
+        imgset = subset[cr_url]
+
+        if apids:
+            imgset.xmeta.astropix_ids = ",".join(sorted(apids))
+
+
 def do_update_astropix(_settings):
     # Load the AstroPix database
 
@@ -2170,6 +2204,7 @@ def do_update_astropix(_settings):
         "chandra": _astropix_associate_chandra,
         "esahubble": _astropix_associate_esahubble,
         "eso": _astropix_associate_eso,
+        "noirlab": _astropix_associate_noirlab,
     }
 
     for pubid, assoc_fn in assocs.items():

--- a/cattool.py
+++ b/cattool.py
@@ -793,6 +793,11 @@ class ConstellationsPrepDatabase(object):
                 fields["license_id"] = "~~LICENSE~~"
                 if imgset.thumbnail_url:
                     fields["thumbnail"] = imgset.thumbnail_url
+
+                apids = getattr(imgset.xmeta, "astropix_ids", None)
+                if apids:
+                    fields["astropix_ids"] = apids
+
                 fields["credits"] = imgset.credits
                 fields["wip"] = "yes"
                 items.append(("image", fields))

--- a/cattool.py
+++ b/cattool.py
@@ -2066,6 +2066,40 @@ def _astropix_associate_esahubble(idb: ImagesetDatabase, apimgs: Dict[str, dict]
             imgset.xmeta.astropix_ids = ",".join(sorted(apids))
 
 
+def _astropix_associate_eso(idb: ImagesetDatabase, apimgs: Dict[str, dict]):
+    subset = {}
+    assocs = {}
+
+    for imgset in idb.by_url.values():
+        cr_url = imgset.credits_url
+
+        if "eso.org" in cr_url:
+            subset[cr_url] = imgset
+
+            prev = getattr(imgset.xmeta, "astropix_ids", None)
+            if prev is None:
+                prev_ids = ()
+            else:
+                prev_ids = prev.split(",")
+
+            assocs[cr_url] = set(prev_ids)
+
+    for img_id in list(apimgs.keys()):
+        search = f"/{img_id}"
+
+        for cr_url, imgset in subset.items():
+            if search in cr_url:
+                assocs[cr_url].add(f"eso|{img_id}")
+                del apimgs[img_id]  # mark this one as associated
+                break
+
+    for cr_url, apids in assocs.items():
+        imgset = subset[cr_url]
+
+        if apids:
+            imgset.xmeta.astropix_ids = ",".join(sorted(apids))
+
+
 def do_update_astropix(_settings):
     # Load the AstroPix database
 
@@ -2135,6 +2169,7 @@ def do_update_astropix(_settings):
     assocs = {
         "chandra": _astropix_associate_chandra,
         "esahubble": _astropix_associate_esahubble,
+        "eso": _astropix_associate_eso,
     }
 
     for pubid, assoc_fn in assocs.items():

--- a/cattool.py
+++ b/cattool.py
@@ -2134,6 +2134,40 @@ def _astropix_associate_noirlab(idb: ImagesetDatabase, apimgs: Dict[str, dict]):
             imgset.xmeta.astropix_ids = ",".join(sorted(apids))
 
 
+def _astropix_associate_spitzer(idb: ImagesetDatabase, apimgs: Dict[str, dict]):
+    subset = {}
+    assocs = {}
+
+    for imgset in idb.by_url.values():
+        cr_url = imgset.credits_url
+
+        if "spitzer.caltech.edu" in cr_url:
+            subset[cr_url] = imgset
+
+            prev = getattr(imgset.xmeta, "astropix_ids", None)
+            if prev is None:
+                prev_ids = ()
+            else:
+                prev_ids = prev.split(",")
+
+            assocs[cr_url] = set(prev_ids)
+
+    for img_id in list(apimgs.keys()):
+        search = f"/{img_id}"
+
+        for cr_url, imgset in subset.items():
+            if search in cr_url:
+                assocs[cr_url].add(f"spitzer|{img_id}")
+                del apimgs[img_id]  # mark this one as associated
+                break
+
+    for cr_url, apids in assocs.items():
+        imgset = subset[cr_url]
+
+        if apids:
+            imgset.xmeta.astropix_ids = ",".join(sorted(apids))
+
+
 def do_update_astropix(_settings):
     # Load the AstroPix database
 
@@ -2205,6 +2239,7 @@ def do_update_astropix(_settings):
         "esahubble": _astropix_associate_esahubble,
         "eso": _astropix_associate_eso,
         "noirlab": _astropix_associate_noirlab,
+        "spitzer": _astropix_associate_spitzer,
     }
 
     for pubid, assoc_fn in assocs.items():

--- a/cattool.py
+++ b/cattool.py
@@ -2061,7 +2061,7 @@ def do_update_astropix(_settings):
         apids = getattr(imgset.xmeta, "astropix_ids", "")
         if apids:
             for apid in apids.split(","):
-                done_ids.add(apids)
+                done_ids.add(apid)
 
     if done_ids:
         print(f"{len(done_ids)} images already linked")
@@ -2136,7 +2136,15 @@ def do_update_astropix(_settings):
                     if imgid not in prev_imgids:
                         n_new += 1
 
-                    w.writerow((imgdata["image_id"], imgdata["reference_url"] or ""))
+                    w.writerow(
+                        (
+                            imgdata["image_id"],
+                            imgdata["reference_url"] or "",
+                            (imgdata["title"] or "")
+                            .replace("\n", " ")
+                            .replace("\r", " "),
+                        )
+                    )
 
         if n_tot or n_fixed:
             qpub = f"`{pubid}`"

--- a/cxprep/chandra.txt
+++ b/cxprep/chandra.txt
@@ -4,6 +4,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-418L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-418.jpg
+astropix_ids: chandra|418
 
 credits> X-ray: NASA/CXC/SAO, Infrared: N; This composite image of the Tycho
 supernova remnant combines X-ray and infrared observations obtained with NASA's
@@ -28,6 +29,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-421L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-421.jpg
+astropix_ids: chandra|421
 
 credits> X-ray (NASA/CXC/Harvard/J.Neilse; The inset of this graphic shows
 Chandra's X-ray image of GRS 1915+105 in context of a crowded field seen in
@@ -52,6 +54,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-425L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-425.jpg
+astropix_ids: chandra|425
 
 credits> X-ray (NASA/CXC/CfA/F.Massaro, e; This composite image of X-ray (red),
 radio (dark blue), and optical (light blue) data shows activity from the central
@@ -76,6 +79,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-427L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-427.jpg
+astropix_ids: chandra|427
 
 credits> X-ray (NASA/CXC/Penn State/S.Par; A new composite image from NASA's
 Chandra X-ray Observatory (purple) and Spitzer Space Telescope (red and green)
@@ -100,6 +104,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-430L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-430.jpg
+astropix_ids: chandra|430
 
 credits> X-ray (NASA/CXC/CfA/E.O'Sullivan; This composite image of X-rays from
 Chandra (colored light blue) and optical data from the Canada-France-Hawaii
@@ -124,6 +129,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-431L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-431.jpg
+astropix_ids: chandra|431
 
 credits> X-ray (NASA/CXC/MIT/D.Dewey et a; This composite image of X-rays from
 Chandra and optical data from Hubble shows new details of the aftermath of a
@@ -148,6 +154,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-432L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-432.jpg
+astropix_ids: chandra|432
 
 credits> X-ray (NASA/CXC/PSU/K. Getman et; This composite image of X-rays from
 Chandra (violet) and infrared data from Spitzer (red, green, and blue) reveals a
@@ -172,6 +179,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-434L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-434.jpg
+astropix_ids: chandra|434
 
 credits> X-ray: NASA/CXC/U.Waterloo/C.Kir; This composite image of the Hydra A
 galaxy cluster shows 10-million-degree gas observed by Chandra (blue) and jets
@@ -196,6 +204,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-436L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-436.jpg
+astropix_ids: chandra|436
 
 credits> X-ray (NASA/CXC/MIT/C.Canizares,; NGC 6240 is a system in which two
 supermassive black holes are a mere 3,000 light years apart. These black holes
@@ -220,6 +229,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-437L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-437.jpg
+astropix_ids: chandra|437
 
 credits> X-ray: NASA/CXC/INAF/S.Andreon e; This is a composite image of the most
 distant galaxy cluster yet detected. This image contains X-rays from NASA's
@@ -244,6 +254,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-438L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-438.jpg
+astropix_ids: chandra|438
 
 credits> X-ray: NASA/CXC/Southampton/W. H; New evidence from Chandra suggests
 that the neutron star at the center of the Cas A supernova remnant has an
@@ -268,6 +279,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-441L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-441.jpg
+astropix_ids: chandra|441
 
 credits> X-ray: NASA/CXC/SAO/M.Machacek;; This composite image of a collision
 between two galaxies, NGC 6872 and IC 4970, contains X-rays from Chandra
@@ -292,6 +304,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-443L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-443.jpg
+astropix_ids: chandra|443
 
 credits> X-ray: NASA/CXC/UA/J. Irwin et a; X-rays from Chandra and optical
 spectra from the Magellan telescopes provide evidence that a star was destroyed
@@ -316,6 +329,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-444L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-444.jpg
+astropix_ids: chandra|444
 
 credits> NASA/CXC/MIT/F.K. Baganoff et al; This Chandra image of Sgr A* and the
 region around it was based on almost two weeks of observing time. A theoretical
@@ -340,6 +354,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-445L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-445.jpg
+astropix_ids: chandra|445
 
 credits> X-ray: NASA/CXC/UVa/M. Sun, et a; This composite image of X-rays (blue)
 and optical and hydrogen light (yellow and red) shows two spectacular tails
@@ -364,6 +379,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-446L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-446.jpg
+astropix_ids: chandra|446
 
 credits> X-ray (NASA/CXC/SAO/P. Green et ; This composite image shows the
 effects of two galaxies caught in the act of merging. A Chandra X-ray
@@ -388,6 +404,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-447L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-447.jpg
+astropix_ids: chandra|447
 
 credits> X-ray (NASA/CXC/MPA/M.Gilfanov &; This composite image of M31 (a.k.a.
 the Andromeda galaxy) contains X-rays from Chandra (gold), optical emission
@@ -412,6 +429,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-448L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-448.jpg
+astropix_ids: chandra|448
 
 credits> X-ray (NASA/CXC/MIT/C.Canizares,; This composite image (X-rays from
 Chandra in red, optical data in green, and radio emission in blue) shows NGC
@@ -436,6 +454,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-449L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-449.jpg
+astropix_ids: chandra|449
 
 credits> X-ray: NASA/CXC/SAO/T.Temim et; A composite image from Chandra (blue)
 and Spitzer (green and red-yellow) data shows the dusty remains of a collapsed
@@ -460,6 +479,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-450L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-450.jpg
+astropix_ids: chandra|450
 
 credits> X-ray (NASA/CXC/SAO/A. Vikhlinin; This composite image of the galaxy
 cluster Abell 3376 combines Chandra and ROSAT X-ray data (gold), an optical
@@ -484,6 +504,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-453L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-453.jpg
+astropix_ids: chandra|453
 
 credits> X-ray: (NASA/CXC/Penn State/S.Pa; This composite image of data from
 Chandra (blue) and Hubble (yellow and purple) depicts the scene of a supernova
@@ -508,6 +529,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-454L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-454.jpg
+astropix_ids: chandra|454
 
 credits> X-ray (NASA/CXC/SAO/Li et al.),; The large image here shows an optical
 view, with the Digitized Sky Survey, of the Andromeda Galaxy, otherwise known as
@@ -532,6 +554,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-455L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-455.jpg
+astropix_ids: chandra|455
 
 credits> X-ray: NASA/CXC/SAO/M.Karovska e; The inset box in this graphic
 contains a composite image of X-ray data from Chandra (red), optical data from
@@ -556,6 +579,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-456L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-456.jpg
+astropix_ids: chandra|456
 
 credits> X-ray: NASA/CXC/SAO/F.Civano et ; Evidence for a recoiling black hole
 has been found using data from Chandra (colored blue in this composite image),
@@ -580,6 +604,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-457L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-457.jpg
+astropix_ids: chandra|457
 
 credits> X-ray (NASA/CXC/Univ of Strasbou; Combined data from Chandra (red,
 green, and blue) as well as optical light (light blue) and hydrogen emission
@@ -604,6 +629,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-458L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-458.jpg
+astropix_ids: chandra|458
 
 credits> X-ray (NASA/CXC/UMD/Hodges-Kluck; The close-up view in the inset shows
 a composite image of the galaxy 4C +00.58 in X-rays from Chandra (gold) and
@@ -628,6 +654,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-459L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-459.jpg
+astropix_ids: chandra|459
 
 credits> X-ray: NASA/CXC/SAO/J.DePasquale; This composite image of the Antennae
 galaxies contains X-rays from Chandra (blue), optical data from Hubble (gold and
@@ -652,6 +679,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-460L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-460.jpg
+astropix_ids: chandra|460
 
 credits> X-ray (NASA/CXC/KIPAC/N. Werner,; This composite image shows the
 eruption of a galactic "super-volcano" in the galaxy M87. X-rays from Chandra
@@ -676,6 +704,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-461L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-461.jpg
+astropix_ids: chandra|461
 
 credits> X-ray (NASA/CXC/SAO/M.Markevitch; This is a composite image of the
 northern part of the galaxy cluster Abell 1758 showing the effects of a
@@ -700,6 +729,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-462L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-462.jpg
+astropix_ids: chandra|462
 
 credits> X-ray (NASA/CXC/SAO/J. Wang et a; This X-ray and optical image shows
 the Rosette star formation region, located about 5,000 light years from Earth.
@@ -724,6 +754,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-463L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-463.jpg
+astropix_ids: chandra|463
 
 credits> X-ray (NASA/CXC/RIT/J.Kastner et al), Optical (UCO/Lick/STScI/M.Perrin
 et al); Illustration: NASA/CXC/M.Weiss
@@ -747,6 +778,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-464L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-464.jpg
+astropix_ids: chandra|464
 
 credits> X-ray: NASA/CXC/SAO/T.Temim et a; G327.1-1.1 is the aftermath of a
 massive star that exploded and left behind a highly magnetic, rapidly spinning
@@ -771,6 +803,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-466L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-466.jpg
+astropix_ids: chandra|466
 
 credits> X-ray: NASA/CXC/SAO/A.Siemiginowska et al, Optical: AURA/Gemini Obs.
 
@@ -793,6 +826,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-467L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-467.jpg
+astropix_ids: chandra|467
 
 credits> X-ray: NASA/CXC/SAO/D.Patnaude et al, Optical: ESO/VLT, Infrared:
 NASA/JPL/Caltech
@@ -816,6 +850,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-468L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-468.jpg
+astropix_ids: chandra|468
 
 credits> X-ray: NASA/CXC/SAO/S.Randall et; This composite image shows an
 intergalactic "weather map" around the elliptical galaxy NGC 5813. Just like a
@@ -840,6 +875,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-469L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-469.jpg
+astropix_ids: chandra|469
 
 credits> X-ray: NASA/CXC/SAO/J.Hughes et ; This composite image contains X-ray
 data from Chandra (green and blue) that show heated material in the center of a
@@ -864,6 +900,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-470L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-470.jpg
+astropix_ids: chandra|470
 
 credits> X-ray: NASA/CXC/Northwestern Univ/D.Haggard et al, Optical: SDSS
 
@@ -886,6 +923,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-471L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-471.jpg
+astropix_ids: chandra|471
 
 credits> NASA/CXC/Wesleyan/R.Kilgard et a; M82 is a galaxy where stars are
 forming at rates that are tens or even hundreds of times higher than in a normal
@@ -932,6 +970,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-473L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-473.jpg
+astropix_ids: chandra|473
 
 credits> X-ray (NASA/CXC/Virginia/A.Reine; Combined observations from Chandra
 (purple), the Very Large Array (yellow) along with Hubble (red, green, and blue)
@@ -956,6 +995,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-474L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-474.jpg
+astropix_ids: chandra|474
 
 credits> X-ray: NASA/CXC/MIT/S.Rappaport et al, Optical: NASA/STScI
 
@@ -978,6 +1018,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-476L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-476.jpg
+astropix_ids: chandra|476
 
 credits> X-ray: NASA/CXC/UNAM/Ioffe/D.Page,P.Shternin et al; Optical:
 NASA/STScI; Illustration: NASA/CXC/M.Weiss
@@ -1001,6 +1042,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-477L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-477.jpg
+astropix_ids: chandra|477
 
 credits> X-ray: NASA/CXC/CfA/J.Wang et al.; Optical: Isaac Newton Group of
 Telescopes, La Palma/Jacobus Kapteyn Telescope, Radio: NSF/NRAO/VLA
@@ -1024,6 +1066,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-478L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-478.jpg
+astropix_ids: chandra|478
 
 credits> X-ray: NASA/CXC/Rutgers/K.Erikse; A long Chandra observation of Tycho
 has revealed a pattern of X-ray stripes never seen before in a supernova
@@ -1048,6 +1091,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-479L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-479.jpg
+astropix_ids: chandra|479
 
 credits> NASA/CXC/Warwick/A.Levan et al.; The center of this image contains an
 extraordinary gamma-ray burst (GRB 110328A) observed with Chandra. The burst was
@@ -1072,6 +1116,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-480L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-480.jpg
+astropix_ids: chandra|480
 
 credits> X-ray: NASA/U. of Sydney/G.Ander; Data from Chandra and Spitzer of a
 region near the Galactic plane have been combined to track down some of the
@@ -1096,6 +1141,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-481L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-481.jpg
+astropix_ids: chandra|481
 
 credits> NASA/CXC/Chinese Academy of Scie; This Chandra image of the Tycho
 supernova remnant contains new evidence for what triggered the original
@@ -1120,6 +1166,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-483L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-483.jpg
+astropix_ids: chandra|483
 
 credits> NASA/CXC/PSU/L.Townsley et al.
 
@@ -1142,6 +1189,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-484L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-484.jpg
+astropix_ids: chandra|484
 
 credits> X-ray: NASA/CXC/U.Hawaii/E.Treis; This composite image combines the
 deepest X-ray image ever taken with optical and infrared data from Hubble.
@@ -1166,6 +1214,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-485L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-485.jpg
+astropix_ids: chandra|485
 
 credits> X-ray: NASA/CXC/ITA/INAF/J.Merte; This composite image features one of
 the most complicated and dramatic collisions between galaxy clusters ever seen.
@@ -1190,6 +1239,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-486L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-486.jpg
+astropix_ids: chandra|486
 
 credits> X-ray: NASA/CXC/IUSS/A.De Luca e; Astronomers using Chandra have found
 evidence for a possible long, X- ray bright tail extending from the pulsar
@@ -1214,6 +1264,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-487L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-487.jpg
+astropix_ids: chandra|487
 
 credits> X-ray: NASA/CXC/Univ. of Alabama; This composite image contains X-rays
 from Chandra (blue) and optical data from the VLT (gold) of the galaxy NGC 3115.
@@ -1238,6 +1289,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-488L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-488.jpg
+astropix_ids: chandra|488
 
 credits> X-ray NASA/CXC/IfA/D.Sanders et ; This composite image of VV 340
 contains X-ray data from Chandra (purple) and optical data from Hubble (red,
@@ -1262,6 +1314,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-489L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-489.jpg
+astropix_ids: chandra|489
 
 credits> X-ray: NASA/CXC/SAO/G.Fabbiano e; Evidence for a pair of supermassive
 black holes in a spiral galaxy has been found in data from NASA's Chandra X-ray
@@ -1286,6 +1339,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-491L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-491.jpg
+astropix_ids: chandra|491
 
 credits> X-ray: NASA/CXC/CfA/S.Wolk; IR: ; This composite image of NGC 281
 contains X-ray data from Chandra (purple) with infrared observations from
@@ -1310,6 +1364,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-492L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-492.jpg
+astropix_ids: chandra|492
 
 credits> X-ray: NASA/CXC/U. Texas at Arlington/S.Park et al, ROSAT; Infrared:
 2MASS/UMass/IPAC-Caltech/NASA/NSF
@@ -1333,6 +1388,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-494L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-494.jpg
+astropix_ids: chandra|494
 
 credits> NASA/JPL-Caltech/B. Williams (NC; This image combines data from four
 different space telescopes to create a multi-wavelength view of all that remains
@@ -1357,6 +1413,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-495L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-495.jpg
+astropix_ids: chandra|495
 
 credits> X-ray: NASA/CXC/PSU/L.Townsley e; About 2,400 massive stars in the
 center of 30 Doradus are producing intense radiation and powerful winds as they
@@ -1381,6 +1438,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-497L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-497.jpg
+astropix_ids: chandra|497
 
 credits> X-ray: NASA/CXC/BU/E.Blanton; Optical: ESO/VLT
 
@@ -1403,6 +1461,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-498L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-498.jpg
+astropix_ids: chandra|498
 
 credits> X-ray & Optical: NASA/CXC/Univ.P; In this composite image, X-rays from
 Chandra and XMM-Newton (blue) have been combined with optical data from the
@@ -1427,6 +1486,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-499L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-499.jpg
+astropix_ids: chandra|499
 
 credits> X-ray: NASA/CXC/Rutgers/J.Hughes; This galaxy cluster, which has been
 nicknamed "El Gordo" for the "big" or "fat" one in Spanish, is a remarkable
@@ -1451,6 +1511,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-500L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-500.jpg
+astropix_ids: chandra|500
 
 credits> X-ray: NASA/CXC/SAO/I.Lovchinsky; G350.1+0.3 is a young and
 exceptionally bright supernova remnant in our Galaxy. While many supernova
@@ -1475,6 +1536,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-501L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-501.jpg
+astropix_ids: chandra|501
 
 credits> X-ray: NASA/CXC/MIT/F. Baganoff ; A new study provides a possible
 explanation of mysterious X-ray flares detected by Chandra over the period of
@@ -1499,6 +1561,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-503L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-503.jpg
+astropix_ids: chandra|503
 
 credits> NASA, ESA, CFHT, CXO, M.J. Jee (; This composite image shows the
 distribution of dark matter, galaxies, and hot gas in the core of the merging
@@ -1523,6 +1586,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-504L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-504.jpg
+astropix_ids: chandra|504
 
 credits> X-ray: NASA/CXC/Caltech/A.Newman; Two teams of astronomers have used
 data from Chandra and other telescopes to map the distribution of dark matter in
@@ -1571,6 +1635,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-506L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-506.jpg
+astropix_ids: chandra|506
 
 credits> X-ray: NASA/CXC/UCDavis/W.Dawson; This composite image shows Chandra
 (red) and Hubble (yellow and white) data of the galaxy cluster system that has
@@ -1595,6 +1660,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-507L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-507.jpg
+astropix_ids: chandra|507
 
 credits> X-ray: NASA/CXC/PSU/L.Townsley e; This composite of 30 Doradus, aka the
 Tarantula Nebula, contains data from Chandra (blue), Hubble (green), and Spitzer
@@ -1619,6 +1685,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-511L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-511.jpg
+astropix_ids: chandra|511
 
 credits> X-ray: NASA/CXC/Royal Military C; This composite image shows the galaxy
 UGC 5189A in X-ray data from Chandra (purple) and optical data from Hubble (red,
@@ -1643,6 +1710,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-512L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-512.jpg
+astropix_ids: chandra|512
 
 credits> NASA/JPL-Caltech/ESA/CfA; This composite image of M101 (aka, the
 "Pinwheel Galaxy") combines data from four of NASA's space-based telescopes.
@@ -1667,6 +1735,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-513L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-513.jpg
+astropix_ids: chandra|513
 
 credits> X-ray: NASA/CXC/SAO/F.Civano et ; Chandra and other telescopes have
 shown that the galaxy CID-42 likely contains a massive black hole being ejected
@@ -1691,6 +1760,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-515L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-515.jpg
+astropix_ids: chandra|515
 
 credits> X-ray: NASA/CXC/UC Berkeley/J.To; Using Chandra, XMM-Newton, and the
 Parkes radio telescope, researchers have found evidence for what may be the
@@ -1715,6 +1785,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-518L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-518.jpg
+astropix_ids: chandra|518
 
 credits> X-ray: NASA/CXC/STScI/K.Long et ; Using Chandra, astronomers have
 detected X-rays from the remains of a supernova that was spotted from Earth over
@@ -1763,6 +1834,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-520L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-520.jpg
+astropix_ids: chandra|520
 
 credits> X-ray: NASA/CXC/U.Mich./S.Oey, I; The star cluster NGC 1929 contains
 massive stars that produce intense radiation, expel matter at high speeds, and
@@ -1787,6 +1859,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-521L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-521.jpg
+astropix_ids: chandra|521
 
 credits> X-ray: NASA/CXC/SAO/D.Patnaude, ; This composite image of Kepler's
 supernova remnant shows different colors ranging from lower to higher energies:
@@ -1811,6 +1884,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-524L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-524.jpg
+astropix_ids: chandra|524
 
 credits> X-ray: NASA/CXC/George Mason Uni; One of the lowest mass supermassive
 black holes ever observed in the middle of a galaxy has been identified, thanks
@@ -1835,6 +1909,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-525L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-525.jpg
+astropix_ids: chandra|525
 
 credits> X-ray: NASA/CXC/SAO/J.Drake et a; This composite image of the star
 cluster Cygnus OB2 contains X-rays from Chandra (blue), infrared data from
@@ -1859,6 +1934,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-526L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-526.jpg
+astropix_ids: chandra|526
 
 credits> Inset X-ray (NASA/CXC/IAA-CSIC/M; The inset image on the right is a
 close-up view of A30 showing X-ray data from NASA's Chandra X-ray Observatory in
@@ -1883,6 +1959,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-527L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-527.jpg
+astropix_ids: chandra|527
 
 credits> X-ray: NASA/CXC/NRC/C.Cheung et ; This composite image shows GB
 1428+4217, a quasar that contains the most distant X-ray jet ever observed. This
@@ -1907,6 +1984,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-528L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-528.jpg
+astropix_ids: chandra|528
 
 credits> X-ray (NASA/CXC/SAO/A.Prestwich ; NGC 922 was formed by the collision
 between two galaxies one seen in this composite image (where X-rays from Chandra
@@ -1931,6 +2009,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-529L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-529.jpg
+astropix_ids: chandra|529
 
 credits> NASA/CXC/Ohio State Univ./C.Grie; This multiwavelength image of the
 galaxy NGC 3627 contains X-rays from Chandra (blue), infrared data from Spitzer
@@ -1955,6 +2034,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-531L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-531.jpg
+astropix_ids: chandra|531
 
 credits> NASA/CXC/Univ of Toronto/M.Duran; This deep image from NASA's Chandra
 X-ray Observatory shows the Vela pulsar, a neutron star that was formed when a
@@ -1979,6 +2059,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-532L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-532.jpg
+astropix_ids: chandra|532
 
 credits> X-ray: NASA/CXC/Univ of Michigan; DEM L50 (a.k.a. N186) is what
 astronomers call a superbubble. These objects are found in regions where massive
@@ -2003,6 +2084,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-533L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-533.jpg
+astropix_ids: chandra|533
 
 credits> X-ray: NASA/CXC/MIT/L.Lopez et a; This highly distorted supernova
 remnant may contain the most recent black hole formed in the Milky Way galaxy.
@@ -2027,6 +2109,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-534L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-534.jpg
+astropix_ids: chandra|534
 
 credits> NASA/CXC/Michigan State/A.Steine; New results from Chandra and other
 X-ray telescopes have provided one of the most reliable determinations yet of
@@ -2051,6 +2134,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-535L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-535.jpg
+astropix_ids: chandra|535
 
 credits> X-ray: NASA/CXC/Univ of Michigan; The previously unknown remains of a
 shattered star have been found by NASA's Swift satellite. A follow-up Chandra
@@ -2075,6 +2159,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-536L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-536.jpg
+astropix_ids: chandra|536
 
 credits> X-ray: NASA/CXC/NCSU/M.Burkey et; Over 400 years ago, Johannes Kepler
 and many others witnessed the appearance of a new "star" in the sky. Today, this
@@ -2099,6 +2184,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-537L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-537.jpg
+astropix_ids: chandra|537
 
 credits> X-ray: NASA/CXC/Univ.Potsdam/L.O; New Chandra observations have been
 used to make the first detection of X-ray emission from young stars with masses
@@ -2145,6 +2231,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-539L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-539.jpg
+astropix_ids: chandra|539
 
 credits> X-ray (NASA/CXC/SAO/E.Nardini et; Scientists have used Chandra to make
 a detailed study of an enormous cloud of hot gas enveloping two large, colliding
@@ -2169,6 +2256,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-540L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-540.jpg
+astropix_ids: chandra|540
 
 credits> X-ray: NASA/CXC/SAO/A.Siemiginow; The intense gravity of a supermassive
 black hole can be tapped to produce immense power in the form of jets moving at
@@ -2193,6 +2281,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-542L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-542.jpg
+astropix_ids: chandra|542
 
 credits> X-ray (NASA/CXC/SAO/R.Barnard, Z; Twenty-six black hole candidates -
 the largest number found in a galaxy outside our own - have been discovered in
@@ -2217,6 +2306,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-543L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-543.jpg
+astropix_ids: chandra|543
 
 credits> X-ray (NASA/CXC/NCSU/K.Borkowski; A new Chandra observation is
 providing important details about the most recent supernova known to have
@@ -2241,6 +2331,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-544L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-544.jpg
+astropix_ids: chandra|544
 
 credits> X-ray: NASA/CXC/IAA-CSIC/N.Ruiz ; When a star like our Sun uses up all
 of the hydrogen in its core, it becomes what is called a "planetary nebula."
@@ -2265,6 +2356,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-546L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-546.jpg
+astropix_ids: chandra|546
 
 credits> X-ray: NASA/CXC/Huntingdon Inst.; A massive multimillion-degree cloud
 of gas has been revealed in X-ray data from Chandra (purple) that have been
@@ -2289,6 +2381,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-547L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-547.jpg
+astropix_ids: chandra|547
 
 credits> X-ray: NASA/UMass/D.Wang et al.,; One of the biggest observing
 campaigns ever performed by Chandra has provided new understanding into why gas
@@ -2313,6 +2406,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-548L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-548.jpg
+astropix_ids: chandra|548
 
 credits> X-ray: NASA/CXC/SAO/F.Seward et ; This composite image contains data
 from Chandra (purple) that provides evidence for the survival of a companion
@@ -2337,6 +2431,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-549L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-549.jpg
+astropix_ids: chandra|549
 
 credits> X-ray: NASA/CXC/MPE/J.Sanders et; Enormous arms of hot gas have been
 revealed in the Coma galaxy cluster in data from NASA's Chandra X-ray
@@ -2361,6 +2456,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-550L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-550.jpg
+astropix_ids: chandra|550
 
 credits> X-ray: NASA/CXC/MSU/J.Strader et; The densest galaxy in the nearby
 Universe may have been found. The galaxy, known as M60-UCD1, is located near a
@@ -2385,6 +2481,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-551L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-551.jpg
+astropix_ids: chandra|551
 
 credits> X-ray: NASA/CXC/ICE/A.Papitto et; These two images from NASA's Chandra
 X-ray Observatory show a large change in X-ray brightness of a rapidly rotating
@@ -2409,6 +2506,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-552L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-552.jpg
+astropix_ids: chandra|552
 
 credits> NASA/CXC/APC/Universite Paris Di; Researchers have found evidence that
 the normally dim region very close to the supermassive black hole at the center
@@ -2433,6 +2531,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-554aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-554a.jpg
+astropix_ids: chandra|554a
 
 credits> NASA/CXC/SAO; This collection of images represents the thousands of
 observations that are permanently stored and accessible to the world in th...
@@ -2456,6 +2555,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-554bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-554b.jpg
+astropix_ids: chandra|554b
 
 credits> NASA/CXC/SAO; This collection of images represents the thousands of
 observations that are permanently stored and accessible to the world in th...
@@ -2479,6 +2579,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-554eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-554e.jpg
+astropix_ids: chandra|554e
 
 credits> NASA/CXC/SAO; This collection of images represents the thousands of
 observations that are permanently stored and accessible to the world in th...
@@ -2502,6 +2603,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-556L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-556.jpg
+astropix_ids: chandra|556
 
 credits> X-ray: NASA/CXC/UCLA/Z.Li et al;; New evidence has been uncovered for
 the presence of a jet of high-energy particles blasting out of the Milky Way's
@@ -2526,6 +2628,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-557L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-557.jpg
+astropix_ids: chandra|557
 
 credits> X-ray: NASA/CXC/Univ. of Wiscons; The youngest member of an important
 class of objects called X-ray binaries has been found using data from Chandra
@@ -2550,6 +2653,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-559L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-559.jpg
+astropix_ids: chandra|559
 
 credits> redit: X-ray: NASA/CXC/Univ. of Alabama/W.P.Maksym et al &
 NASA/CXC/GSFC/UMD/D.Donato, et al; Optical: CFHT.
@@ -2573,6 +2677,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-560L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-560.jpg
+astropix_ids: chandra|560
 
 credits> X-ray: NASA/CXC/Stanford/J.Hlava; Astronomers have used NASA's Chandra
 X-ray Observatory and other telescopes to reveal one of the most powerful black
@@ -2597,6 +2702,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-561L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-561.jpg
+astropix_ids: chandra|561
 
 credits> X-ray: NASA/CXC/U.Birmingham/M.B; Centaurus A is a galaxy well known
 for a gargantuan jet blasting away from a central supermassive black hole, which
@@ -2621,6 +2727,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-562L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-562.jpg
+astropix_ids: chandra|562
 
 credits> X-ray: NASA/CXC/ISDC/L.Pavan et ; An extraordinary jet trailing behind
 a runaway pulsar is seen in this composite image that contains X-ray data from
@@ -2645,6 +2752,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-563L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-563.jpg
+astropix_ids: chandra|563
 
 credits> X-ray: NASA/CXC/Univ of Michigan; Multiple images of a distant quasar
 known as RX J1131-1231 are visible in this combined view from Chandra (pink) and
@@ -2669,6 +2777,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-564L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-564.jpg
+astropix_ids: chandra|564,chandra|811c
 
 credits> X-ray: NASA/CXC/UAH/M.Sun et al;; This image combines NASA/ESA Hubble
 Space Telescope observations with data from the Chandra X-ray Observatory. As
@@ -2693,6 +2802,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-565L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-565.jpg
+astropix_ids: chandra|565,chandra|809
 
 credits> NASA, ESA, J. Jee (Univ. of California, Davis), J. Hughes (Rutgers
 Univ.), F. Menanteau (Rutgers Univ. & Univ. of Illinois, Urbana-Champaign), C.
@@ -2718,6 +2828,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-566L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-566.jpg
+astropix_ids: chandra|566
 
 credits> X-ray: NASA/CXC/Morehead State U; Supernova remnants are created when a
 massive star explodes and its remains are hurled into space. Astronomers have
@@ -2742,6 +2853,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-568L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-568.jpg
+astropix_ids: chandra|568
 
 credits> X-ray: NASA/CXC/PSU/K.Getman, E.; Astronomers have studied two star
 clusters to gain insight on how clusters of stars like our Sun form. This
@@ -2766,6 +2878,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-569L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-569.jpg
+astropix_ids: chandra|569
 
 credits> X-ray: NASA/CXC/Stanford Univ/N.; This four-panel of images represents
 a sample of giant elliptical galaxies observed by Chandra and the Hershel Space
@@ -2812,6 +2925,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-570aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-570a.jpg
+astropix_ids: chandra|570a
 
 credits> X-ray: NASA/CXC/Wesleyan Univ./R; This image contains nearly a million
 seconds worth of Chandra observing time (purple) along with optical data from
@@ -2836,6 +2950,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-571L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-571.jpg
+astropix_ids: chandra|571
 
 credits> X-ray: NASA/CXC/SAO/E.Bulbul, e; A new study of the Perseus galaxy
 cluster, shown in this image, and others using Chandra and XMM-Newton has
@@ -2860,6 +2975,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-572L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-572.jpg
+astropix_ids: chandra|572
 
 credits> X-ray: NASA/CXC/Caltech/P.Ogle e; NGC 4258 is a spiral galaxy well
 known to astronomers for having two so-called anomalous arms that glow in X-ray,
@@ -2884,6 +3000,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-576L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-576.jpg
+astropix_ids: chandra|576
 
 credits> NASA/CXC/SAO/R.Margutti et al; New Chandra data gives insight into the
 explosion that produced SN 2014J, one of the closest supernovas discovered in
@@ -2908,6 +3025,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-577L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-577.jpg
+astropix_ids: chandra|577
 
 credits> X-ray: NASA/CXC/IAFE/G.Dubner et; The destructive results of a powerful
 supernova explosion are seen in a delicate tapestry of X-ray light in this new
@@ -2932,6 +3050,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-578L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-578.jpg
+astropix_ids: chandra|578
 
 credits> NASA/CXC/GSFC/K.Hamaguchi, et al.
 
@@ -2954,6 +3073,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-580L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-580.jpg
+astropix_ids: chandra|580
 
 credits> X-ray: NASA/CXC/Univ. of Toulous; Ultraluminous X-ray Sources (ULXs)
 are objects that produce more X-rays than most "normal" X-ray binary systems, in
@@ -2978,6 +3098,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-581aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-581a.jpg
+astropix_ids: chandra|581a
 
 credits> X-ray: NASA/CXC/ESA-ESTEC/E.Wins; With the passing of Chandra's 15th
 anniversary, the Chandra Data Archive, which houses all of the mission's data,
@@ -3002,6 +3123,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-581cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-581c.jpg
+astropix_ids: chandra|581c
 
 credits> X-ray: NASA/CXC/Univ. of Manitob; With the passing of Chandra's 15th
 anniversary, the Chandra Data Archive, which houses all of the mission's data,
@@ -3026,6 +3148,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-581dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-581d.jpg
+astropix_ids: chandra|581d
 
 credits> X-ray: NASA/CXC/SAO, Optical: NA; With the passing of Chandra's 15th
 anniversary, the Chandra Data Archive, which houses all of the mission's data,
@@ -3050,6 +3173,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-581eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-581e.jpg
+astropix_ids: chandra|581e
 
 credits> X-ray: NASA/CXC/SAO; Infared: NA; With the passing of Chandra's 15th
 anniversary, the Chandra Data Archive, which houses all of the mission's data,
@@ -3074,6 +3198,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-581fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-581f.jpg
+astropix_ids: chandra|581f
 
 credits> X-ray: NASA/CXC/Universita di Bo; With the passing of Chandra's 15th
 anniversary, the Chandra Data Archive, which houses all of the mission's data,
@@ -3098,6 +3223,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-582aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-582a.jpg
+astropix_ids: chandra|582a
 
 credits> NASA/CXC/Stanford/I.Zhuravleva e; Chandra observations of the Perseus
 and Virgo galaxy clusters have provided direct evidence that turbulence is
@@ -3122,6 +3248,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-582bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-582b.jpg
+astropix_ids: chandra|582b
 
 credits> NASA/CXC/Stanford/I.Zhuravleva e; Chandra observations of the Perseus
 and Virgo galaxy clusters have provided direct evidence that turbulence is
@@ -3146,6 +3273,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-583L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-583.jpg
+astropix_ids: chandra|583
 
 credits> NASA/CXC/Univ. of Wisconsin/Y.Ba; The supermassive black hole at the
 center of the Milky Way may be producing tiny particles, called neutrinos, that
@@ -3170,6 +3298,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-584bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-584b.jpg
+astropix_ids: chandra|584b
 
 credits> NASA/CXC/GSFC/T.Temim et al. ; A long observation with Chandra of the
 supernova remnant MSH 11-62 reveals an irregular shell of hot gas, shown in red,
@@ -3194,6 +3323,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-585L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-585.jpg
+astropix_ids: chandra|585
 
 credits> X-ray: NASA/CXC/SAO/S.Mineo et a; X-ray data from Chandra have revealed
 that NGC 2207 and IC 2163, currently in the process of colliding with one
@@ -3218,6 +3348,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-586L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-586.jpg
+astropix_ids: chandra|586
 
 credits> X-ray: NASA/CXC/INAF/P.Tozzi, et al; Optical: NAOJ/Subaru and ESO/VLT;
 Infrared : ESA/Herschel
@@ -3241,6 +3372,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-587aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-587a.jpg
+astropix_ids: chandra|587a
 
 credits> X-ray: NASA/CXC/SAO; UV: NASA/JP; This montage features images of five
 different objects, ranging from a distant galaxy to a relatively close supernova
@@ -3265,6 +3397,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-587bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-587b.jpg
+astropix_ids: chandra|587b
 
 credits> X-ray: NASA/CXC/Rutgers/J.Hughes; This montage features images of five
 different objects, ranging from a distant galaxy to a relatively close supernova
@@ -3289,6 +3422,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-587dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-587d.jpg
+astropix_ids: chandra|587d
 
 credits> X-ray: NASA/CXC/SAO; Optical: NA; This montage features images of five
 different objects, ranging from a distant galaxy to a relatively close supernova
@@ -3313,6 +3447,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-587eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-587e.jpg
+astropix_ids: chandra|587e
 
 credits> X-ray: NASA/CXC/SAO; UV: NASA/JPL-Caltech; Optical: NASA/STScI; IR:
 NASA/JPL-Caltech
@@ -3336,6 +3471,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-588L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-588.jpg
+astropix_ids: chandra|588
 
 credits> NASA/CXC/Amherst College/D.Hagga; Astronomers have detected the largest
 X-ray flare ever from the supermassive black hole at the center of the Milky
@@ -3360,6 +3496,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-589L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-589.jpg
+astropix_ids: chandra|589
 
 credits> X-ray: NASA/CXC/U.Texas/S.Post et al, Infrared:
 2MASS/UMass/IPAC-Caltech/NASA/NSF
@@ -3383,6 +3520,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-590L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-590.jpg
+astropix_ids: chandra|590
 
 credits> X-ray: NASA/CXC/SAO/M.Mezcua et ; A newly discovered object in the
 galaxy NGC 2276 may prove to be an important black hole that helps fill in the
@@ -3407,6 +3545,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-591L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-591.jpg
+astropix_ids: chandra|591
 
 credits> X-ray: NASA/CXC/Michigan State U; A new Chandra study of over 200
 galaxy clusters has helped determine how giant black holes at their centers
@@ -3431,6 +3570,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-592L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-592.jpg
+astropix_ids: chandra|592
 
 credits> X-ray: NASA/CXC/RIKEN/D.Takei et; Using NASA's Chandra X-ray
 Observatory, astronomers have studied the "classical nova" called GK Persei.
@@ -3455,6 +3595,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-593aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-593a.jpg
+astropix_ids: chandra|593a
 
 credits> X-ray: NASA/CXC/Ecole Polytechni; These galaxy clusters are part of a
 large study using Chandra and Hubble that sets new limits on how dark matter -
@@ -3479,6 +3620,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-593bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-593b.jpg
+astropix_ids: chandra|593b
 
 credits> X-ray: NASA/CXC/Ecole Polytechni; These galaxy clusters are part of a
 large study using Chandra and Hubble that sets new limits on how dark matter -
@@ -3503,6 +3645,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-593cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-593c.jpg
+astropix_ids: chandra|593c
 
 credits> X-ray: NASA/CXC/Ecole Polytechni; These galaxy clusters are part of a
 large study using Chandra and Hubble that sets new limits on how dark matter -
@@ -3527,6 +3670,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-593dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-593d.jpg
+astropix_ids: chandra|593d
 
 credits> X-ray: NASA/CXC/Ecole Polytechni; These galaxy clusters are part of a
 large study using Chandra and Hubble that sets new limits on how dark matter -
@@ -3551,6 +3695,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-593eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-593e.jpg
+astropix_ids: chandra|593e
 
 credits> X-ray: NASA/CXC/Ecole Polytechnique Federale de Lausanne,
 Switzerland/D.Harvey & NASA/CXC/Durham Univ/R.Massey; Optical & Lensing Map:
@@ -3576,6 +3721,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-593fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-593f.jpg
+astropix_ids: chandra|593f
 
 credits> X-ray: NASA/CXC/Ecole Polytechni; These galaxy clusters are part of a
 large study using Chandra and Hubble that sets new limits on how dark matter -
@@ -3600,6 +3746,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-594L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-594.jpg
+astropix_ids: chandra|594
 
 credits> X-ray: NASA/CXC/IASF Palermo/M.Del Santo et al; Optical: NASA/STScI
 
@@ -3622,6 +3769,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-596L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-596.jpg
+astropix_ids: chandra|596
 
 credits> NASA/CXC/INAF/F.Coti Zelati et a; Since its discovery two years ago
 when it gave off a burst of X-rays, astronomers have been actively monitoring
@@ -3646,6 +3794,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-599L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-599.jpg
+astropix_ids: chandra|599
 
 credits> X-ray: NASA/CXC/SAO/S.Randall et; Astronomers have used NASA's Chandra
 X-ray Observatory to show that a supermassive black hole at the center of a
@@ -3670,6 +3819,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-600L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-600.jpg
+astropix_ids: chandra|600
 
 credits> X-ray: NASA/CXC/Univ. of Wiscons; Chandra data of Circinus X-1 reveal a
 set of four rings that appear as circles around the neutron star, providing a
@@ -3694,6 +3844,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-601L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-601.jpg
+astropix_ids: chandra|601
 
 credits> X-ray: NASA/CXC/SAO/S.Wolk et al; NGC 1333 is a cluster that contains
 many stars that are less than two million years old, which is very young in
@@ -3718,6 +3869,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-606L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-606.jpg
+astropix_ids: chandra|606
 
 credits> X-ray: NASA/CXC/Univ of Michigan; The smallest supermassive black hole
 ever detected in the center of a galaxy has been identified using observations
@@ -3742,6 +3894,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-607L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-607.jpg
+astropix_ids: chandra|607
 
 credits> X-ray: NASA/CXC/Univ of Hamburg/; Astronomers have found evidence for a
 "radio phoenix" in the collision of two galaxy clusters, where vast clouds of
@@ -3766,6 +3919,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-609L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-609.jpg
+astropix_ids: chandra|609
 
 credits> X-ray: NASA/CXC/MIT/M.McDonald e; New observations of the galaxy
 cluster SPT-CLJ2344-4243 at X-ray, ultraviolet, and optical wavelengths are
@@ -3790,6 +3944,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-610aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-610a.jpg
+astropix_ids: chandra|610a
 
 credits> X-ray: NASA/CXC/Univ. of Georgia; These six images represent the
 potential for new images and discoveries housed in the Chandra Data Archive. To
@@ -3814,6 +3969,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-610bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-610b.jpg
+astropix_ids: chandra|610b
 
 credits> X-ray: NASA/CXC/PUS/E.Helder et ; These six images represent the
 potential for new images and discoveries housed in the Chandra Data Archive. To
@@ -3838,6 +3994,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-610cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-610c.jpg
+astropix_ids: chandra|610c
 
 credits> X-ray: NASA/CXC/SAO/F.Seward et ; These six images represent the
 potential for new images and discoveries housed in the Chandra Data Archive. To
@@ -3862,6 +4019,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-610dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-610d.jpg
+astropix_ids: chandra|610d
 
 credits> X-ray: NASA/CXC/Univ. of Waterlo; These six images represent the
 potential for new images and discoveries housed in the Chandra Data Archive. To
@@ -3886,6 +4044,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-610eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-610e.jpg
+astropix_ids: chandra|610e
 
 credits> X-ray: NASA/CXC/Cambridge/S.Alle; These six images represent the
 potential for new images and discoveries housed in the Chandra Data Archive. To
@@ -3910,6 +4069,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-610fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-610f.jpg
+astropix_ids: chandra|610f
 
 credits> X-ray: NASA/CXC/UMass/S.Johnson ; These six images represent the
 potential for new images and discoveries housed in the Chandra Data Archive. To
@@ -3934,6 +4094,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-612L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-612.jpg
+astropix_ids: chandra|612
 
 credits> X-ray: NASA/CXC/GSFC/M.Corcoran ; Delta Orionis is a complex star
 system that contains five stars in total. Two of those stars are in a close
@@ -3958,6 +4119,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-613L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-613.jpg
+astropix_ids: chandra|614
 
 credits> Wide Field Optical: Focal Pointe; The Jellyfish Nebula is the remnant
 of a supernova that occurred over 10,000 years ago in our galaxy. New Chandra
@@ -3982,6 +4144,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-615L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-615.jpg
+astropix_ids: chandra|615
 
 credits> X-ray: NASA/CXC/University of Bo; An extraordinary ribbon of hot gas
 trailing behind a galaxy like a tail has been discovered using data from NASA's
@@ -4006,6 +4169,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-617L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-617.jpg
+astropix_ids: chandra|617
 
 credits> X-ray: NASA/CXC/Univ of Missouri; Astronomers have made the most
 detailed study yet of an extremely massive young galaxy cluster using three of
@@ -4030,6 +4194,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-620L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-620.jpg
+astropix_ids: chandra|620
 
 credits> X-ray: NASA/CXC/Univ of Hertford; The Pictor A galaxy has a
 supermassive black hole at its center, and material falling onto the black hole
@@ -4054,6 +4219,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-621L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-621.jpg
+astropix_ids: chandra|621
 
 credits> X-ray: NASA/CXC/ISAS/A.Simionesc; Jets in the early Universe give
 astronomers a way to probe the growth of black holes at a very early epoch in
@@ -4078,6 +4244,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-622aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-622a.jpg
+astropix_ids: chandra|622a
 
 credits> X-ray: NASA/CXC/SAO/G.Ogrean et ; These two galaxy clusters are part of
 the "Frontier Fields" project, which uses some of the world's most powerful
@@ -4102,6 +4269,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-622bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-622b.jpg
+astropix_ids: chandra|622b
 
 credits> X-ray: NASA/CXC/SAO/G.Ogrean et ; These two galaxy clusters are part of
 the "Frontier Fields" project, which uses some of the world's most powerful
@@ -4126,6 +4294,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-624L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-624.jpg
+astropix_ids: chandra|624
 
 credits> X-ray (NASA/CXC/CfA/S.Chakrabort; Scientists have found the likely
 trigger for the most recent supernova in the Milky Way, by studying the remnant
@@ -4150,6 +4319,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-626aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-626a.jpg
+astropix_ids: chandra|626a
 
 credits> X-ray: NASA/CXC/Univ. of Alabama; These four galaxy clusters were part
 of a large survey of over 300 clusters used to investigate dark energy, the
@@ -4174,6 +4344,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-626bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-626b.jpg
+astropix_ids: chandra|626b
 
 credits> X-ray: NASA/CXC/Univ. of Alabama; These four galaxy clusters were part
 of a large survey of over 300 clusters used to investigate dark energy, the
@@ -4198,6 +4369,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-626cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-626c.jpg
+astropix_ids: chandra|626c
 
 credits> X-ray: NASA/CXC/Univ. of Alabama; These four galaxy clusters were part
 of a large survey of over 300 clusters used to investigate dark energy, the
@@ -4222,6 +4394,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-626dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-626d.jpg
+astropix_ids: chandra|626d
 
 credits> X-ray: NASA/CXC/Univ. of Alabama; These four galaxy clusters were part
 of a large survey of over 300 clusters used to investigate dark energy, the
@@ -4246,6 +4419,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-627L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-627.jpg
+astropix_ids: chandra|627
 
 credits> X-ray: NASA/CXC/GSFC/B.Williams ; By combining observations from over
 15 years with the Chandra X-ray Observatory and 30 years with the Very Large
@@ -4270,6 +4444,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-630L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-630.jpg
+astropix_ids: chandra|630
 
 credits> X-ray: NASA/CXC/Univ. of Alberta; By combining data from Chandra and
 several other telescopes, astronomers have identified the true nature of an
@@ -4294,6 +4469,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-633L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-633.jpg
+astropix_ids: chandra|633
 
 credits> X-ray: NASA/CXC/ETH Zurich/L.Sar; New data from Chandra and other
 telescopes of a cosmic 'blob' and a gas bubble could be a new way to probe the
@@ -4318,6 +4494,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-634L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-634.jpg
+astropix_ids: chandra|634
 
 credits> X-ray: NASA/CXC/NCSU/K.Borkowski; New Chandra observations of the
 G11.2-0.3 supernova remnant in our Galaxy have stripped away its connection to
@@ -4342,6 +4519,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-635L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-635.jpg
+astropix_ids: chandra|635
 
 credits> X-ray: NASA/CXC/Université Pari; The galaxy cluster CL J1001+0220 is
 the most distant galaxy cluster ever discovered and may have been caught right
@@ -4366,6 +4544,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-636L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-636.jpg
+astropix_ids: chandra|636
 
 credits> X-ray: NASA/CXC/University of Am; Using Chandra and other X-ray
 observatories, astronomers have found evidence for what is likely one of the
@@ -4390,6 +4569,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-638L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-638.jpg
+astropix_ids: chandra|638
 
 credits> X-ray: NASA/CXC/UNH/D.Lin et al;; Using Chandra and XMM-Newton,
 astronomers have discovered an extremely luminous, variable X-ray source located
@@ -4414,6 +4594,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-640aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-640a.jpg
+astropix_ids: chandra|640a
 
 credits> NASA/CXC/SAO; The Chandra Data Archive is a sophisticated digital
 system that ultimately contains all of the data obtained by the telescope, c...
@@ -4437,6 +4618,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-640bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-640b.jpg
+astropix_ids: chandra|640b
 
 credits> NASA/CXC/SAO; The Chandra Data Archive is a sophisticated digital
 system that ultimately contains all of the data obtained by the telescope, c...
@@ -4460,6 +4642,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-640cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-640c.jpg
+astropix_ids: chandra|640c
 
 credits> NASA/CXC/SAO; The Chandra Data Archive is a sophisticated digital
 system that ultimately contains all of the data obtained by the telescope, c...
@@ -4483,6 +4666,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-640dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-640d.jpg
+astropix_ids: chandra|640d
 
 credits> NASA/CXC/SAO; The Chandra Data Archive is a sophisticated digital
 system that ultimately contains all of the data obtained by the telescope, c...
@@ -4506,6 +4690,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-640eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-640e.jpg
+astropix_ids: chandra|640e
 
 credits> NASA/CXC/SAO; The Chandra Data Archive is a sophisticated digital
 system that ultimately contains all of the data obtained by the telescope, c...
@@ -4529,6 +4714,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-640fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-640f.jpg
+astropix_ids: chandra|640f
 
 credits> NASA/CXC/SAO; The Chandra Data Archive is a sophisticated digital
 system that ultimately contains all of the data obtained by the telescope, c...
@@ -4552,6 +4738,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-641L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-641.jpg
+astropix_ids: chandra|641
 
 credits> NASA/CXC/UA/J.Irwin et al.; Astronomers have found a pair of
 extraordinary objects that dramatically burst in X-rays. This discovery,
@@ -4576,6 +4763,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-643L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-643.jpg
+astropix_ids: chandra|643
 
 credits> X-ray: NASA/CXC/SAO/M.McCollough; A snapshot of the life cycle of stars
 has been captured where a stellar nursery is reflecting X-rays from a source
@@ -4600,6 +4788,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-645L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-645.jpg
+astropix_ids: chandra|645
 
 credits> X-ray: NASA/CXC/PSU/L.Townsley e; This composite image captures the
 star formation region called NGC 6357 located within the Milky Way galaxy.
@@ -4624,6 +4813,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-646L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-646.jpg
+astropix_ids: chandra|646
 
 credits> X-ray: NASA/CXC/SAO/R. van Weere; Astronomers have discovered what
 happens when the eruption from a supermassive black hole is swept up by the
@@ -4648,6 +4838,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-647L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-647.jpg
+astropix_ids: chandra|647
 
 credits> X-ray: NASA/CXC/Penn State/B.Luo; Made with over 7 million seconds of
 Chandra observing time, this image is part of the Chandra Deep Field-South
@@ -4672,6 +4863,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-648L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-648.jpg
+astropix_ids: chandra|648
 
 credits> X-ray: NASA/CXC/PSU/B.Posselt et; This four-panel graphic shows the two
 pulsars, Geminga (upper left) and B0355+54 (upper right), observed by Chandra.
@@ -4696,6 +4888,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-66L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-66.jpg
+astropix_ids: chandra|66
 
 credits> X-ray: NASA/CXC/Bristol U./M. Hardcastle et al.; Radio:
 NRAO/AUI/NSF/Bristol U./M. Hardcastle
@@ -4719,6 +4912,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-71L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-71.jpg
+astropix_ids: chandra|71
 
 credits> NASA/CXC/U.Leicester/U.London/R.Soria & K.Wu
 
@@ -4741,6 +4935,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-74L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-74.jpg
+astropix_ids: chandra|74
 
 credits> X-ray: NASA/CXC/ESO/P.Rosati et al.; Optical: ESO/VLT/P.Rosati et al.
 
@@ -4787,6 +4982,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-80L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-80.jpg
+astropix_ids: chandra|80
 
 credits> NASA/CXC/PSU/S.Park et al.
 
@@ -4809,6 +5005,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-81L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-81.jpg
+astropix_ids: chandra|81
 
 credits> NASA/SAO/CXC/G.Fabbiano et al.
 
@@ -4831,6 +5028,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-82L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-82.jpg
+astropix_ids: chandra|82
 
 credits> NASA/CXC/SAO/G.Fabbiano et al
 
@@ -4853,6 +5051,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-87L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-87.jpg
+astropix_ids: chandra|87
 
 credits> NASA/CXC/MIT/F.K.Baganoff et al.
 
@@ -4875,6 +5074,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-90L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-90.jpg
+astropix_ids: chandra|90
 
 credits> NASA/CXC/PSU/D.M.Alexander, F.E.Bauer, W.N.Brandt et al.
 
@@ -4897,6 +5097,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-92L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-92.jpg
+astropix_ids: chandra|92
 
 credits> X-ray: NASA/CXC/MIT/UCSB/P.Ogle et al.; Optical: NASA/STScI/A.Capetti
 et al.
@@ -4920,6 +5121,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-93L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-93.jpg
+astropix_ids: chandra|93
 
 credits> NASA/CXC/PSU/L.Townsley et al.
 
@@ -4942,6 +5144,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-94L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-94.jpg
+astropix_ids: chandra|94
 
 credits> NASA/CXC/M.Machacek et al.
 
@@ -4964,6 +5167,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Chandra-97L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Chandra-97.jpg
+astropix_ids: chandra|97
 
 credits> NASA/CXC/W. Forman et al.
 
@@ -4986,6 +5190,7 @@ url: http://www.worldwidetelescope.org/wwtweb/tiles.aspx?q={1},{2},{3},112935813
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1129358135
+astropix_ids: chandra|395
 
 credits> Chandra X-ray: NASA/CXC/HSC/J. Keohane et al.; ROSAT X-ray: NASA/ROSAT;
 Optical : NOAO/CTIO/P.F. Winkler et al.; Radio: NSF/NRAO/VLA/G. Dubner et al.
@@ -5167,6 +5372,7 @@ url: http://www.worldwidetelescope.org/wwtweb/tiles.aspx?q={1},{2},{3},251702032
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=251702032
+astropix_ids: chandra|400
 
 credits> X-ray: NASA/CXC/CfA/W. Forman et al.; Radio: NRAO/AUI/NSF/W. Cotton;
 Optical : NASA/ESA/Hubble Heritage Team (STScI/AURA), and R. Gendler. This image

--- a/cxprep/eso.txt
+++ b/cxprep/eso.txt
@@ -4,6 +4,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0649b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0649b/thumb.jpg
+astropix_ids: eso|eso0649b
 
 credits> ESO
 
@@ -30,6 +31,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0650a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0650a/thumb.jpg
+astropix_ids: eso|eso0650a
 
 credits> ESO/R. Fosbury (ST-ECF)
 
@@ -62,6 +64,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0650b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0650b/thumb.jpg
+astropix_ids: eso|eso0650b
 
 credits> ESO
 
@@ -89,6 +92,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0708a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0708a/thumb.jpg
+astropix_ids: eso|eso0708a
 
 credits> ESO
 
@@ -114,6 +118,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0709a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0709a/thumb.jpg
+astropix_ids: eso|eso0709a
 
 credits> ESO
 
@@ -143,6 +148,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0712a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0712a/thumb.jpg
+astropix_ids: eso|eso0712a
 
 credits> ESO
 
@@ -171,6 +177,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0715a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0715a/thumb.jpg
+astropix_ids: eso|eso0715a
 
 credits> ESO/Digitized Sky Survey.
 
@@ -194,6 +201,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0716a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0716a/thumb.jpg
+astropix_ids: eso|eso0716a
 
 credits> ESO
 
@@ -225,6 +233,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0722c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0722c/thumb.jpg
+astropix_ids: eso|eso0722c
 
 credits> Digital Sky Survey
 
@@ -247,6 +256,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0736b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0736b/thumb.jpg
+astropix_ids: eso|eso0736b
 
 credits> ESO
 
@@ -273,6 +283,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0736c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0736c/thumb.jpg
+astropix_ids: eso|eso0736c
 
 credits> ESO
 
@@ -298,6 +309,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0739a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0739a/thumb.jpg
+astropix_ids: eso|eso0739a
 
 credits> ESO
 
@@ -326,6 +338,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0749a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0749a/thumb.jpg
+astropix_ids: eso|eso0749a
 
 credits> ESO
 
@@ -365,6 +378,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0755a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0755a/thumb.jpg
+astropix_ids: eso|eso0755a
 
 credits> ESO
 
@@ -396,6 +410,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0755b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0755b/thumb.jpg
+astropix_ids: eso|eso0755b
 
 credits> ESO
 
@@ -424,6 +439,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0802a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0802a/thumb.jpg
+astropix_ids: eso|eso0802a
 
 credits> ESO
 
@@ -458,6 +474,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0803c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0803c/thumb.jpg
+astropix_ids: eso|eso0803c
 
 credits> ESO
 
@@ -480,6 +497,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0805a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0805a/thumb.jpg
+astropix_ids: eso|eso0805a
 
 credits> ESO
 
@@ -512,6 +530,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0806a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0806a/thumb.jpg
+astropix_ids: eso|eso0806a
 
 credits> ESO
 
@@ -545,6 +564,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0809a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0809a/thumb.jpg
+astropix_ids: eso|eso0809a
 
 credits> Digital Sky Survey/VirGO.
 
@@ -572,6 +592,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0823a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0823a/thumb.jpg
+astropix_ids: eso|eso0823a
 
 credits> ESO
 
@@ -596,6 +617,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0825a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0825a/thumb.jpg
+astropix_ids: eso|eso0825a
 
 credits> ESO
 
@@ -626,6 +648,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0832a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0832a/thumb.jpg
+astropix_ids: eso|eso0832a
 
 credits> X-ray (NASA/CXC/Columbia/F.Bauer et al); Visible light
 (NASA/STScI/UMD/A.Wilson et al.)
@@ -661,6 +684,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0832b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0832b/thumb.jpg
+astropix_ids: eso|eso0832b
 
 credits> ESO
 
@@ -686,6 +710,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0834a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0834a/thumb.jpg
+astropix_ids: eso|eso0834a
 
 credits> ESO/ESA/ JPL-Caltech/NASA/ D. Gouliermis (MPIA) et al.
 
@@ -717,6 +742,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0837a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0837a/thumb.jpg
+astropix_ids: eso|eso0837a
 
 credits> ESO
 
@@ -744,6 +770,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0837b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0837b/thumb.jpg
+astropix_ids: eso|eso0837b
 
 credits> ESO
 
@@ -768,6 +795,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0839a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0839a/thumb.jpg
+astropix_ids: eso|eso0839a
 
 credits> ESO/ Mario Nonino, Piero Rosati and the ESO GOODS Team
 
@@ -796,6 +824,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0840a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0840a/thumb.jpg
+astropix_ids: eso|eso0840a
 
 credits> ESO/APEX/DSS2/ SuperCosmos/ Deharveng(LAM)/ Zavagno(LAM)
 
@@ -826,6 +855,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0841a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0841a/thumb.jpg
+astropix_ids: eso|eso0841a
 
 credits> ESO/APEX/2MASS/A. Eckart et al.
 
@@ -854,6 +884,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0844a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0844a/thumb.jpg
+astropix_ids: eso|eso0844a
 
 credits> ESO
 
@@ -883,6 +914,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0846a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0846a/thumb.jpg
+astropix_ids: eso|eso0846a
 
 credits> ESO/S. Gillessen et al.
 
@@ -909,6 +941,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0847a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0847a/thumb.jpg
+astropix_ids: eso|eso0847a
 
 credits> ESO/F. Courbin et al
 
@@ -939,6 +972,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0848a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0848a/thumb.jpg
+astropix_ids: eso|eso0848a
 
 credits> ESO
 
@@ -967,6 +1001,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0902a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0902a/thumb.jpg
+astropix_ids: eso|eso0902a
 
 credits> ESO
 
@@ -997,6 +1032,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0902b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0902b/thumb.jpg
+astropix_ids: eso|eso0902b
 
 credits> ESO/NASA/ESA
 
@@ -1025,6 +1061,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0902c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0902c/thumb.jpg
+astropix_ids: eso|eso0902c
 
 credits> ESO
 
@@ -1052,6 +1089,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0902d/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0902d/thumb.jpg
+astropix_ids: eso|eso0902d
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin.
 
@@ -1075,6 +1113,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0903a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0903a/thumb.jpg
+astropix_ids: eso|eso0903a
 
 credits> ESO/WFI (Optical); MPIfR/ESO/APEX/A.Weiss et al. (Submillimetre);
 NASA/CXC/CfA/R.Kraft et al. (X-ray)
@@ -1105,6 +1144,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0905a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0905a/thumb.jpg
+astropix_ids: eso|eso0905a
 
 credits> ESO
 
@@ -1137,6 +1177,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0905b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0905b/thumb.jpg
+astropix_ids: eso|eso0905b
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin.
 
@@ -1160,6 +1201,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0906e/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0906e/thumb.jpg
+astropix_ids: eso|eso0906e
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin
 
@@ -1184,6 +1226,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0907a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0907a/thumb.jpg
+astropix_ids: eso|eso0907a
 
 credits> ESO
 
@@ -1217,6 +1260,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0907b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0907b/thumb.jpg
+astropix_ids: eso|eso0907b
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin
 
@@ -1243,6 +1287,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0911a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0911a/thumb.jpg
+astropix_ids: eso|eso0911a
 
 credits> ESO
 
@@ -1271,6 +1316,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0911b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0911b/thumb.jpg
+astropix_ids: eso|eso0911b
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin.
 
@@ -1294,6 +1340,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0914a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0914a/thumb.jpg
+astropix_ids: eso|eso0914a
 
 credits> ESO
 
@@ -1320,6 +1367,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0915c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0915c/thumb.jpg
+astropix_ids: eso|eso0915c
 
 credits> ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin
 
@@ -1342,6 +1390,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0919c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0919c/thumb.jpg
+astropix_ids: eso|eso0919c
 
 credits> ESO/Digitized Sky Survey 2
 
@@ -1371,6 +1420,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0921a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0921a/thumb.jpg
+astropix_ids: eso|eso0921a
 
 credits> ESO/P. Espinoza
 
@@ -1399,6 +1449,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0921c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0921c/thumb.jpg
+astropix_ids: eso|eso0921c
 
 credits> ESO
 
@@ -1433,6 +1484,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0923a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0923a/thumb.jpg
+astropix_ids: eso|eso0923a
 
 credits> ESO/E. Helder &amp; NASA/Chandra
 
@@ -1461,6 +1513,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0923b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0923b/thumb.jpg
+astropix_ids: eso|eso0923b
 
 credits> ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin
 
@@ -1513,6 +1566,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0925a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0925a/thumb.jpg
+astropix_ids: eso|eso0925a
 
 credits> ESO
 
@@ -1541,6 +1595,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0925b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0925b/thumb.jpg
+astropix_ids: eso|eso0925b
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin.
 
@@ -1565,6 +1620,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0926a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0926a/thumb.jpg
+astropix_ids: eso|eso0926a
 
 credits> ESO
 
@@ -1596,6 +1652,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0926b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0926b/thumb.jpg
+astropix_ids: eso|eso0926b
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin.
 
@@ -1620,6 +1677,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0927e/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0927e/thumb.jpg
+astropix_ids: eso|eso0927e
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin.
 
@@ -1643,6 +1701,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0928a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0928a/thumb.jpg
+astropix_ids: eso|eso0928a
 
 credits> ESO/F. Millour et al.
 
@@ -1672,6 +1731,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0928e/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0928e/thumb.jpg
+astropix_ids: eso|eso0928e
 
 credits> ESO/F. Millour et al.
 
@@ -1706,6 +1766,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0928f/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0928f/thumb.jpg
+astropix_ids: eso|eso0928f
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin.
 
@@ -1729,6 +1790,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0929a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0929a/thumb.jpg
+astropix_ids: eso|eso0929a
 
 credits> ESO
 
@@ -1760,6 +1822,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0929b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0929b/thumb.jpg
+astropix_ids: eso|eso0929b
 
 credits> ESO
 
@@ -1792,6 +1855,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0929c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0929c/thumb.jpg
+astropix_ids: eso|eso0929c
 
 credits> ESO
 
@@ -1825,6 +1889,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0929d/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0929d/thumb.jpg
+astropix_ids: eso|eso0929d
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin
 
@@ -1848,6 +1913,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0930a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0930a/thumb.jpg
+astropix_ids: eso|eso0930a
 
 credits> ESO
 
@@ -1876,6 +1942,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0930b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0930b/thumb.jpg
+astropix_ids: eso|eso0930b
 
 credits> ESO
 
@@ -1905,6 +1972,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0931a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0931a/thumb.jpg
+astropix_ids: eso|eso0931a
 
 credits> ESO
 
@@ -1936,6 +2004,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0931b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0931b/thumb.jpg
+astropix_ids: eso|eso0931b
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin
 
@@ -1959,6 +2028,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0933b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0933b/thumb.jpg
+astropix_ids: eso|eso0933b
 
 credits> ESO/Digitized Sky Survey
 
@@ -2011,6 +2081,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0934a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0934a/thumb.jpg
+astropix_ids: eso|eso0934a
 
 credits> ESO/S. Guisard (www.eso.org/~sguisard)
 
@@ -2053,6 +2124,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0936a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0936a/thumb.jpg
+astropix_ids: eso|eso0936a
 
 credits> ESO
 
@@ -2081,6 +2153,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0938a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0938a/thumb.jpg
+astropix_ids: eso|eso0938a
 
 credits> ESO
 
@@ -2116,6 +2189,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0938b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0938b/thumb.jpg
+astropix_ids: eso|eso0938b
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin
 
@@ -2139,6 +2213,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0940a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0940a/thumb.jpg
+astropix_ids: eso|eso0940a
 
 credits> ESO/Y. Beletsky
 
@@ -2166,6 +2241,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0940b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0940b/thumb.jpg
+astropix_ids: eso|eso0940b
 
 credits> ESO
 
@@ -2192,6 +2268,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0940c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0940c/thumb.jpg
+astropix_ids: eso|eso0940c
 
 credits> NASA/ESA and Jesús Maíz Apellániz (Instituto de Astrofísica de
 Andalucía, Spain)
@@ -2222,6 +2299,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0940d/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0940d/thumb.jpg
+astropix_ids: eso|eso0940d
 
 credits> ESO, ESA/Hubble and Digitized Sky Survey 2. Acknowledgment: Davide De
 Martin (ESA/Hubble)
@@ -2250,6 +2328,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0941c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0941c/thumb.jpg
+astropix_ids: eso|eso0941c
 
 credits> ESO/Subaru/National Astronomical Observatory of Japan/M. Tanaka
 
@@ -2279,6 +2358,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0943b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0943b/thumb.jpg
+astropix_ids: eso|eso0943b
 
 credits> ESO/Digitized Sky Survey 2
 
@@ -2326,6 +2406,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0944a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0944a/thumb.jpg
+astropix_ids: eso|eso0944a
 
 credits> ESO/Y. Beletsky
 
@@ -2354,6 +2435,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0945a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0945a/thumb.jpg
+astropix_ids: eso|eso0945a
 
 credits> ESO/F. Ferraro
 
@@ -2384,6 +2466,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0946b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0946b/thumb.jpg
+astropix_ids: eso|eso0946b
 
 credits> ESO
 
@@ -2414,6 +2497,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0947a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0947a/thumb.jpg
+astropix_ids: eso|eso0947a
 
 credits> ESO/H. Sana
 
@@ -2447,6 +2531,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0947b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0947b/thumb.jpg
+astropix_ids: eso|eso0947b
 
 credits> ESO
 
@@ -2470,6 +2555,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0949a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0949a/thumb.jpg
+astropix_ids: eso|eso0949a
 
 credits> ESO/J. Emerson/VISTA. Acknowledgment: Cambridge Astronomical Survey
 Unit
@@ -2506,6 +2592,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0949b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0949b/thumb.jpg
+astropix_ids: eso|eso0949b
 
 credits> ESO/VISTA. Acknowledgment: Cambridge Astronomical Survey Unit
 
@@ -2536,6 +2623,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0949c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0949c/thumb.jpg
+astropix_ids: eso|eso0949c
 
 credits> ESO/J. Emerson/VISTA. Acknowledgment: Cambridge Astronomical Survey
 Unit
@@ -2565,6 +2653,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0949k/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0949k/thumb.jpg
+astropix_ids: eso|eso0949k
 
 credits> ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin
 
@@ -2592,6 +2681,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0949l/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0949l/thumb.jpg
+astropix_ids: eso|eso0949l
 
 credits> ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin and S.
 Guisard (www.eso.org/~sguisard)
@@ -2621,6 +2711,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0949m/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0949m/thumb.jpg
+astropix_ids: eso|eso0949m
 
 credits> ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin
 
@@ -2647,6 +2738,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0949n/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0949n/thumb.jpg
+astropix_ids: eso|eso0949n
 
 credits> ESO/J. Emerson/VISTA. Acknowledgment: Cambridge Astronomical Survey
 Unit
@@ -2681,6 +2773,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso0950b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso0950b/thumb.jpg
+astropix_ids: eso|eso0950b
 
 credits> ESO/Digitized Sky Survey 2
 
@@ -2711,6 +2804,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1005a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1005a/thumb.jpg
+astropix_ids: eso|eso1005a
 
 credits> ESO
 
@@ -2744,6 +2838,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1006a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1006a/thumb.jpg
+astropix_ids: eso|eso1006a
 
 credits> ESO/J. Emerson/VISTA. Acknowledgment: Cambridge Astronomical Survey
 Unit
@@ -2776,6 +2871,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1017a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1017a/thumb.jpg
+astropix_ids: eso|eso1017a
 
 credits> ESO/J. Emerson/VISTAAcknowledgment: Cambridge Astronomical Survey Unit
 
@@ -2806,6 +2902,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1027a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1027a/thumb.jpg
+astropix_ids: eso|eso1027a
 
 credits> ESO
 
@@ -2834,6 +2931,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1031b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1031b/thumb.jpg
+astropix_ids: eso|eso1031b
 
 credits> ESO
 
@@ -2861,6 +2959,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1105a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1105a/thumb.jpg
+astropix_ids: eso|eso1105a
 
 credits> ESO/Igor Chekalin
 
@@ -2889,6 +2988,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1109a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1109a/thumb.jpg
+astropix_ids: eso|eso1109a
 
 credits> ESO/Sergey Stepanenko
 
@@ -2918,6 +3018,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1119a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1119a/thumb.jpg
+astropix_ids: eso|eso1119a
 
 credits> ESO/INAF-VST/OmegaCAM. Acknowledgement: OmegaCen/Astro-WISE/Kapteyn
 Institute
@@ -2948,6 +3049,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1119b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1119b/thumb.jpg
+astropix_ids: eso|eso1119b
 
 credits> ESO/INAF-VST/OmegaCAM. Acknowledgement: A. Grado, L.
 Limatola/INAF-Capodimonte Observatory
@@ -2977,6 +3079,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1131a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1131a/thumb.jpg
+astropix_ids: eso|eso1131a
 
 credits> ESO
 
@@ -3057,6 +3160,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1208a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1208a/thumb.jpg
+astropix_ids: eso|eso1208a
 
 credits> ESO/T. Preibisch
 
@@ -3082,6 +3186,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1221a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1221a/thumb.jpg
+astropix_ids: eso|eso1221a
 
 credits> ESO
 
@@ -3108,6 +3213,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1233a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1233a/thumb.jpg
+astropix_ids: eso|eso1233a
 
 credits> ESO
 
@@ -3134,6 +3240,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1236a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1236a/thumb.jpg
+astropix_ids: eso|eso1236a
 
 credits> ESO
 
@@ -3161,6 +3268,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1238a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1238a/thumb.jpg
+astropix_ids: eso|eso1238a
 
 credits> ESO/B. Bailleul
 
@@ -3191,6 +3299,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1302a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1302a/thumb.jpg
+astropix_ids: eso|eso1302a
 
 credits> ESO/M.-R. Cioni/VISTA Magellanic Cloud survey.Acknowledgment: Cambridge
 Astronomical Survey Unit
@@ -3220,6 +3329,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1303a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1303a/thumb.jpg
+astropix_ids: eso|eso1303a
 
 credits> ESO/F. Comeron
 
@@ -3249,6 +3359,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1320a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1320a/thumb.jpg
+astropix_ids: eso|eso1320a
 
 credits> ESO/U.G. Jørgensen
 
@@ -3276,6 +3387,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1322a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1322a/thumb.jpg
+astropix_ids: eso|eso1322a
 
 credits> ESO
 
@@ -3305,6 +3417,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1412a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1412a/thumb.jpg
+astropix_ids: eso|eso1412a
 
 credits> ESO
 
@@ -3332,6 +3445,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1420a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1420a/thumb.jpg
+astropix_ids: eso|eso1420a
 
 credits> ESO
 
@@ -3359,6 +3473,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1422a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1422a/thumb.jpg
+astropix_ids: eso|eso1422a
 
 credits> ESO/G. Beccari
 
@@ -3387,6 +3502,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1424a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1424a/thumb.jpg
+astropix_ids: eso|eso1424a
 
 credits> ESO
 
@@ -3415,6 +3531,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1436a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1436a/thumb.jpg
+astropix_ids: eso|eso1436a
 
 credits> ALMA (ESO/NAOJ/NRAO)
 
@@ -3442,6 +3559,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1503a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1503a/thumb.jpg
+astropix_ids: eso|eso1503a
 
 credits> ESO
 
@@ -3467,6 +3585,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1520a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1520a/thumb.jpg
+astropix_ids: eso|eso1520a
 
 credits> ESO
 
@@ -3494,6 +3613,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1532a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1532a/thumb.jpg
+astropix_ids: eso|eso1532a
 
 credits> ESO
 
@@ -3520,6 +3640,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1607a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1607a/thumb.jpg
+astropix_ids: eso|eso1607a
 
 credits> ESO
 
@@ -3554,6 +3675,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1607b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1607b/thumb.jpg
+astropix_ids: eso|eso1607b
 
 credits> ESO
 
@@ -3588,6 +3710,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1612a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1612a/thumb.jpg
+astropix_ids: eso|eso1612a
 
 credits> ESO. Acknowledgement: Aniello Grado and Luca Limatola
 
@@ -3613,6 +3736,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1625a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1625a/thumb.jpg
+astropix_ids: eso|eso1625a
 
 credits> ESO/H. Drass et al.
 
@@ -3638,6 +3762,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1628a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1628a/thumb.jpg
+astropix_ids: eso|eso1628a
 
 credits> ESO
 
@@ -3665,6 +3790,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1701-compa/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1701-compa/thumb.jpg
+astropix_ids: eso|eso1701-compa
 
 credits> ESO/VISION survey
 
@@ -3691,6 +3817,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1701-compb/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1701-compb/thumb.jpg
+astropix_ids: eso|eso1701-compb
 
 credits> ESO/Digitized Sky Survey 2.
 
@@ -3714,6 +3841,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1701a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1701a/thumb.jpg
+astropix_ids: eso|eso1701a
 
 credits> ESO/VISION survey
 
@@ -3829,6 +3957,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1723a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1723a/thumb.jpg
+astropix_ids: eso|eso1723a
 
 credits> ESO/G. Beccari
 
@@ -3886,6 +4015,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1740a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1740a/thumb.jpg
+astropix_ids: eso|eso1740a
 
 credits> ESO
 
@@ -3912,6 +4042,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1907a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1907a/thumb.jpg
+astropix_ids: eso|eso1907a
 
 credits> EHT Collaboration
 
@@ -3955,6 +4086,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1914a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1914a/thumb.jpg
+astropix_ids: eso|eso1914a
 
 credits> ESO/VMC Survey
 
@@ -3982,6 +4114,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso1920a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso1920a/thumb.jpg
+astropix_ids: eso|eso1920a
 
 credits> ESO/Nogueras-Lara et al.
 
@@ -4014,6 +4147,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2001b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2001b/thumb.jpg
+astropix_ids: eso|eso2001b
 
 credits> ALMA (ESO/NAOJ/NRAO), Rivilla et al.
 
@@ -4041,6 +4175,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2001e/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2001e/thumb.jpg
+astropix_ids: eso|eso2001e
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin
 
@@ -4065,6 +4200,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2002a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2002a/thumb.jpg
+astropix_ids: eso|eso2002a
 
 credits> ALMA (ESO/NAOJ/NRAO), Olofsson et al. Acknowledgement: Robert Cumming
 
@@ -4095,6 +4231,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2002c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2002c/thumb.jpg
+astropix_ids: eso|eso2002c
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin
 
@@ -4120,6 +4257,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2003a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2003a/thumb.jpg
+astropix_ids: eso|eso2003a
 
 credits> ESO/M. Montargès et al.
 
@@ -4148,6 +4286,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2003b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2003b/thumb.jpg
+astropix_ids: eso|eso2003b
 
 credits> ESO/M. Montargès et al.
 
@@ -4204,6 +4343,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2007c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2007c/thumb.jpg
+astropix_ids: eso|eso2007c
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin
 
@@ -4231,6 +4371,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2008a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2008a/thumb.jpg
+astropix_ids: eso|eso2008a
 
 credits> ESO/Boccaletti et al.
 
@@ -4259,6 +4400,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2008b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2008b/thumb.jpg
+astropix_ids: eso|eso2008b
 
 credits> ESO/Boccaletti et al.
 
@@ -4286,6 +4428,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2008f/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2008f/thumb.jpg
+astropix_ids: eso|eso2008f
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin
 
@@ -4310,6 +4453,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2010b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2010b/thumb.jpg
+astropix_ids: eso|eso2010b
 
 credits> NASA, ESA/Hubble, J. Andrews (U. Arizona)
 
@@ -4337,6 +4481,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2010d/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2010d/thumb.jpg
+astropix_ids: eso|eso2010d
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin
 
@@ -4361,6 +4506,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2011a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2011a/thumb.jpg
+astropix_ids: eso|eso2011a
 
 credits> ESO/Bohn et al.
 
@@ -4390,6 +4536,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2011c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2011c/thumb.jpg
+astropix_ids: eso|eso2011c
 
 credits> ESO/Bohn et al.
 
@@ -4423,6 +4570,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2012a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2012a/thumb.jpg
+astropix_ids: eso|eso2012a
 
 credits> ESO
 
@@ -4449,6 +4597,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2012c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2012c/thumb.jpg
+astropix_ids: eso|eso2012c
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin
 
@@ -4473,6 +4622,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2013a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2013a/thumb.jpg
+astropix_ids: eso|eso2013a
 
 credits> ALMA (ESO/NAOJ/NRAO), Rizzo et al.
 
@@ -4498,6 +4648,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2014c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2014c/thumb.jpg
+astropix_ids: eso|eso2014c
 
 credits> ESO/Exeter/Kraus et al., ALMA (ESO/NAOJ/NRAO)
 
@@ -4529,6 +4680,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2103b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2103b/thumb.jpg
+astropix_ids: eso|eso2103b
 
 credits> ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin
 
@@ -4554,6 +4706,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2105a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2105a/thumb.jpg
+astropix_ids: eso|eso2105a
 
 credits> EHT Collaboration
 
@@ -4583,6 +4736,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2105d/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2105d/thumb.jpg
+astropix_ids: eso|eso2105d
 
 credits> ALMA (ESO/NAOJ/NRAO), Goddi et al.
 
@@ -4611,6 +4765,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2107j/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2107j/thumb.jpg
+astropix_ids: eso|eso2107j
 
 credits> ESA
 
@@ -4640,6 +4795,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2109c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2109c/thumb.jpg
+astropix_ids: eso|eso2109c
 
 credits> ESO/M. Montargès et al.
 
@@ -4669,6 +4825,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2109d/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2109d/thumb.jpg
+astropix_ids: eso|eso2109d
 
 credits> ESO/M. Montargès et al.
 
@@ -4698,6 +4855,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2109e/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2109e/thumb.jpg
+astropix_ids: eso|eso2109e
 
 credits> ESO/M. Montargès et al.
 
@@ -4728,6 +4886,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2109f/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2109f/thumb.jpg
+astropix_ids: eso|eso2109f
 
 credits> ESO/M. Montargès et al.
 
@@ -4758,6 +4917,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2110b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2110b/thumb.jpg
+astropix_ids: eso|eso2110b
 
 credits> ESO/PHANGS
 
@@ -4791,6 +4951,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2110c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2110c/thumb.jpg
+astropix_ids: eso|eso2110c
 
 credits> ESO/PHANGS
 
@@ -4824,6 +4985,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2110d/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2110d/thumb.jpg
+astropix_ids: eso|eso2110d
 
 credits> ESO/PHANGS
 
@@ -4856,6 +5018,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2110e/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2110e/thumb.jpg
+astropix_ids: eso|eso2110e
 
 credits> ESO/PHANGS
 
@@ -4888,6 +5051,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2110f/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2110f/thumb.jpg
+astropix_ids: eso|eso2110f
 
 credits> ESO/PHANGS
 
@@ -4921,6 +5085,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2110g/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2110g/thumb.jpg
+astropix_ids: eso|eso2110g
 
 credits> ESO/ALMA (ESO/NAOJ/NRAO)/PHANGS
 
@@ -4958,6 +5123,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2110h/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2110h/thumb.jpg
+astropix_ids: eso|eso2110h
 
 credits> ESO/ALMA (ESO/NAOJ/NRAO)/PHANGS
 
@@ -4995,6 +5161,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2110i/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2110i/thumb.jpg
+astropix_ids: eso|eso2110i
 
 credits> ESO/ALMA (ESO/NAOJ/NRAO)/PHANGS
 
@@ -5031,6 +5198,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2110j/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2110j/thumb.jpg
+astropix_ids: eso|eso2110j
 
 credits> ESO/ALMA (ESO/NAOJ/NRAO)/PHANGS
 
@@ -5067,6 +5235,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2110k/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2110k/thumb.jpg
+astropix_ids: eso|eso2110k
 
 credits> ESO/ALMA (ESO/NAOJ/NRAO)/PHANGS
 
@@ -5104,6 +5273,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2111b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2111b/thumb.jpg
+astropix_ids: eso|eso2111b
 
 credits> ALMA (ESO/NAOJ/NRAO)/Benisty et al.
 
@@ -5135,6 +5305,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2111c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2111c/thumb.jpg
+astropix_ids: eso|eso2111c
 
 credits> ALMA (ESO/NAOJ/NRAO)/Benisty et al.
 
@@ -5163,6 +5334,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2116b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2116b/thumb.jpg
+astropix_ids: eso|eso2116b
 
 credits> ESO, NASA/ESA/R. Gilmozzi/S. Casertano, J. Schmidt
 
@@ -5197,6 +5369,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2117b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2117b/thumb.jpg
+astropix_ids: eso|eso2117b
 
 credits> ESO/Voggel et al.
 
@@ -5227,6 +5400,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2117d/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2117d/thumb.jpg
+astropix_ids: eso|eso2117d
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin
 
@@ -5254,6 +5428,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2118a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2118a/thumb.jpg
+astropix_ids: eso|eso2118a
 
 credits> ESO/Janson et al.
 
@@ -5288,6 +5463,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2119b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2119b/thumb.jpg
+astropix_ids: eso|eso2119b
 
 credits> ESO/GRAVITY collaboration
 
@@ -5313,6 +5489,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2119c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2119c/thumb.jpg
+astropix_ids: eso|eso2119c
 
 credits> ESO/GRAVITY collaboration
 
@@ -5338,6 +5515,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2119d/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2119d/thumb.jpg
+astropix_ids: eso|eso2119d
 
 credits> ESO/GRAVITY collaboration
 
@@ -5363,6 +5541,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2119e/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2119e/thumb.jpg
+astropix_ids: eso|eso2119e
 
 credits> ESO/GRAVITY collaboration
 
@@ -5388,6 +5567,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso2120b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso2120b/thumb.jpg
+astropix_ids: eso|eso2120b
 
 credits> ESO/Miret-Roig et al.
 
@@ -5422,6 +5602,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso8709a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso8709a/thumb.jpg
+astropix_ids: eso|eso8709a
 
 credits> ESO
 
@@ -5447,6 +5628,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso8906b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso8906b/thumb.jpg
+astropix_ids: eso|eso8906b
 
 credits> ESO
 
@@ -5508,6 +5690,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9003d/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9003d/thumb.jpg
+astropix_ids: eso|eso9003d
 
 credits> ESO
 
@@ -5535,6 +5718,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9003g/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9003g/thumb.jpg
+astropix_ids: eso|eso9003g
 
 credits> ESO
 
@@ -5558,6 +5742,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9003h/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9003h/thumb.jpg
+astropix_ids: eso|eso9003h
 
 credits> ESO
 
@@ -5581,6 +5766,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9003i/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9003i/thumb.jpg
+astropix_ids: eso|eso9003i
 
 credits> ESO
 
@@ -5603,6 +5789,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9003k/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9003k/thumb.jpg
+astropix_ids: eso|eso9003k
 
 credits> ESO
 
@@ -5625,6 +5812,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9011a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9011a/thumb.jpg
+astropix_ids: eso|eso9011a
 
 credits> ESO
 
@@ -5650,6 +5838,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9532a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9532a/thumb.jpg
+astropix_ids: eso|eso9532a
 
 credits> This graph accompanies ESO Press Release 16/95 (20 November 1995). It
 may be reproduced, if credit is given to the European Southern Observatory.
@@ -5681,6 +5870,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9533a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9533a/thumb.jpg
+astropix_ids: eso|eso9533a
 
 credits> ESO
 
@@ -5708,6 +5898,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9720a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9720a/thumb.jpg
+astropix_ids: eso|eso9720a
 
 credits> ESO
 
@@ -5741,6 +5932,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9801a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9801a/thumb.jpg
+astropix_ids: eso|eso9801a
 
 credits> ESO
 
@@ -5777,6 +5969,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9801b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9801b/thumb.jpg
+astropix_ids: eso|eso9801b
 
 credits> ESO
 
@@ -5814,6 +6007,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9805a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9805a/thumb.jpg
+astropix_ids: eso|eso9805a
 
 credits> ESO/N. Devillard
 
@@ -5847,6 +6041,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9805b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9805b/thumb.jpg
+astropix_ids: eso|eso9805b
 
 credits> ESO
 
@@ -5873,6 +6068,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9805c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9805c/thumb.jpg
+astropix_ids: eso|eso9805c
 
 credits> ESO / F. Selman
 
@@ -5902,6 +6098,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9805d/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9805d/thumb.jpg
+astropix_ids: eso|eso9805d
 
 credits> ESO
 
@@ -5933,6 +6130,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9805e/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9805e/thumb.jpg
+astropix_ids: eso|eso9805e
 
 credits> ESO
 
@@ -5960,6 +6158,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9820c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9820c/thumb.jpg
+astropix_ids: eso|eso9820c
 
 credits> ESO
 
@@ -6001,6 +6200,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9820d/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9820d/thumb.jpg
+astropix_ids: eso|eso9820d
 
 credits> ESO
 
@@ -6043,6 +6243,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9821a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9821a/thumb.jpg
+astropix_ids: eso|eso9821a
 
 credits> ESO
 
@@ -6072,6 +6273,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9825a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9825a/thumb.jpg
+astropix_ids: eso|eso9825a
 
 credits> ESO
 
@@ -6107,6 +6309,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9827a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9827a/thumb.jpg
+astropix_ids: eso|eso9827a
 
 credits> ESO
 
@@ -6141,6 +6344,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9833a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9833a/thumb.jpg
+astropix_ids: eso|eso9833a
 
 credits> ESO
 
@@ -6168,6 +6372,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9842c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9842c/thumb.jpg
+astropix_ids: eso|eso9842c
 
 credits> ESO
 
@@ -6203,6 +6408,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9845a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9845a/thumb.jpg
+astropix_ids: eso|eso9845a
 
 credits> ESO
 
@@ -6234,6 +6440,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9845b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9845b/thumb.jpg
+astropix_ids: eso|eso9845b
 
 credits> ESO
 
@@ -6265,6 +6472,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9845c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9845c/thumb.jpg
+astropix_ids: eso|eso9845c
 
 credits> ESO
 
@@ -6290,6 +6498,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9845d/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9845d/thumb.jpg
+astropix_ids: eso|eso9845d
 
 credits> ESO
 
@@ -6327,6 +6536,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9845e/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9845e/thumb.jpg
+astropix_ids: eso|eso9845e
 
 credits> ESO
 
@@ -6356,6 +6566,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9846a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9846a/thumb.jpg
+astropix_ids: eso|eso9846a
 
 credits> ESO/I. Appenzeller, W. Seifert, O. Stahl, M. Zamani
 
@@ -6403,6 +6614,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9846b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9846b/thumb.jpg
+astropix_ids: eso|eso9846b
 
 credits> ESO/I. Appenzeller, W. Seifert, O. Stahl, M. Zamani
 
@@ -6443,6 +6655,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9847b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9847b/thumb.jpg
+astropix_ids: eso|eso9847b
 
 credits> ESO
 
@@ -6467,6 +6680,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9856d/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9856d/thumb.jpg
+astropix_ids: eso|eso9856d
 
 credits> ESO
 
@@ -6496,6 +6710,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9857c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9857c/thumb.jpg
+astropix_ids: eso|eso9857c
 
 credits> ESO
 
@@ -6523,6 +6738,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9857d/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9857d/thumb.jpg
+astropix_ids: eso|eso9857d
 
 credits> ESO
 
@@ -6550,6 +6766,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9858h/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9858h/thumb.jpg
+astropix_ids: eso|eso9858h
 
 credits> ESO
 
@@ -6578,6 +6795,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9903a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9903a/thumb.jpg
+astropix_ids: eso|eso9903a
 
 credits> ESO
 
@@ -6611,6 +6829,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9903b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9903b/thumb.jpg
+astropix_ids: eso|eso9903b
 
 credits> ESO
 
@@ -6646,6 +6865,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9920a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9920a/thumb.jpg
+astropix_ids: eso|eso9920a
 
 credits> ESO
 
@@ -6678,6 +6898,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9920e/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9920e/thumb.jpg
+astropix_ids: eso|eso9920e
 
 credits> ESO
 
@@ -6719,6 +6940,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9920f/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9920f/thumb.jpg
+astropix_ids: eso|eso9920f
 
 credits> ESO
 
@@ -6745,6 +6967,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9920g/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9920g/thumb.jpg
+astropix_ids: eso|eso9920g
 
 credits> ESO
 
@@ -6772,6 +6995,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9920h/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9920h/thumb.jpg
+astropix_ids: eso|eso9920h
 
 credits> ESO
 
@@ -6800,6 +7024,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9920i/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9920i/thumb.jpg
+astropix_ids: eso|eso9920i
 
 credits> ESO
 
@@ -6829,6 +7054,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9920k/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9920k/thumb.jpg
+astropix_ids: eso|eso9920k
 
 credits> ESO
 
@@ -6863,6 +7089,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9920p/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9920p/thumb.jpg
+astropix_ids: eso|eso9920p
 
 credits> ESO
 
@@ -6891,6 +7118,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9920q/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9920q/thumb.jpg
+astropix_ids: eso|eso9920q
 
 credits> ESO
 
@@ -6918,6 +7146,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9920v/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9920v/thumb.jpg
+astropix_ids: eso|eso9920v
 
 credits> ESO
 
@@ -6943,6 +7172,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9921a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9921a/thumb.jpg
+astropix_ids: eso|eso9921a
 
 credits> ESO
 
@@ -6972,6 +7202,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9921b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9921b/thumb.jpg
+astropix_ids: eso|eso9921b
 
 credits> ESO
 
@@ -6995,6 +7226,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9921c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9921c/thumb.jpg
+astropix_ids: eso|eso9921c
 
 credits> ESO
 
@@ -7024,6 +7256,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9922a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9922a/thumb.jpg
+astropix_ids: eso|eso9922a
 
 credits> ESO
 
@@ -7064,6 +7297,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9922b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9922b/thumb.jpg
+astropix_ids: eso|eso9922b
 
 credits> ESO
 
@@ -7106,6 +7340,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9922c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9922c/thumb.jpg
+astropix_ids: eso|eso9922c
 
 credits> ESO
 
@@ -7148,6 +7383,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9922d/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9922d/thumb.jpg
+astropix_ids: eso|eso9922d
 
 credits> ESO
 
@@ -7178,6 +7414,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9923a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9923a/thumb.jpg
+astropix_ids: eso|eso9923a
 
 credits> ESO
 
@@ -7268,6 +7505,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9923d/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9923d/thumb.jpg
+astropix_ids: eso|eso9923d
 
 credits> ESO
 
@@ -7299,6 +7537,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9924a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9924a/thumb.jpg
+astropix_ids: eso|eso9924a
 
 credits> ESO
 
@@ -7345,6 +7584,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9924b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9924b/thumb.jpg
+astropix_ids: eso|eso9924b
 
 credits> ESO
 
@@ -7388,6 +7628,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9924c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9924c/thumb.jpg
+astropix_ids: eso|eso9924c
 
 credits> ESO
 
@@ -7425,6 +7666,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9924d/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9924d/thumb.jpg
+astropix_ids: eso|eso9924d
 
 credits> ESO
 
@@ -7457,6 +7699,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9924e/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9924e/thumb.jpg
+astropix_ids: eso|eso9924e
 
 credits> ESO
 
@@ -7496,6 +7739,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9924f/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9924f/thumb.jpg
+astropix_ids: eso|eso9924f
 
 credits> ESO
 
@@ -7526,6 +7770,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9925a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9925a/thumb.jpg
+astropix_ids: eso|eso9925a
 
 credits> ESO
 
@@ -7581,6 +7826,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9925b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9925b/thumb.jpg
+astropix_ids: eso|eso9925b
 
 credits> ESO
 
@@ -7633,6 +7879,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9926b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9926b/thumb.jpg
+astropix_ids: eso|eso9926b
 
 credits> ESO
 
@@ -7662,6 +7909,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9926d/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9926d/thumb.jpg
+astropix_ids: eso|eso9926d
 
 credits> ESO
 
@@ -7686,6 +7934,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9931a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9931a/thumb.jpg
+astropix_ids: eso|eso9931a
 
 credits> ESO
 
@@ -7713,6 +7962,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9931b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9931b/thumb.jpg
+astropix_ids: eso|eso9931b
 
 credits> ESO
 
@@ -7743,6 +7993,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9931c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9931c/thumb.jpg
+astropix_ids: eso|eso9931c
 
 credits> ESO
 
@@ -7771,6 +8022,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9931d/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9931d/thumb.jpg
+astropix_ids: eso|eso9931d
 
 credits> ESO
 
@@ -7799,6 +8051,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9931e/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9931e/thumb.jpg
+astropix_ids: eso|eso9931e
 
 credits> ESO
 
@@ -7827,6 +8080,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9931f/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9931f/thumb.jpg
+astropix_ids: eso|eso9931f
 
 credits> ESO
 
@@ -7852,6 +8106,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9934a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9934a/thumb.jpg
+astropix_ids: eso|eso9934a
 
 credits> ESO
 
@@ -7885,6 +8140,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9936a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9936a/thumb.jpg
+astropix_ids: eso|eso9936a
 
 credits> ESO
 
@@ -7914,6 +8170,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9944a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9944a/thumb.jpg
+astropix_ids: eso|eso9944a
 
 credits> ESO
 
@@ -7940,6 +8197,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9946a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9946a/thumb.jpg
+astropix_ids: eso|eso9946a
 
 credits> ESO
 
@@ -7984,6 +8242,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9946b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9946b/thumb.jpg
+astropix_ids: eso|eso9946b
 
 credits> ESO
 
@@ -8014,6 +8273,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9948b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9948b/thumb.jpg
+astropix_ids: eso|eso9948b
 
 credits> ESO
 
@@ -8054,6 +8314,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9948c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9948c/thumb.jpg
+astropix_ids: eso|eso9948c
 
 credits> ESO
 
@@ -8087,6 +8348,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9948d/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9948d/thumb.jpg
+astropix_ids: eso|eso9948d
 
 credits> ESO
 
@@ -8121,6 +8383,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9948e/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9948e/thumb.jpg
+astropix_ids: eso|eso9948e
 
 credits> ESO
 
@@ -8155,6 +8418,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9948f/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9948f/thumb.jpg
+astropix_ids: eso|eso9948f
 
 credits> ESO
 
@@ -8197,6 +8461,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9948g/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9948g/thumb.jpg
+astropix_ids: eso|eso9948g
 
 credits> ESO
 
@@ -8230,6 +8495,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9949a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9949a/thumb.jpg
+astropix_ids: eso|eso9949a
 
 credits> ESO
 
@@ -8269,6 +8535,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9954a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9954a/thumb.jpg
+astropix_ids: eso|eso9954a
 
 credits> ESO
 
@@ -8306,6 +8573,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9954c/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9954c/thumb.jpg
+astropix_ids: eso|eso9954c
 
 credits> ESO
 
@@ -8343,6 +8611,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9954d/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9954d/thumb.jpg
+astropix_ids: eso|eso9954d
 
 credits>
 
@@ -8374,6 +8643,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9954e/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9954e/thumb.jpg
+astropix_ids: eso|eso9954e
 
 credits> ESO
 
@@ -8405,6 +8675,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9954f/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9954f/thumb.jpg
+astropix_ids: eso|eso9954f
 
 credits> ESO
 
@@ -8436,6 +8707,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9954g/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9954g/thumb.jpg
+astropix_ids: eso|eso9954g
 
 credits> ESO
 
@@ -8466,6 +8738,7 @@ url: http://data1.wwtassets.org/feeds/eso/eso9954h/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/eso9954h/thumb.jpg
+astropix_ids: eso|eso9954h
 
 credits> ESO
 
@@ -8493,6 +8766,7 @@ url: http://data1.wwtassets.org/feeds/eso/helix/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/helix/thumb.jpg
+astropix_ids: eso|helix
 
 credits> ESO
 
@@ -8523,6 +8797,7 @@ url: http://data1.wwtassets.org/feeds/eso/hh-111/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/hh-111/thumb.jpg
+astropix_ids: eso|hh-111
 
 credits> ESO
 
@@ -8546,6 +8821,7 @@ url: http://data1.wwtassets.org/feeds/eso/j16081299-2304314-dss/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/j16081299-2304314-dss/thumb.jpg
+astropix_ids: eso|j16081299-2304314-dss
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin
 
@@ -8570,6 +8846,7 @@ url: http://data1.wwtassets.org/feeds/eso/jewel-box/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/jewel-box/thumb.jpg
+astropix_ids: eso|jewel-box
 
 credits> ESO
 
@@ -8595,6 +8872,7 @@ url: http://data1.wwtassets.org/feeds/eso/m4/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/m4/thumb.jpg
+astropix_ids: eso|m4
 
 credits> ESO
 
@@ -8618,6 +8896,7 @@ url: http://data1.wwtassets.org/feeds/eso/m55-3point6-m_copy/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/m55-3point6-m_copy/thumb.jpg
+astropix_ids: eso|m55-3point6-m_copy
 
 credits> ESO
 
@@ -8641,6 +8920,7 @@ url: http://data1.wwtassets.org/feeds/eso/m83/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/m83/thumb.jpg
+astropix_ids: eso|m83
 
 credits> ESO/IDA/Danish 1.5 m/R. Gendler, S. Guisard (www.eso.org/~sguisard) and
 C. Thöne
@@ -8682,6 +8962,7 @@ url: http://data1.wwtassets.org/feeds/eso/mcneil/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/mcneil/thumb.jpg
+astropix_ids: eso|mcneil
 
 credits> ESO
 
@@ -8705,6 +8986,7 @@ url: http://data1.wwtassets.org/feeds/eso/minor_planet_tunis/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/minor_planet_tunis/thumb.jpg
+astropix_ids: eso|minor_planet_tunis
 
 credits> ESO
 
@@ -8731,6 +9013,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1008a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1008a/thumb.jpg
+astropix_ids: eso|potw1008a
 
 credits> ESO
 
@@ -8768,6 +9051,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1009a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1009a/thumb.jpg
+astropix_ids: eso|potw1009a
 
 credits> ESO
 
@@ -8805,6 +9089,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1012a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1012a/thumb.jpg
+astropix_ids: eso|potw1012a
 
 credits> ESO
 
@@ -8844,6 +9129,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1015a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1015a/thumb.jpg
+astropix_ids: eso|potw1015a
 
 credits> ESO/IDA/Danish 1.5 m/ R. Gendler, U.G. Jørgensen, J. Skottfelt, K.
 Harpsøe
@@ -8876,6 +9162,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1016a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1016a/thumb.jpg
+astropix_ids: eso|potw1016a
 
 credits> ESO/IDA/Danish 1.5 m/ R. Gendler, U.G. Jørgensen, K. Harpsøe
 
@@ -8911,6 +9198,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1022a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1022a/thumb.jpg
+astropix_ids: eso|potw1022a
 
 credits> ESO
 
@@ -8947,6 +9235,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1026a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1026a/thumb.jpg
+astropix_ids: eso|potw1026a
 
 credits> ESO
 
@@ -8999,6 +9288,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1030a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1030a/thumb.jpg
+astropix_ids: eso|potw1030a
 
 credits> ESO
 
@@ -9032,6 +9322,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1032a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1032a/thumb.jpg
+astropix_ids: eso|potw1032a
 
 credits> ESO/ESA/Hubble and NASA
 
@@ -9074,6 +9365,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1035a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1035a/thumb.jpg
+astropix_ids: eso|potw1035a
 
 credits> ESO
 
@@ -9111,6 +9403,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1037a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1037a/thumb.jpg
+astropix_ids: eso|potw1037a
 
 credits> ESO/IDA/Danish 1.5 m/ R. Gendler, J-E. Ovaldsen, C. Thöne, and C.
 Feron.
@@ -9146,6 +9439,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1046a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1046a/thumb.jpg
+astropix_ids: eso|potw1046a
 
 credits> ESO
 
@@ -9185,6 +9479,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1047a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1047a/thumb.jpg
+astropix_ids: eso|potw1047a
 
 credits> ESO/R. Schoedel
 
@@ -9226,6 +9521,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1048a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1048a/thumb.jpg
+astropix_ids: eso|potw1048a
 
 credits> ESO
 
@@ -9259,6 +9555,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1106a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1106a/thumb.jpg
+astropix_ids: eso|potw1106a
 
 credits> ESO
 
@@ -9296,6 +9593,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1107a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1107a/thumb.jpg
+astropix_ids: eso|potw1107a
 
 credits> ESO
 
@@ -9342,6 +9640,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1120a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1120a/thumb.jpg
+astropix_ids: eso|potw1120a
 
 credits> ESO
 
@@ -9389,6 +9688,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1126a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1126a/thumb.jpg
+astropix_ids: eso|potw1126a
 
 credits> ESO/G. Bono &amp; CTIO
 
@@ -9435,6 +9735,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1128a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1128a/thumb.jpg
+astropix_ids: eso|potw1128a
 
 credits> ESO/R. Gendler
 
@@ -9486,6 +9787,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1131a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1131a/thumb.jpg
+astropix_ids: eso|potw1131a
 
 credits> ESO
 
@@ -9530,6 +9832,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1140a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1140a/thumb.jpg
+astropix_ids: eso|potw1140a
 
 credits> ESO/A. Milani
 
@@ -9577,6 +9880,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1143a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1143a/thumb.jpg
+astropix_ids: eso|potw1143a
 
 credits> ESO/Oleg Maliy
 
@@ -9624,6 +9928,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1148a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1148a/thumb.jpg
+astropix_ids: eso|potw1148a
 
 credits> ESO
 
@@ -9668,6 +9973,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1202a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1202a/thumb.jpg
+astropix_ids: eso|potw1202a
 
 credits> ESO
 
@@ -9718,6 +10024,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1204a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1204a/thumb.jpg
+astropix_ids: eso|potw1204a
 
 credits> ESO
 
@@ -9754,6 +10061,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1212a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1212a/thumb.jpg
+astropix_ids: eso|potw1212a
 
 credits> ESO
 
@@ -9794,6 +10102,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1228a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1228a/thumb.jpg
+astropix_ids: eso|potw1228a
 
 credits> ESO/R. Gendler &amp; R.M. Hannahoe
 
@@ -9837,6 +10146,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1231a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1231a/thumb.jpg
+astropix_ids: eso|potw1231a
 
 credits> ESO
 
@@ -9875,6 +10185,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1236a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1236a/thumb.jpg
+astropix_ids: eso|potw1236a
 
 credits> Optical: ESO, X-ray: NASA/CXC/U.Mich./S.Oey, IR: NASA/JPL
 
@@ -9922,6 +10233,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1242a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1242a/thumb.jpg
+astropix_ids: eso|potw1242a
 
 credits> ESO
 
@@ -9961,6 +10273,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1304a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1304a/thumb.jpg
+astropix_ids: eso|potw1304a
 
 credits> ESO
 
@@ -10009,6 +10322,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1312a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1312a/thumb.jpg
+astropix_ids: eso|potw1312a
 
 credits> ESO
 
@@ -10047,6 +10361,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1330a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1330a/thumb.jpg
+astropix_ids: eso|potw1330a
 
 credits> ESO
 
@@ -10086,6 +10401,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1332a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1332a/thumb.jpg
+astropix_ids: eso|potw1332a
 
 credits> ESO
 
@@ -10138,6 +10454,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1334a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1334a/thumb.jpg
+astropix_ids: eso|potw1334a
 
 credits> ESO
 
@@ -10170,6 +10487,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1335a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1335a/thumb.jpg
+astropix_ids: eso|potw1335a
 
 credits> ESO/PESSTO/S. Smartt
 
@@ -10215,6 +10533,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1338a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1338a/thumb.jpg
+astropix_ids: eso|potw1338a
 
 credits> ESO, and D. Minniti and J. C. Beamín (Pontificia Universidad Católica
 de Chile).
@@ -10265,6 +10584,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1339a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1339a/thumb.jpg
+astropix_ids: eso|potw1339a
 
 credits> ESO
 
@@ -10305,6 +10625,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1341a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1341a/thumb.jpg
+astropix_ids: eso|potw1341a
 
 credits> ESO/VPHAS+ Survey/N. Wright
 
@@ -10356,6 +10677,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1428a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1428a/thumb.jpg
+astropix_ids: eso|potw1428a
 
 credits> ESO
 
@@ -10395,6 +10717,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1444a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1444a/thumb.jpg
+astropix_ids: eso|potw1444a
 
 credits> ESO
 
@@ -10444,6 +10767,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1448a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1448a/thumb.jpg
+astropix_ids: eso|potw1448a
 
 credits> ESO/VVV Team/A. Guzmán
 
@@ -10487,6 +10811,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1509a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1509a/thumb.jpg
+astropix_ids: eso|potw1509a
 
 credits> ESO/C. Snodgrass
 
@@ -10525,6 +10850,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1518a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1518a/thumb.jpg
+astropix_ids: eso|potw1518a
 
 credits> ESO
 
@@ -10568,6 +10894,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1523a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1523a/thumb.jpg
+astropix_ids: eso|potw1523a
 
 credits> ESO / Manu Mejias
 
@@ -10610,6 +10937,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1531a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1531a/thumb.jpg
+astropix_ids: eso|potw1531a
 
 credits> ESO
 
@@ -10648,6 +10976,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1541a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1541a/thumb.jpg
+astropix_ids: eso|potw1541a
 
 credits> ESO/M. McCaughrean
 
@@ -10688,6 +11017,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1543a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1543a/thumb.jpg
+astropix_ids: eso|potw1543a
 
 credits> ESO, A. M. Lagrange (Université Grenoble Alpes)
 
@@ -10729,6 +11059,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1550a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1550a/thumb.jpg
+astropix_ids: eso|potw1550a
 
 credits> ESO
 
@@ -10769,6 +11100,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1605a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1605a/thumb.jpg
+astropix_ids: eso|potw1605a
 
 credits> ESO
 
@@ -10809,6 +11141,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1612a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1612a/thumb.jpg
+astropix_ids: eso|potw1612a
 
 credits> ESO
 
@@ -10850,6 +11183,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1619a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1619a/thumb.jpg
+astropix_ids: eso|potw1619a
 
 credits> ESO. Acknowledgements: Jean-Christophe Lambry
 
@@ -10883,6 +11217,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1621a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1621a/thumb.jpg
+astropix_ids: eso|potw1621a
 
 credits> ESO/Marino et al.
 
@@ -10930,6 +11265,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1624a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1624a/thumb.jpg
+astropix_ids: eso|potw1624a
 
 credits> ESO/Schmidt et al.
 
@@ -10980,6 +11316,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1636a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1636a/thumb.jpg
+astropix_ids: eso|potw1636a
 
 credits> ESO Acknowledgements: Flickr user jbarring
 
@@ -11015,6 +11352,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1640a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1640a/thumb.jpg
+astropix_ids: eso|potw1640a
 
 credits> B. Saxton (NRAO/AUI/NSF); ALMA (ESO/NAOJ/NRAO)
 
@@ -11053,6 +11391,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1644a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1644a/thumb.jpg
+astropix_ids: eso|potw1644a
 
 credits> ALMA (ESO/NAOJ/NRAO)/J.J. Tobin (University of Oklahoma/Leiden
 University)
@@ -11114,6 +11453,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1645a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1645a/thumb.jpg
+astropix_ids: eso|potw1645a
 
 credits> ALMA (ESO/NAOJ/NRAO)/M. Kaufman &amp; the NASA/ESA Hubble Space
 Telescope
@@ -11169,6 +11509,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1652a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1652a/thumb.jpg
+astropix_ids: eso|potw1652a
 
 credits> ESO, ALMA (ESO/NAOJ/NRAO); A. Isella; B. Saxton (NRAO/AUI/NSF)
 
@@ -11206,6 +11547,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1706a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1706a/thumb.jpg
+astropix_ids: eso|potw1706a
 
 credits> ESO Acknowledgement: Flickr user Josh Barrington
 
@@ -11243,6 +11585,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1708a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1708a/thumb.jpg
+astropix_ids: eso|potw1708a
 
 credits> ALMA (ESO/NAOJ/NRAO)/T. Kitayama (Toho University, Japan)/ESA/Hubble
 &amp; NASA
@@ -11288,6 +11631,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1709a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1709a/thumb.jpg
+astropix_ids: eso|potw1709a
 
 credits> ALMA: ESO/NAOJ/NRAO/A. Angelich Hubble: NASA, ESA, R. Kirshner
 (Harvard-Smithsonian Center for Astrophysics and Gordon and Betty Moore
@@ -11333,6 +11677,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1710a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1710a/thumb.jpg
+astropix_ids: eso|potw1710a
 
 credits> ALMA (ESO/NAOJ/NRAO)/H. Kim et al.
 
@@ -11363,8 +11708,8 @@ star. Now, ALMA’s observations, of which this image only shows one
 “cross-section”, have added an extra dimension to reveal the exquisitely-ordered
 3D geometry of the spiral pattern. A full view of the 3D video can be seen in
 this video. An additional image shows a composition of the ALMA and Hubble data.
+Links : ALMA and Hubble observe LL Pegasi 3D view of LL Pegasi
 
-Links: ALMA and Hubble observe LL Pegasi 3D view of LL Pegasi
 wip: yes
 ---
 
@@ -11373,6 +11718,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1710b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1710b/thumb.jpg
+astropix_ids: eso|potw1710b
 
 credits> ALMA (ESO/NAOJ/NRAO)/H. Kim et al., ESA/NASA &amp; R. Sahai
 
@@ -11401,6 +11747,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1711b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1711b/thumb.jpg
+astropix_ids: eso|potw1711b
 
 credits> ESO, ALMA (ESO/NAOJ/NRAO)/A. Schruba, VLA (NRAO)/Y. Bagetakos/Little
 THINGS
@@ -11430,6 +11777,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1712a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1712a/thumb.jpg
+astropix_ids: eso|potw1712a
 
 credits> ALMA (ESO/NAOJ/NRAO); C. Brogan, B. Saxton (NRAO/AUI/NSF)
 
@@ -11466,6 +11814,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1714a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1714a/thumb.jpg
+astropix_ids: eso|potw1714a
 
 credits> ALMA (ESO/NAOJ/NRAO)/ Fedele et al.
 
@@ -11505,6 +11854,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1720a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1720a/thumb.jpg
+astropix_ids: eso|potw1720a
 
 credits> ALMA (ESO/NAOJ/NRAO)/ Lee et al.
 
@@ -11546,6 +11896,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1721a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1721a/thumb.jpg
+astropix_ids: eso|potw1721a
 
 credits> ALMA (ESO/NAOJ/NRAO)/L. Matrà/M. A. MacGregor
 
@@ -11589,6 +11940,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1724a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1724a/thumb.jpg
+astropix_ids: eso|potw1724a
 
 credits> ALMA (ESO/NAOJ/NRAO)/R. Sahai
 
@@ -11625,6 +11977,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1726a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1726a/thumb.jpg
+astropix_ids: eso|potw1726a
 
 credits> ALMA (ESO/NAOJ/NRAO)/E. O’Gorman/P. Kervella
 
@@ -11667,6 +12020,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1730a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1730a/thumb.jpg
+astropix_ids: eso|potw1730a
 
 credits> ESO
 
@@ -11704,6 +12058,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1731a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1731a/thumb.jpg
+astropix_ids: eso|potw1731a
 
 credits> ESOAcknowledgements: Flickr user hdahle70
 
@@ -11745,6 +12100,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1739a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1739a/thumb.jpg
+astropix_ids: eso|potw1739a
 
 credits> ESO/Jean-Christophe Lambry
 
@@ -11781,6 +12137,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1742a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1742a/thumb.jpg
+astropix_ids: eso|potw1742a
 
 credits> ALMA (ESO/NAOJ/NRAO)/S. Kraus (University of Exeter, UK)
 
@@ -11823,6 +12180,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1746b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1746b/thumb.jpg
+astropix_ids: eso|potw1746b
 
 credits> ESO/T. Contini (IRAP, Toulouse), B. Epinat (LAM, Marseille)
 
@@ -11848,6 +12206,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1747a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1747a/thumb.jpg
+astropix_ids: eso|potw1747a
 
 credits> ESO/Arrigoni Battaia et al.
 
@@ -11886,6 +12245,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1752a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1752a/thumb.jpg
+astropix_ids: eso|potw1752a
 
 credits> ESO, ESA/Hubble &amp; NASA
 
@@ -11927,6 +12287,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1752b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1752b/thumb.jpg
+astropix_ids: eso|potw1752b
 
 credits> ESO &amp; ESA/Hubble &amp; NASA
 
@@ -11957,6 +12318,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1801a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1801a/thumb.jpg
+astropix_ids: eso|potw1801a
 
 credits> ESO
 
@@ -11997,6 +12359,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1805a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1805a/thumb.jpg
+astropix_ids: eso|potw1805a
 
 credits> ESO/M. Bellazzini et al.
 
@@ -12031,6 +12394,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1806a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1806a/thumb.jpg
+astropix_ids: eso|potw1806a
 
 credits> NASA &amp; ESA, Acknowledgement: Judy Schmidt (Geckzilla)
 
@@ -12059,6 +12423,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1806b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1806b/thumb.jpg
+astropix_ids: eso|potw1806b
 
 credits> ESO/ESA/Hubble &amp; NASA/J. Weaver et al.
 
@@ -12101,6 +12466,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1807a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1807a/thumb.jpg
+astropix_ids: eso|potw1807a
 
 credits> ESO/M. Wittkowski (ESO)
 
@@ -12145,6 +12511,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1809a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1809a/thumb.jpg
+astropix_ids: eso|potw1809a
 
 credits> ALMA (ESO/NAOJ/NRAO)/ D. Fedele et al.
 
@@ -12185,6 +12552,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1814a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1814a/thumb.jpg
+astropix_ids: eso|potw1814a
 
 credits> ESO Acknowledgements: P. Merluzzi (INAF-Osservatorio Astronomico di
 Capodimonte, Italy)
@@ -12225,6 +12593,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1818a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1818a/thumb.jpg
+astropix_ids: eso|potw1818a
 
 credits> ESO/VVV Survey/D. Minniti Acknowledgement: Ignacio Toledo
 
@@ -12261,6 +12630,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1821a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1821a/thumb.jpg
+astropix_ids: eso|potw1821a
 
 credits> ESO/Juan Carlos Muñoz
 
@@ -12304,6 +12674,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1822a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1822a/thumb.jpg
+astropix_ids: eso|potw1822a
 
 credits> ESO/A. Alonso-Herrero et al.; ALMA (ESO/NAOJ/NRAO)
 
@@ -12344,6 +12715,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1827a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1827a/thumb.jpg
+astropix_ids: eso|potw1827a
 
 credits> ESO/R. Dong et al.; ALMA (ESO/NAOJ/NRAO)
 
@@ -12384,6 +12756,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1831a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1831a/thumb.jpg
+astropix_ids: eso|potw1831a
 
 credits> ESO
 
@@ -12425,6 +12798,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1838a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1838a/thumb.jpg
+astropix_ids: eso|potw1838a
 
 credits> ESO
 
@@ -12459,6 +12833,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1841a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1841a/thumb.jpg
+astropix_ids: eso|potw1841a
 
 credits> ALMA (ESO/NAOJ/NRAO)/S. P. S. Eyres
 
@@ -12502,6 +12877,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1843a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1843a/thumb.jpg
+astropix_ids: eso|potw1843a
 
 credits> ALMA (ESO/NAOJ/NRAO)/ J. R. Goicoechea (Instituto de Física
 Fundamental, CSIC, Spain)
@@ -12546,6 +12922,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1847a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1847a/thumb.jpg
+astropix_ids: eso|potw1847a
 
 credits> ESO
 
@@ -12593,6 +12970,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1849a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1849a/thumb.jpg
+astropix_ids: eso|potw1849a
 
 credits> ESO/D. Fenech et al.; ALMA (ESO/NAOJ/NRAO)
 
@@ -12635,6 +13013,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1850a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1850a/thumb.jpg
+astropix_ids: eso|potw1850a
 
 credits> ESO
 
@@ -12674,6 +13053,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1850b/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1850b/thumb.jpg
+astropix_ids: eso|potw1850b
 
 credits> T. Liimets et al./ESO
 
@@ -12701,6 +13081,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1901a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1901a/thumb.jpg
+astropix_ids: eso|potw1901a
 
 credits> ESO
 
@@ -12741,6 +13122,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1905a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1905a/thumb.jpg
+astropix_ids: eso|potw1905a
 
 credits> ALMA (ESO/NAOJ/NRAO), S. Andrews et al.; NRAO/AUI/NSF, S. Dagnello
 
@@ -12786,6 +13168,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1906a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1906a/thumb.jpg
+astropix_ids: eso|potw1906a
 
 credits> ALMA (ESO/NAOJ/NRAO), S. Andrews et al.; NRAO/AUI/NSF, S. Dagnello
 
@@ -12828,6 +13211,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1908a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1908a/thumb.jpg
+astropix_ids: eso|potw1908a
 
 credits> ESO/SPECULOOS Team/E. Jehin
 
@@ -12869,6 +13253,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1909a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1909a/thumb.jpg
+astropix_ids: eso|potw1909a
 
 credits> ESO/SPECULOOS Team/E. Jehin
 
@@ -12909,6 +13294,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1911a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1911a/thumb.jpg
+astropix_ids: eso|potw1911a
 
 credits> ESO
 
@@ -12952,6 +13338,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1917a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1917a/thumb.jpg
+astropix_ids: eso|potw1917a
 
 credits> ALMA (ESO/NAOJ/NRAO); NRAO/AUI/NSF, B. Saxton
 
@@ -12990,6 +13377,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1919a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1919a/thumb.jpg
+astropix_ids: eso|potw1919a
 
 credits> ESO
 
@@ -13038,6 +13426,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1927a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1927a/thumb.jpg
+astropix_ids: eso|potw1927a
 
 credits> ESO
 
@@ -13085,6 +13474,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1928a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1928a/thumb.jpg
+astropix_ids: eso|potw1928a
 
 credits> ALMA (ESO/NAOJ/NRAO)/K. Blundell (University of Oxford, UK), R. Laing,
 S. Lee &amp; A. Richards, Ap J Letters.
@@ -13128,6 +13518,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1930a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1930a/thumb.jpg
+astropix_ids: eso|potw1930a
 
 credits> ESO/SPECULOOS Team/E. Jehin
 
@@ -13176,6 +13567,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1935a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1935a/thumb.jpg
+astropix_ids: eso|potw1935a
 
 credits> ESO/ R. Leaman/ D. Gadotti/ K. Sandstrom/ D. Calzetti
 
@@ -13211,6 +13603,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1939a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1939a/thumb.jpg
+astropix_ids: eso|potw1939a
 
 credits> ALMA (ESO/NAOJ/NRAO), P. Jachym (Czech Academy of Sciences) et al.
 
@@ -13261,6 +13654,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1943a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1943a/thumb.jpg
+astropix_ids: eso|potw1943a
 
 credits> ESO
 
@@ -13294,6 +13688,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw1949a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw1949a/thumb.jpg
+astropix_ids: eso|potw1949a
 
 credits> ESO
 
@@ -13333,6 +13728,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw2003a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw2003a/thumb.jpg
+astropix_ids: eso|potw2003a
 
 credits> ESO
 
@@ -13370,6 +13766,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw2020a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw2020a/thumb.jpg
+astropix_ids: eso|potw2020a
 
 credits> ESO
 
@@ -13404,6 +13801,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw2027a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw2027a/thumb.jpg
+astropix_ids: eso|potw2027a
 
 credits> ESO
 
@@ -13442,6 +13840,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw2034a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw2034a/thumb.jpg
+astropix_ids: eso|potw2034a
 
 credits> ESO/TIMER survey
 
@@ -13481,6 +13880,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw2038a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw2038a/thumb.jpg
+astropix_ids: eso|potw2038a
 
 credits> ALMA (ESO/NAOJ/NRAO), Decin et al.
 
@@ -13523,6 +13923,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw2047a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw2047a/thumb.jpg
+astropix_ids: eso|potw2047a
 
 credits> ESO/TIMER survey
 
@@ -13559,6 +13960,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw2106a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw2106a/thumb.jpg
+astropix_ids: eso|potw2106a
 
 credits> ESO/TIMER survey
 
@@ -13594,6 +13996,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw2108a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw2108a/thumb.jpg
+astropix_ids: eso|potw2108a
 
 credits> ESO/Ginski et al.
 
@@ -13630,6 +14033,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw2113a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw2113a/thumb.jpg
+astropix_ids: eso|potw2113a
 
 credits> ESO
 
@@ -13668,6 +14072,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw2117a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw2117a/thumb.jpg
+astropix_ids: eso|potw2117a
 
 credits> ESO/Tubín et al.
 
@@ -13708,6 +14113,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw2119a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw2119a/thumb.jpg
+astropix_ids: eso|potw2119a
 
 credits> ESO
 
@@ -13741,6 +14147,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw2122a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw2122a/thumb.jpg
+astropix_ids: eso|potw2122a
 
 credits> ESO/Iodice et al.
 
@@ -13778,6 +14185,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw2123a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw2123a/thumb.jpg
+astropix_ids: eso|potw2123a
 
 credits> ESO
 
@@ -13815,6 +14223,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw2130a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw2130a/thumb.jpg
+astropix_ids: eso|potw2130a
 
 credits> ESO/Ragusa, Spavone et al.
 
@@ -13859,6 +14268,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw2143a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw2143a/thumb.jpg
+astropix_ids: eso|potw2143a
 
 credits> ESO/TIMER survey
 
@@ -13892,6 +14302,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw2145a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw2145a/thumb.jpg
+astropix_ids: eso|potw2145a
 
 credits> ESO/Iodice et al.
 
@@ -13934,6 +14345,7 @@ url: http://data1.wwtassets.org/feeds/eso/potw2148a/L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://data1.wwtassets.org/feeds/eso/potw2148a/thumb.jpg
+astropix_ids: eso|potw2148a
 
 credits> ESO/VST ATLAS team. Acknowledgement: Durham University/CASU/WFAU
 
@@ -13969,8 +14381,9 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-cenaL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-cena.jpg
+astropix_ids: eso|cena
 
-credits> ESO/IDA/Danish 1.5 m/R. Gendler, J.-E. Ovaldsen &amp; S. Guisard
+credits> ESO/IDA/Danish 1.5 m/R. Gendler, J.-E. Ovaldsen & S. Guisard
 (www.eso.org/~sguisard) (ESO); Centaurus A is our nearest giant galaxy, at a
 distance of about 13 million light-years in the southern constellation of
 Centauru...
@@ -13994,6 +14407,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso-6302L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso-6302.jpg
+astropix_ids: eso|eso-6302
 
 credits> ESO/IDA/Danish 1.5 m/R. Gendler, A. Hornstrup and J.-E. Ovaldsen; The
 Bug Nebula, NGC 6302, is one of the brightest and most extreme planetary nebulae
@@ -14018,6 +14432,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso-flameL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso-flame.jpg
+astropix_ids: eso|eso-flame
 
 credits> ESO/IDA/Danish 1.5 m/R. Gendler, J.-E. Ovaldsen, C. Thöne and C. Féron;
 Sparkling at the edge of a giant cloud of gas and dust, the Flame Nebula, also
@@ -14042,6 +14457,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso-m100L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso-m100.jpg
+astropix_ids: eso|eso-m100
 
 credits> ESO/IDA/Danish 1.5 m/R. Gendler,; Similar in appearance to our own
 Milky Way, Messier 100 is a grand spiral galaxy that presents an intricate
@@ -14112,6 +14528,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso0104bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso0104b.jpg
+astropix_ids: eso|eso0104b
 
 credits> ESO/M.McCaughrean et al. (AIP); This image shows smaller, particularly
 interesting areas of ESO Press Photo eso0104a. The traces of a massive outflow
@@ -14136,6 +14553,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso0216fL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso0216f.jpg
+astropix_ids: eso|eso0216f
 
 credits> ESO; Long and bright "filaments" of luminous gas in an area SW of the
 centre of the Tarantula Nebula....
@@ -14159,6 +14577,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso0417dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso0417d.jpg
+astropix_ids: eso|eso0417d
 
 credits> ESO; Colour composite image of the Galactic Centre at a distance of
 about 30,000 light-years. It was made by combining images in filt...
@@ -14182,6 +14601,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso0430eL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso0430e.jpg
+astropix_ids: eso|eso0430e
 
 credits> ESO; Composite, false-colour image showing asteroid (4179) Toutatis
 moving in front of background stars, as seen from Paranal (red tr...
@@ -14205,6 +14625,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso0436cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso0436c.jpg
+astropix_ids: eso|eso0436c
 
 credits> ESO; Composite colour-coded image of another magnificent spiral galaxy,
 NGC 7424, at a distance of 40 million light-years. It is base...
@@ -14228,6 +14649,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso0817bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso0817b.jpg
+astropix_ids: eso|eso0817b
 
 credits> ESO; Located 9,000 light-years away, NGC 3576 is a gigantic region of
 glowing gas about 100 light-years across, where stars are curre...
@@ -14251,6 +14673,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso0945bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso0945b.jpg
+astropix_ids: eso|eso0945b
 
 credits> ESO/Digitized Sky Survey 2; This wide-field image, based on data from
 Digitized Sky Survey 2, shows the whole region around the stellar grouping
@@ -14275,6 +14698,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1003bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1003b.jpg
+astropix_ids: eso|eso1003b
 
 credits> ESO/Digitized Sky Survey 2; Wide view centred on the Cat’s Paw Nebula
 (NGC 6334)....
@@ -14298,6 +14722,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1004cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1004c.jpg
+astropix_ids: eso|eso1004c
 
 credits> ESO/P. Crowther; Astronomers using ESO’s Very Large Telescope (VLT)
 have detected a stellar-mass black hole much further away than any other prev...
@@ -14321,6 +14746,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1004dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1004d.jpg
+astropix_ids: eso|eso1004d
 
 credits> ESO/Digitized Sky Survey 2; This wide field image, from the Digitized
 Sky Survey 2, shows the area around the spiral galaxy, NGC 300, six million
@@ -14345,6 +14771,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1005bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1005b.jpg
+astropix_ids: eso|eso1005b
 
 credits> ESO/Digitized Sky Survey 2; This wide-field image, based on data from
 Digitized Sky Survey 2, shows the whole region around the cosmic factory NGC
@@ -14369,6 +14796,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1007aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1007a.jpg
+astropix_ids: eso|eso1007a
 
 credits> ESO/Digitized Sky Survey 2; The Fornax dwarf galaxy is one of our Milky
 Way’s neighbouring dwarf galaxies. The Milky Way is, like all large galaxies,
@@ -14393,6 +14821,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1007bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1007b.jpg
+astropix_ids: eso|eso1007b
 
 credits> ESO/Digitized Sky Survey 2; The Sculptor dwarf galaxy is one of our
 Milky Way’s neighbouring dwarf galaxies. The Milky Way is, like all large
@@ -14417,6 +14846,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1008aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1008a.jpg
+astropix_ids: eso|eso1008a
 
 credits> ESO; NGC 346, the brightest star-forming region in the neighbouring
 Small Magellanic Cloud galaxy, some 210,000 light-years away from...
@@ -14440,6 +14870,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1008bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1008b.jpg
+astropix_ids: eso|eso1008b
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgements: Davide De Martin; Wide
 field image, based on data from Digitized Sky Survey 2, around the star-forming
@@ -14464,6 +14895,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1009aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1009a.jpg
+astropix_ids: eso|eso1009a
 
 credits> ESO; The delicate nebula NGC 1788, located in a dark and often
 neglected corner of the Orion constellation, is revealed in this finel...
@@ -14487,6 +14919,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1009bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1009b.jpg
+astropix_ids: eso|eso1009b
 
 credits> ESO/Digitized Sky Survey 2; The delicate nebula NGC 1788 is located in
 a dark and often neglected corner of the Orion constellation. Although this
@@ -14511,9 +14944,10 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1012dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1012d.jpg
+astropix_ids: eso|eso1012d
 
-credits> ESO &amp; DSS2; This image shows the wider region around the distant
-galaxy SMM J2135-0102, which is being gravitationally lensed by the galaxy ...
+credits> ESO & DSS2; This image shows the wider region around the distant galaxy
+SMM J2135-0102, which is being gravitationally lensed by the galaxy ...
 
 wip: yes
 ---
@@ -14558,6 +14992,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1014aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1014a.jpg
+astropix_ids: eso|eso1014a
 
 credits> ESO; This image of the Gum 19 star-forming region was obtained with
 SOFI, an infrared instrument mounted on ESO’s New Technology Tele...
@@ -14581,6 +15016,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1014bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1014b.jpg
+astropix_ids: eso|eso1014b
 
 credits> ESO/Digitized Sky Survey 2; This image shows the area around the
 star-forming region Gum 19, in the direction of the constellation of Vela (the
@@ -14605,6 +15041,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1019aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1019a.jpg
+astropix_ids: eso|eso1019a
 
 credits> ESO/J. Dietrich; This wide-field, deep image reveals thousands of
 galaxies crowding an area on the sky roughly as large as the full Moon. These
@@ -14629,6 +15066,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1019bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1019b.jpg
+astropix_ids: eso|eso1019b
 
 credits> ESO/ Digitized Sky Survey 2; This image, based on data from the
 Digitized Sky Survey 2, shows a wide area (2.6 x 2.9 degrees) around the cluster
@@ -14653,6 +15091,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1020aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1020a.jpg
+astropix_ids: eso|eso1020a
 
 credits> ESO/M. Gieles.Acknowledgement: Mischa Schirmer; This image of the
 nearby galaxy Messier 83 was taken in the infrared part of the spectrum with the
@@ -14677,6 +15116,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1020dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1020d.jpg
+astropix_ids: eso|eso1020d
 
 credits> ESO, Digitized Sky Survey 2. Acknowledgement: Davide De Martin; This
 wide-field view shows the field around the spiral galaxy Messier 83. The image
@@ -14701,6 +15141,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1021aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1021a.jpg
+astropix_ids: eso|eso1021a
 
 credits> ESO; This spectacular new image from the Wide Field Imager on the
 MPG/ESO 2.2-metre telescope at ESO’s La Silla Observatory in Chile ...
@@ -14724,6 +15165,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1021cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1021c.jpg
+astropix_ids: eso|eso1021c
 
 credits> ESO, Digitized Sky Survey 2. Acknowledgement: Davide De Martin; This
 wide-field view shows a section of the Large Magellanic Cloud, centred on the
@@ -14748,6 +15190,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1023aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1023a.jpg
+astropix_ids: eso|eso1023a
 
 credits> TRAPPIST/E. Jehin/ESO; This first light image of the TRAPPIST national
 telescope at La Silla shows the Tarantula Nebula, located in the Large
@@ -14772,6 +15215,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1023cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1023c.jpg
+astropix_ids: eso|eso1023c
 
 credits> TRAPPIST/E. Jehin/ESO; The globular cluster Omega Centauri was one of
 the targets observed for first light of the TRAPPIST national telescope at La
@@ -14796,6 +15240,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1023dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1023d.jpg
+astropix_ids: eso|eso1023d
 
 credits> TRAPPIST/E. Jehin/ESO; One of the TRAPPIST first light images shows the
 spiral galaxy Messier 83. Messier 83 lies roughly 15 million light-years away
@@ -14820,6 +15265,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1024dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1024d.jpg
+astropix_ids: eso|eso1024d
 
 credits> ESO/Digitized Sky Survey 2; Beta Pictoris is located about 60
 light-years away towards the constellation of Pictor (the Painter's Easel) and
@@ -14844,6 +15290,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1025aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1025a.jpg
+astropix_ids: eso|eso1025a
 
 credits> ESO/J. Emerson/VISTA. Acknowledgment: Cambridge Astronomical Survey
 Unit; NGC 253 is one of the closest galaxies to our own. It is a bright spiral
@@ -14868,6 +15315,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1027bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1027b.jpg
+astropix_ids: eso|eso1027b
 
 credits> Loke Kun Tan (StarryScapes.com); This spectacular wide field image
 shows the area around the star R Coronae Australis. A huge dust cloud, about
@@ -14892,6 +15340,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1029dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1029d.jpg
+astropix_ids: eso|eso1029d
 
 credits> ESO/Digitized Sky Survey 2; The object IRAS 13481-6124, which consists
 of a young central star, about 20 times the mass of our Sun and 5 times its
@@ -14916,6 +15365,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1030dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1030d.jpg
+astropix_ids: eso|eso1030d
 
 credits> ESO/P. Crowther/C.J. Evans; A new near-infrared image of the R136
 cluster, obtained at high resolution with the MAD adaptive optics instrument at
@@ -14940,6 +15390,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1031aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1031a.jpg
+astropix_ids: eso|eso1031a
 
 credits> ESO; This image of part of the Carina Nebula was created from images
 taken through red, green and blue filters with the Wide Field Im...
@@ -14963,6 +15414,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1033aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1033a.jpg
+astropix_ids: eso|eso1033a
 
 credits> ESO/M.-R. Cioni/VISTA Magellanic; This VISTA image shows the
 spectacular 30 Doradus star-forming region, also called the Tarantula Nebula. At
@@ -14987,6 +15439,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1033cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1033c.jpg
+astropix_ids: eso|eso1033c
 
 credits> ESO/M.-R. Cioni/VISTA Magellanic; This VISTA image shows the
 spectacular 30 Doradus star-forming region, also called the Tarantula Nebula. At
@@ -15011,6 +15464,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1034bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1034b.jpg
+astropix_ids: eso|eso1034b
 
 credits> ESO; This image of the young star cluster Westerlund 1 was taken with
 the Wide Field Imager on the MPG/ESO 2.2-metre telescope at ESO...
@@ -15034,6 +15488,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1034cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1034c.jpg
+astropix_ids: eso|eso1034c
 
 credits> ESO; This image of the young star cluster Westerlund 1 was taken with
 the Wide Field Imager on the MPG/ESO 2.2-metre telescope at ESO...
@@ -15057,6 +15512,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1035bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1035b.jpg
+astropix_ids: eso|eso1035b
 
 credits> ESO, Digitized Sky Survey 2. Acknowledgement: Davide De Martin; This
 wide-field image shows the sky around the star HD 10180, which appears as a
@@ -15081,6 +15537,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1035cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1035c.jpg
+astropix_ids: eso|eso1035c
 
 credits> ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin; This
 image shows a close-up of the sky around the star HD 10180. The picture was
@@ -15105,6 +15562,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1036aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1036a.jpg
+astropix_ids: eso|eso1036a
 
 credits> ESO/J. Dietrich; This visible light image, made with the Wide Field
 Imager on the MPG/ESO 2.2-metre telescope at the La Silla Observatory in Chil...
@@ -15128,6 +15586,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1036bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1036b.jpg
+astropix_ids: eso|eso1036b
 
 credits> ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin; This
 visible light wide-field image of the region around NGC 4666 was created from
@@ -15152,6 +15611,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1037aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1037a.jpg
+astropix_ids: eso|eso1037a
 
 credits> ESO; This picture of the spectacular southern spiral galaxy NGC 300 was
 taken using the Wide Field Imager (WFI) at ESO’s La Silla Obs...
@@ -15175,6 +15635,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1038aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1038a.jpg
+astropix_ids: eso|eso1038a
 
 credits> ESO/P. Grosbøl; This striking new image, taken with the powerful HAWK-I
 infrared camera on ESO’s Very Large Telescope at Paranal Observatory in ...
@@ -15198,6 +15659,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1039aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1039a.jpg
+astropix_ids: eso|eso1039a
 
 credits> ESO/J. Emerson/VISTA. Acknowledg; This dramatic infrared image shows
 the nearby star formation region Monoceros R2, located some 2700 light-years
@@ -15222,6 +15684,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1039eL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1039e.jpg
+astropix_ids: eso|eso1039e
 
 credits> ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin; This
 visible light wide-field image of the region around Monoceros R2 was created
@@ -15246,6 +15709,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1042bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1042b.jpg
+astropix_ids: eso|eso1042b
 
 credits> ESO/P. Grosbøl; This image shows NGC 5247, a grand design barred spiral
 galaxy, located 60–70 million light-years away. The galaxy lies face-on ...
@@ -15269,6 +15733,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1042cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1042c.jpg
+astropix_ids: eso|eso1042c
 
 credits> ESO/P. Grosbøl; This galaxy is Messier 100, also known as NGC 4321,
 which was discovered in the 18th century. About 55 million light-years from ...
@@ -15292,6 +15757,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1042dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1042d.jpg
+astropix_ids: eso|eso1042d
 
 credits> ESO/P. Grosbøl; This image is of NGC 1300, a spiral galaxy with arms
 extending from the ends of a spectacularly prominent central bar. It is con...
@@ -15315,6 +15781,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1042eL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1042e.jpg
+astropix_ids: eso|eso1042e
 
 credits> ESO/P. Grosbøl; This spiral galaxy, NGC 4030, lies about 75 million
 light-years from Earth, in the constellation of Virgo. In 2007 Takao Doi, a ...
@@ -15338,6 +15805,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1042fL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1042f.jpg
+astropix_ids: eso|eso1042f
 
 credits> ESO/P. Grosbøl; This image, NGC 2997, is a spiral galaxy roughly 30
 million light-years away in the constellation of Antlia (the Air Pump). NGC ...
@@ -15361,6 +15829,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1042gL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1042g.jpg
+astropix_ids: eso|eso1042g
 
 credits> ESO/P. Grosbøl; NGC 1232 is a spiral galaxy some 65 million light-years
 away in the constellation of Eridanus (the River). The galaxy is classif...
@@ -15384,6 +15853,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1044aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1044a.jpg
+astropix_ids: eso|eso1044a
 
 credits> ESO; This new image shows the results of a vast collision between two
 galaxies. This strange object is known as NGC 7252, or Arp 226,...
@@ -15407,6 +15877,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1044cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1044c.jpg
+astropix_ids: eso|eso1044c
 
 credits> ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin; This
 visible light wide-field image of the region around NGC 7252 was created from
@@ -15431,6 +15902,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1045cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1045c.jpg
+astropix_ids: eso|eso1045c
 
 credits> ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin; This
 visible light wide-field image of the region around the exoplanet HIP 13044 b
@@ -15455,6 +15927,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1046bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1046b.jpg
+astropix_ids: eso|eso1046b
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This wide field view of part of our
 neighbouring galaxy, the Large Magellanic Cloud, was created from photographs
@@ -15479,6 +15952,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1048aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1048a.jpg
+astropix_ids: eso|eso1048a
 
 credits> ESO/ESO Imaging Survey; The globular cluster Messier 107, also known as
 NGC 6171, is located about 21 000 light-years away in the constellation of
@@ -15503,6 +15977,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1101aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1101a.jpg
+astropix_ids: eso|eso1101a
 
 credits> ESO/VVVAcknowledgment: Cambridge; This new infrared view of the star
 formation region Messier 8, often called the Lagoon Nebula, was captured by the
@@ -15527,6 +16002,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1101dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1101d.jpg
+astropix_ids: eso|eso1101d
 
 credits> ESO/VVVAcknowledgment: Cambridge; This new infrared view of the star
 formation region Messier 8, often called the Lagoon Nebula, was captured by the
@@ -15551,6 +16027,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1103aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1103a.jpg
+astropix_ids: eso|eso1103a
 
 credits> ESO/Igor Chekalin; This new image of the Orion Nebula was captured
 using the Wide Field Imager camera on the MPG/ESO 2.2-metre telescope at the La
@@ -15575,6 +16052,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1104aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1104a.jpg
+astropix_ids: eso|eso1104a
 
 credits> ESO and Joe DePasquale; This picture of the spiral galaxy NGC 3621 was
 taken using the Wide Field Imager (WFI) at ESO’s La Silla Observatory in Chile.
@@ -15599,6 +16077,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1106cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1106c.jpg
+astropix_ids: eso|eso1106c
 
 credits> ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin; This
 visible-light wide-field image of the region around the young star T Cha was
@@ -15623,6 +16102,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1106dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1106d.jpg
+astropix_ids: eso|eso1106d
 
 credits> ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin; This
 visible-light wide-field image of the region around the young star T Cha was
@@ -15647,6 +16127,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1107aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1107a.jpg
+astropix_ids: eso|eso1107a
 
 credits> ESO; This picture of the spiral galaxy NGC 247 was taken using the Wide
 Field Imager (WFI) at ESO’s La Silla Observatory in Chile. NG...
@@ -15670,6 +16151,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1107cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1107c.jpg
+astropix_ids: eso|eso1107c
 
 credits> ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin; This
 visible light wide-field image of the region around NGC 247 was created from
@@ -15694,6 +16176,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1108aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1108a.jpg
+astropix_ids: eso|eso1108a
 
 credits> ESO/NOAJ/Subaru/R. Gobat; This image is a composite of very long
 exposures taken with ESO’s Very Large Telescope in Chile and the NAOJ’s Subaru
@@ -15718,6 +16201,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1108cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1108c.jpg
+astropix_ids: eso|eso1108c
 
 credits> ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin; This
 visible light wide-field image of the region around the most remote mature
@@ -15742,6 +16226,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1109cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1109c.jpg
+astropix_ids: eso|eso1109c
 
 credits> ESO/Sergey Stepanenko; This very detailed image of the star-forming
 region NGC 6729 from ESO’s Very Large Telescope shows the dramatic effects of
@@ -15766,6 +16251,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1110cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1110c.jpg
+astropix_ids: eso|eso1110c
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgement: Davide de Martin; This
 visible light wide-field image of the region around the brown dwarf binary
@@ -15790,6 +16276,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1111aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1111a.jpg
+astropix_ids: eso|eso1111a
 
 credits> ESO/Manu Mejias; This picture of the star cluster and surrounding
 nebula NGC 371 was taken using the FORS1 instrument on ESO’s Very Large
@@ -15814,6 +16301,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1113aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1113a.jpg
+astropix_ids: eso|eso1113a
 
 credits> ESO, Digitized Sky Survey 2 and Joe DePasquale ; This picture of the
 star formation region NGC 3582 was taken using the Wide Field Imager at ESO's La
@@ -15838,6 +16326,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1113cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1113c.jpg
+astropix_ids: eso|eso1113c
 
 credits> ESO and Digitized Sky Survey 2.Acknowledgment: Davide De Martin ; This
 visible light wide-field image of the region around NGC 3582 was created from
@@ -15862,6 +16351,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1114aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1114a.jpg
+astropix_ids: eso|eso1114a
 
 credits> ESO/Igor Chekalin; This image from the Wide Field Imager on the MPG/ESO
 2.2-metre telescope at the La Silla Observatory in Chile captures the pair ...
@@ -15885,6 +16375,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1114cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1114c.jpg
+astropix_ids: eso|eso1114c
 
 credits> ESO and Digitized Sky Survey 2. Acknowledgement: Davide De Martin; This
 visible-light wide-field image of the region around NGC 3169 and NGC 3166 was
@@ -15909,6 +16400,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1114dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1114d.jpg
+astropix_ids: eso|eso1114d
 
 credits> ESO/Igor Chekalin; This section of a picture from the Wide Field Imager
 on the MPG/ESO 2.2-metre telescope at the La Silla Observatory in Chile sho...
@@ -15932,6 +16424,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1115aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1115a.jpg
+astropix_ids: eso|eso1115a
 
 credits> ESO; This picture of the Meathook Galaxy (NGC 2442) was taken by the
 Wide Field Imager on the MPG/ESO 2.2-metre telescope at La Silla...
@@ -15955,6 +16448,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1115bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1115b.jpg
+astropix_ids: eso|eso1115b
 
 credits> NASA/ESA and ESO; This close-up Hubble view of the Meathook Galaxy (NGC
 2442) focuses on the more compact of its two asymmetric spiral arms as wel...
@@ -15978,6 +16472,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1115cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1115c.jpg
+astropix_ids: eso|eso1115c
 
 credits> ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin; This
 visible-light wide-field image of the region around the deformed spiral galaxy
@@ -16002,6 +16497,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1117aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1117a.jpg
+astropix_ids: eso|eso1117a
 
 credits> ESO/M.-R. Cioni/VISTA Magellanic Cloud survey. Acknowledgment:
 Cambridge Astronomical Survey Unit; This view shows part of the very active
@@ -16052,6 +16548,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1118aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1118a.jpg
+astropix_ids: eso|eso1118a
 
 credits> ESO; This picture of the nearby galaxy NGC 6744 was taken with the Wide
 Field Imager on the MPG/ESO 2.2-metre telescope at La Silla. ...
@@ -16075,6 +16572,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1118cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1118c.jpg
+astropix_ids: eso|eso1118c
 
 credits> ESO and Digitized Sky Survey 2; This visible-light wide-field image of
 the region around NGC 6744 was created from photographs taken through blue, red
@@ -16099,6 +16597,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1123aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1123a.jpg
+astropix_ids: eso|eso1123a
 
 credits> ESO/S. Guisard (www.eso.org/~sgu; The colourful Rho Ophiuchi star
 formation region, about 400 light-years from Earth, contains very cold (around
@@ -16123,6 +16622,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1124aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1124a.jpg
+astropix_ids: eso|eso1124a
 
 credits> CFHT/IAP/Terapix/CNRS/ESO; This very deep image shows the COSMOS field
 imaged by the Canada France Hawaii Telescope (CFHT). Huge numbers of very faint
@@ -16147,6 +16647,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1124cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1124c.jpg
+astropix_ids: eso|eso1124c
 
 credits> ESO and Digitized Sky Survey 2. Acknowledgement: Davide De Martin.;
 This visible-light wide-field image of the region around the COSMOS field was
@@ -16171,6 +16672,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1124dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1124d.jpg
+astropix_ids: eso|eso1124d
 
 credits> CFHT/IAP/Terapix/CNRS/ESO; This very deep image shows the COSMOS field
 imaged by the Canada France Hawaii Telescope (CFHT). Huge numbers of very faint
@@ -16195,6 +16697,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1126cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1126c.jpg
+astropix_ids: eso|eso1126c
 
 credits> ESO and Digitized Sky Survey 2; This visible-light wide-field image of
 the region around the Leo Triplet of galaxies was created from photographs taken
@@ -16219,6 +16722,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1129aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1129a.jpg
+astropix_ids: eso|eso1129a
 
 credits> ESO/O. Maliy; This picture of the nearby galaxy NGC 3521 was taken
 using the FORS1 instrument on ESO’s Very Large Telescope, at the Paranal Ob...
@@ -16242,6 +16746,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1129cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1129c.jpg
+astropix_ids: eso|eso1129c
 
 credits> ESO and Digitized Sky Survey 2; This visible light wide-field image of
 the region around NGC 3521 was created from photographs taken through blue, red
@@ -16266,6 +16771,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1130cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1130c.jpg
+astropix_ids: eso|eso1130c
 
 credits> ESO and Digitized Sky Survey 2 ; This visible-light wide-field image of
 the region around the giant Lyman-alpha blob LAB1 was created from photographs
@@ -16290,6 +16796,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1132aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1132a.jpg
+astropix_ids: eso|eso1132a
 
 credits> ESO/Digitized Sky Survey 2; At the centre of this picture is a very
 unremarkable looking faint star, too faint to be seen through all but the
@@ -16314,6 +16821,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1132eL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1132e.jpg
+astropix_ids: eso|eso1132e
 
 credits> ESO and Digitized Sky Survey 2; This visible light wide-field image of
 the region around SDSS J102915+172927 was created from photographs taken through
@@ -16338,6 +16846,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1141bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1141b.jpg
+astropix_ids: eso|eso1141b
 
 credits> Ê ESO/D. Minniti/VVV Team; This image from VISTA is a tiny part of the
 VISTA Variables in the Via Lactea (VVV) survey that is systematically studying
@@ -16362,6 +16871,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1141cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1141c.jpg
+astropix_ids: eso|eso1141c
 
 credits> Ê ESO/D. Minniti/VVV Team; This image from VISTA is a tiny part of the
 VISTA Variables in the Via Lactea (VVV) survey that is systematically studying
@@ -16386,6 +16896,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1147dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1147d.jpg
+astropix_ids: eso|eso1147d
 
 credits> ESO; This view shows part of the stellar nursery called the Tarantula
 Nebula in the Large Magellanic Cloud, a small neighbour of the ...
@@ -16409,6 +16920,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1148cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1148c.jpg
+astropix_ids: eso|eso1148c
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin.; This
 wide-field image of the sky around the unusual double star SS Leporis is a
@@ -16433,6 +16945,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1201aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1201a.jpg
+astropix_ids: eso|eso1201a
 
 credits> ESO; This image of the Omega Nebula (Messier 17), captured by ESO's
 Very Large Telescope (VLT), is one of the sharpest of this objec...
@@ -16456,6 +16969,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1205aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1205a.jpg
+astropix_ids: eso|eso1205a
 
 credits> ESO/VISTA/J. Emerson. Acknowledgment: Cambridge Astronomical Survey
 Unit; ESO's Visible and Infrared Survey Telescope for Astronomy (VISTA) has
@@ -16480,6 +16994,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1206aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1206a.jpg
+astropix_ids: eso|eso1206a
 
 credits> ESO, APEX (MPIfR/ESO/OSO), A. We; The LABOCA camera on the ESO-operated
 12-metre Atacama Pathfinder Experiment (APEX) telescope reveals distant galaxies
@@ -16504,6 +17019,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1208dbL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1208db.jpg
+astropix_ids: eso|eso1208db
 
 credits> ESO/T. Preibisch; Colour-composite image of the Carina Nebula,
 revealing exquisite details in the stars and dust of the region. Several well
@@ -16528,6 +17044,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1208dcL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1208dc.jpg
+astropix_ids: eso|eso1208dc
 
 credits> ESO; Colour-composite image of the Carina Nebula, revealing exquisite
 details in the stars and dust of the region. Several well known...
@@ -16551,6 +17068,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1209aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1209a.jpg
+astropix_ids: eso|eso1209a
 
 credits> ESO/APEX (MPIfR/ESO/OSO)/A. Haca; This image from the APEX telescope,
 of part of the Taurus Molecular Cloud, shows a sinuous filament of cosmic dust
@@ -16575,6 +17093,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1211dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1211d.jpg
+astropix_ids: eso|eso1211d
 
 credits> ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin.; This
 visible-light wide-field image of the region around the Hercules cluster of
@@ -16599,6 +17118,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1212dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1212d.jpg
+astropix_ids: eso|eso1212d
 
 credits> Digitized Sky Survey 2. Acknowle; This image shows a photographic view
 created from the Digitized Sky Survey 2 of part of the constellation of Cetus
@@ -16623,6 +17143,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1213aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1213a.jpg
+astropix_ids: eso|eso1213a
 
 credits> ESO/UltraVISTA team. Acknowledge; This view shows a section of the
 widest deep view of the sky ever taken using infrared light, with a total
@@ -16702,6 +17223,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1218cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1218c.jpg
+astropix_ids: eso|eso1218c
 
 credits> ESO and Digitized Sky Survey 2; This visible-light wide-field image of
 the region around the star cluster NGC 6604 was created from photographs taken
@@ -16726,6 +17248,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1219aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1219a.jpg
+astropix_ids: eso|eso1219a
 
 credits> ESO/APEX (MPIfR/ESO/OSO)/T. Stanke et al./Igor Chekalin/Digitized Sky
 Survey 2; This image of the region surrounding the reflection nebula Messier 78,
@@ -16750,6 +17273,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1220aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1220a.jpg
+astropix_ids: eso|eso1220a
 
 credits> ESO/J. Emerson/VISTA. Acknowledgment: Cambridge Astronomical Survey
 Unit; This striking view of the globular star cluster Messier 55 in the
@@ -16774,6 +17298,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1220cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1220c.jpg
+astropix_ids: eso|eso1220c
 
 credits> ESO and Digitized Sky Survey 2; This visible light wide-field image of
 the region around Messier 55 was created from photographs taken through blue and
@@ -16798,6 +17323,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1222cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1222c.jpg
+astropix_ids: eso|eso1222c
 
 credits> ESO; This is part of the image comparison The radio galaxy Centaurus A,
 as seen by ALMA....
@@ -16821,6 +17347,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1227cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1227c.jpg
+astropix_ids: eso|eso1227c
 
 credits> ESO/Digitized Sky Survey 2; This image of the sky around the star Tau
 Boötis was created from the Digitized Sky Survey 2 images. The star itself,
@@ -16845,6 +17372,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1228aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1228a.jpg
+astropix_ids: eso|eso1228a
 
 credits> ESO, Digitized Sky Survey 2 and S. Cantalupo (UCSC); This deep image
 shows the region of the sky around the quasar HE0109-3518. The quasar is near
@@ -16869,6 +17397,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1236cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1236c.jpg
+astropix_ids: eso|eso1236c
 
 credits> ESO/Digitized Sky Survey 2Acknowledgment: Davide De Martin. ; This
 image of the region of sky around the Pencil Nebula shows a spectacular
@@ -16893,6 +17422,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1248cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1248c.jpg
+astropix_ids: eso|eso1248c
 
 credits> ALMA (ESO/NAOJ/NRAO)/Digitized S; This image shows the brown dwarf
 ISO-Oph 102, or Rho-Oph 102, in the Rho Ophiuchi star-forming region. Its
@@ -16917,6 +17447,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1249aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1249a.jpg
+astropix_ids: eso|eso1249a
 
 credits> CFHT/ESO/M. Schirmer; This view from the Canada-France-Hawaii Telescope
 shows thousands of galaxies in the distant Universe. But the one close to the
@@ -16941,6 +17472,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1249bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1249b.jpg
+astropix_ids: eso|eso1249b
 
 credits> CFHT/ESO/M. Schirmer; This view from the Canada-France-Hawaii Telescope
 shows a close-up of the sky around a very unusual green object called
@@ -16965,6 +17497,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1250aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1250a.jpg
+astropix_ids: eso|eso1250a
 
 credits> ESO. Acknowledgement: VPHAS+ Consortium/Cambridge Astronomical Survey
 Unit; The spectacular star-forming Carina Nebula has been captured in great
@@ -16989,6 +17522,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1302cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1302c.jpg
+astropix_ids: eso|eso1302c
 
 credits> ESO/Digitized Sky Survey 2Acknowledgment: Davide De Martin.; This view
 of 47 Tucanae covers a field of view of 2.4 x 2.8 degrees, and shows the
@@ -17013,6 +17547,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1307aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1307a.jpg
+astropix_ids: eso|eso1307a
 
 credits> ESO; This image from the Wide Field Imager on the MPG/ESO 2.2-metre
 telescope at ESO’s La Silla Observatory in Chile, shows the brigh...
@@ -17036,6 +17571,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1307cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1307c.jpg
+astropix_ids: eso|eso1307c
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin; This
 wide-field view shows the very rich star fields of the Large Sagittarius Star
@@ -17060,6 +17596,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1308bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1308b.jpg
+astropix_ids: eso|eso1308b
 
 credits> Radio: NRAO/AUI/NSF/GBT/VLA/Dyer; This remarkable image was created
 from pictures taken by different telescopes in space and on the ground. It shows
@@ -17084,6 +17621,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1308cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1308c.jpg
+astropix_ids: eso|eso1308c
 
 credits> NASA, ESA, and the Hubble Herita; This image is a composite of
 hydrogen-light observations taken with Hubble's Advanced Camera for Surveys in
@@ -17108,6 +17646,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1309aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1309a.jpg
+astropix_ids: eso|eso1309a
 
 credits> ESO/VVV Survey/D. Minniti. Acknowledgement: Ignacio Toledo; This image
 from ESO’s VISTA telescope captures a celestial landscape of vast, glowing
@@ -17132,6 +17671,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1310fL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1310f.jpg
+astropix_ids: eso|eso1310f
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This picture shows the sky around the
 young star HD 100546 in the southern constellation of Musca (The Fly). It was
@@ -17156,6 +17696,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1315aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1315a.jpg
+astropix_ids: eso|eso1315a
 
 credits> ESO; This image from ESO’s Very Large Telescope at the Paranal
 Observatory in Chile shows NGC 1637, a spiral galaxy located about 35 ...
@@ -17179,6 +17720,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1315bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1315b.jpg
+astropix_ids: eso|eso1315b
 
 credits> ESO; This image from ESO’s Very Large Telescope at the Paranal
 Observatory in Chile shows NGC 1637, a spiral galaxy located about 35 ...
@@ -17202,6 +17744,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1315dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1315d.jpg
+astropix_ids: eso|eso1315d
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin; This
 image shows the sky around the spiral galaxy NGC 1637 in the constellation of
@@ -17226,6 +17769,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1323aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1323a.jpg
+astropix_ids: eso|eso1323a
 
 credits> ESO; This image from the Wide Field Imager on the MPG/ESO 2.2-metre
 telescope at the La Silla Observatory in Chile shows the globul...
@@ -17249,6 +17793,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1324cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1324c.jpg
+astropix_ids: eso|eso1324c
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin; This
 picture shows the sky around the young star HD 95086 in the southern
@@ -17273,6 +17818,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1326aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1326a.jpg
+astropix_ids: eso|eso1326a
 
 credits> ESO; This spectacular group of young stars is the open star cluster NGC
 3766 in the constellation of Centaurus (The Centaur). Very ca...
@@ -17296,6 +17842,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1327bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1327b.jpg
+astropix_ids: eso|eso1327b
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This picture was created from images
 forming part of the Digitized Sky Survey 2. It shows the region of sky around
@@ -17320,6 +17867,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1328cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1328c.jpg
+astropix_ids: eso|eso1328c
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin; This
 picture shows the sky around multiple star Gliese 667. The bright star at the
@@ -17344,6 +17892,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1330bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1330b.jpg
+astropix_ids: eso|eso1330b
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This wide-field view shows the sky
 around a very rare galaxy and quasar pair in the southern constellation of
@@ -17368,6 +17917,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1331aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1331a.jpg
+astropix_ids: eso|eso1331a
 
 credits> ALMA (ESO/NRAJ/NRAO)/NASA/Spitze; Observations of the dark cloud SDC
 335.579-0.292 using the Atacama Large Millimeter/submillimeter array (ALMA) have
@@ -17392,6 +17942,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1331cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1331c.jpg
+astropix_ids: eso|eso1331c
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This wide-field view shows a region
 of sky in the southern constellation of Norma (The Carpenter's Square). At the
@@ -17416,6 +17967,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1336bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1336b.jpg
+astropix_ids: eso|eso1336b
 
 credits> ESO/ALMA (ESO/NAOJ/NRAO)/H. Arce; Astronomers using the Atacama Large
 Millimeter/submillimeter Array (ALMA) have obtained a vivid close-up view of
@@ -17440,6 +17992,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1336cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1336c.jpg
+astropix_ids: eso|eso1336c
 
 credits> ESO/Bo Reipurth; This image from ESO's New Technology Telescope at the
 La Silla Observatory in Chile shows the Herbig-Haro object HH 46/47 as jet...
@@ -17463,6 +18016,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1337cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1337c.jpg
+astropix_ids: eso|eso1337c
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin; This
 wide-field view captures the solar twin HIP 102152 in the constellation of
@@ -17487,6 +18041,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1338aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1338a.jpg
+astropix_ids: eso|eso1338a
 
 credits> ESO; This image shows an example of a bipolar planetary nebula known as
 NGC 6537 taken with the New Technology Telescope at ESO’s La ...
@@ -17510,9 +18065,10 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1339dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1339d.jpg
+astropix_ids: eso|eso1339d
 
-credits> NASA &amp; ESA; This image from the NASA/ESA Hubble Space Telescope
-shows edge-on galaxy NGC 4710. When staring directly at the centre of the ga...
+credits> NASA & ESA; This image from the NASA/ESA Hubble Space Telescope shows
+edge-on galaxy NGC 4710. When staring directly at the centre of the ga...
 
 wip: yes
 ---
@@ -17533,6 +18089,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1340aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1340a.jpg
+astropix_ids: eso|eso1340a
 
 credits> ESO. Acknowledgement: Martin Pug; The glowing jumble of gas clouds
 visible in new image make up a huge stellar nursery nicknamed the Prawn Nebula.
@@ -17557,6 +18114,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1344bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1344b.jpg
+astropix_ids: eso|eso1344b
 
 credits> ALMA (ESO/NAOJ/NRAO)/NASA/ESA/I.; This image from the NASA/ESA Hubble
 Space Telescope shows the distant active galaxy PKG 1830-211. It shows up as an
@@ -17581,6 +18139,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1347aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1347a.jpg
+astropix_ids: eso|eso1347a
 
 credits> ESO/G. Beccari; The Wide Field Imager on the MPG/ESO 2.2-metre
 telescope at ESO’s La Silla Observatory in Chile has captured the best image so
@@ -17605,6 +18164,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1347cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1347c.jpg
+astropix_ids: eso|eso1347c
 
 credits> ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin; This
 wide-field image shows the patch of sky around the star cluster NGC 3572 and its
@@ -17629,6 +18189,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1403aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1403a.jpg
+astropix_ids: eso|eso1403a
 
 credits> ESO/VPHAS+ team; The VLT Survey Telescope (VST) at ESO's Paranal
 Observatory in Chile has captured this richly detailed new image of the Lagoon
@@ -17653,6 +18214,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1406aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1406a.jpg
+astropix_ids: eso|eso1406a
 
 credits> ESO; This new image from the Wide Field Imager on the MPG/ESO 2.2-metre
 telescope at ESO’s La Silla Observatory in Chile, shows the b...
@@ -17676,6 +18238,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1407cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1407c.jpg
+astropix_ids: eso|eso1407c
 
 credits> ESO/MUSE consortium/R. Bacon; This colour composite of the unusual
 polar ring galaxy NGC 4650A was created from data from the new MUSE instrument
@@ -17700,6 +18263,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1409aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1409a.jpg
+astropix_ids: eso|eso1409a
 
 credits> ESO/Digitized Sky Survey 2; HR 5171, the brightest star just below the
 centre of this wide-field image, is a yellow hypergiant, a very rare type of
@@ -17724,6 +18288,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1411cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1411c.jpg
+astropix_ids: eso|eso1411c
 
 credits> ESO/Digitized Sky Survey 2; This picture shows the sky around the pair
 of galaxies NGC 1316 and 1317. It was created from images forming part of the
@@ -17748,6 +18313,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1412cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1412c.jpg
+astropix_ids: eso|eso1412c
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This wide-field view shows the sky
 around the planetary nebula Abell 33, which appears as the ghostly blue circle
@@ -17772,6 +18338,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1413aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1413a.jpg
+astropix_ids: eso|eso1413a
 
 credits> ESO; This new image from the Wide Field Imager (WFI) on the MPG/ESO
 2.2-metre telescope at the La Silla Observatory in Chile reveals ...
@@ -17795,6 +18362,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1415dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1415d.jpg
+astropix_ids: eso|eso1415d
 
 credits> ESO/Digitized Sky Survey 2 Ackno; This wide-field view from the
 Digitized Sky Survey 2 is centred on the star cluster Westerlund 1 in the
@@ -17819,6 +18387,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1420cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1420c.jpg
+astropix_ids: eso|eso1420c
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This wide-field view captures the
 spectacular celestial landscape around the central object Gum 15. Among many
@@ -17843,10 +18412,10 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1421bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1421b.jpg
+astropix_ids: eso|eso1421b
 
-credits> ESA/Hubble amp; NASA; This image from the NASA/ESA Hubble Space
-Telescope shows the irregular dwarf galaxy UGC 5189A. This star-forming galaxy
-was the...
+credits> ESA/Hubble & NASA; This image from the NASA/ESA Hubble Space Telescope
+shows the irregular dwarf galaxy UGC 5189A. This star-forming galaxy was the...
 
 wip: yes
 ---
@@ -17867,6 +18436,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1423cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1423c.jpg
+astropix_ids: eso|eso1423c
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This wide field image shows extensive
 dust and small clumps of star formation in part of the Taurus star formation
@@ -17891,6 +18461,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1423dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1423d.jpg
+astropix_ids: eso|eso1423d
 
 credits> B. Saxton (NRAO/AUI/NSF); K. Sta; This image of the binary system HK
 Tauri combines visible light and infrared data from the NASA/ESA Hubble Space
@@ -17915,6 +18486,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1423eL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1423e.jpg
+astropix_ids: eso|eso1423e
 
 credits> NASA/JPL-Caltech/R. Hurt (IPAC); This picture shows the key velocity
 data taken with ALMA that helped the astronomers determine that the discs in HK
@@ -17939,6 +18511,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1424cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1424c.jpg
+astropix_ids: eso|eso1424c
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This wide field view of the sky
 around the nearby galaxy Messier 33 was assembled from images forming part of
@@ -17963,6 +18536,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1425aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1425a.jpg
+astropix_ids: eso|eso1425a
 
 credits> ESO/G. Beccari; This mosaic of images from the Wide Field Imager on the
 MPG/ESO 2.2-metre telescope at ESO’s La Silla Observatory in Chile shows...
@@ -17986,6 +18560,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1426aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1426a.jpg
+astropix_ids: eso|eso1426a
 
 credits> ESO/NASA/ESA/W. M. Keck Observat; The Atacama Large
 Millimeter/submillimeter Array (ALMA) and many other telescopes on the ground
@@ -18010,6 +18585,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1426cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1426c.jpg
+astropix_ids: eso|eso1426c
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This wide-field view of the sky
 around the gravitationally lensed galaxy merger H-ATLAS J142935.3-002836 was
@@ -18034,6 +18610,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1426dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1426d.jpg
+astropix_ids: eso|eso1426d
 
 credits> ALMA (ESO/NAOJ/NRAO)/NASA/ESA/W.; The Atacama Large
 Millimeter/submillimeter Array (ALMA) and many other telescopes on the ground
@@ -18058,6 +18635,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1427aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1427a.jpg
+astropix_ids: eso|eso1427a
 
 credits> ESO; The Wide Field Imager (WFI) on the MPG/ESO 2.2-metre telescope at
 the La Silla Observatory in Chile captured this view of dark c...
@@ -18081,6 +18659,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1427cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1427c.jpg
+astropix_ids: eso|eso1427c
 
 credits> ESO/Digitized Sky Survey 2; This view of the sky around the dark cloud
 Lupus 4 was created from the images forming part of the Digitized Sky Survey 2.
@@ -18105,6 +18684,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1428cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1428c.jpg
+astropix_ids: eso|eso1428c
 
 credits> ESO and Digitized Sky Survey 2; This visible-light wide-field image of
 the region around the globular star cluster Messier 54 was created from
@@ -18129,6 +18709,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1430aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1430a.jpg
+astropix_ids: eso|eso1430a
 
 credits> ESO; The Wide Field Imager (WFI) on the MPG/ESO 2.2-metre telescope at
 the La Silla Observatory in Chile has taken this beautiful ima...
@@ -18152,6 +18733,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1431bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1431b.jpg
+astropix_ids: eso|eso1431b
 
 credits> ESO; This image shows the APEX view in sub-millimetre light of the
 region around the Spiderweb Galaxy — a protocluster of galaxies in...
@@ -18175,6 +18757,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1431cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1431c.jpg
+astropix_ids: eso|eso1431c
 
 credits> NASA, ESA, G. Miley and R. Overz; This image, taken by the NASA/ESA
 Hubble Space Telescope, shows the full ACS overview of the region around the
@@ -18199,6 +18782,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1431dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1431d.jpg
+astropix_ids: eso|eso1431d
 
 credits> Digitized Sky Survey 2 and ESA/H; This image is a colour composite made
 from exposures from the Digitized Sky Survey 2 (DSS2). The field of view is 2.8
@@ -18223,6 +18807,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1434bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1434b.jpg
+astropix_ids: eso|eso1434b
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This wide-field view shows the sky
 around the young multiple star system GG Tauri, which appears very close to the
@@ -18247,6 +18832,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1436dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1436d.jpg
+astropix_ids: eso|eso1436d
 
 credits> ESA/Hubble and NASA Acknowledgem; This image was taken by the NASA/ESA
 Hubble Space Telescope and shows the tumultuous region around HL Tauri, a young
@@ -18271,6 +18857,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1436gL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1436g.jpg
+astropix_ids: eso|eso1436g
 
 credits> ESO/Digitized Sky Survey 2; This image shows the region in which HL
 Tauri is situated. HL Tauri is part of one of the closest star-forming regions
@@ -18295,6 +18882,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1437aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1437a.jpg
+astropix_ids: eso|eso1437a
 
 credits> ESO/M. Fumagalli; The MUSE instrument on ESO’s Very Large Telescope has
 provided researchers with the best view yet of a spectacular cosmic crash....
@@ -18318,6 +18906,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1437bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1437b.jpg
+astropix_ids: eso|eso1437b
 
 credits> ESO/M. Fumagalli; The MUSE instrument on ESO’s Very Large Telescope has
 provided researchers with the best view yet of a spectacular cosmic crash....
@@ -18341,6 +18930,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1437dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1437d.jpg
+astropix_ids: eso|eso1437d
 
 credits> ESO/Digitized Sky Survey 2; This wide-field view shows the sky around
 the galaxy ESO 137-001, which appears near the bottom-right of this picture.
@@ -18365,6 +18955,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1437eL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1437e.jpg
+astropix_ids: eso|eso1437e
 
 credits> NASA, ESA, CXC; This image combines NASA/ESA Hubble Space Telescope
 observations with data from the Chandra X-ray Observatory. As well as the el...
@@ -18388,6 +18979,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1439aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1439a.jpg
+astropix_ids: eso|eso1439a
 
 credits> ESO/G. Beccari; The MPG/ESO 2.2-metre telescope at ESO’s La Silla
 Observatory in Chile captured this richly colourful view of the bright star
@@ -18412,6 +19004,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1439cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1439c.jpg
+astropix_ids: eso|eso1439c
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This wide-field view of the sky
 around the cluster NGC 3532 was created from photographic material forming part
@@ -18436,6 +19029,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1441aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1441a.jpg
+astropix_ids: eso|eso1441a
 
 credits> ESO; This spectacular image of the star cluster Messier 47 was taken
 using the Wide Field Imager camera, installed on the MPG/ESO 2.2...
@@ -18459,6 +19053,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1441cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1441c.jpg
+astropix_ids: eso|eso1441c
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This wide-field image shows part of
 the constellation of Puppis (The Poop). This region of the sky includes some
@@ -18483,6 +19078,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1501aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1501a.jpg
+astropix_ids: eso|eso1501a
 
 credits> ESO; The Wide Field Imager (WFI) on the MPG/ESO 2.2-metre telescope at
 the La Silla Observatory in Chile snapped this image of the da...
@@ -18506,6 +19102,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1501cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1501c.jpg
+astropix_ids: eso|eso1501c
 
 credits> ESO and Digitized Sky Survey 2; This visible-light wide-field image of
 the region around the dark nebula LDN 483 was created from photographs forming
@@ -18530,6 +19127,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1503cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1503c.jpg
+astropix_ids: eso|eso1503c
 
 credits> ESO and Digitized Sky Survey 2; This wide-field image shows a rich
 region of the sky in the constellation of Puppis (The Poop). At the centre lies
@@ -18554,6 +19152,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1504aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1504a.jpg
+astropix_ids: eso|eso1504a
 
 credits> ESO/VVV consortium/D. Minniti; This small extract from the VISTA VVV
 survey of the central parts of the Milky Way shows the famous Trifid Nebula to
@@ -18578,6 +19177,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1504eL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1504e.jpg
+astropix_ids: eso|eso1504e
 
 credits> ESO/VVV consortium/D. Minniti; This extract from the VISTA VVV survey
 of the central parts of the Milky Way shows the famous Trifid Nebula at the
@@ -18602,6 +19202,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1504fL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1504f.jpg
+astropix_ids: eso|eso1504f
 
 credits> ESO/VVV consortium/D. Minniti; This small extract from the VISTA VVV
 survey of the central parts of the Milky Way shows the famous Trifid Nebula to
@@ -18626,6 +19227,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1504gL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1504g.jpg
+astropix_ids: eso|eso1504g
 
 credits> ESO/Gábor Tóth; This picture shows a familiar visible-light view of the
 Trifid Nebula from a small telescope on the ground....
@@ -18649,6 +19251,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1505bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1505b.jpg
+astropix_ids: eso|eso1505b
 
 credits> ESO; This image of the unusual planetary nebula was obtained using
 ESO’s Very Large Telescope at the Paranal Observatory in Chile. In...
@@ -18672,6 +19275,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1505dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1505d.jpg
+astropix_ids: eso|eso1505d
 
 credits> ESO/Digitized Sky Survey 2; This picture shows the sky around the
 planetary nebula Henize 2-428. The object itself is visible as a small curving
@@ -18696,6 +19300,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1506cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1506c.jpg
+astropix_ids: eso|eso1506c
 
 credits> ESO/Digitized Sky Survey 2; This picture shows the sky around the
 unusual double star V471 Tauri. The object itself is visible as an unremarkable
@@ -18720,6 +19325,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1508cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1508c.jpg
+astropix_ids: eso|eso1508c
 
 credits> NASA; ESA; L. Bradley (Johns Hop; This spectacular view from the
 NASA/ESA Hubble Space Telescope shows the rich galaxy cluster Abell 1689. The
@@ -18744,6 +19350,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1508dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1508d.jpg
+astropix_ids: eso|eso1508d
 
 credits> ESO/Digitized Sky Survey 2; This view from the Digitized Sky Survey 2
 shows the region of sky in the constellation of Virgo (The Virgin) around the
@@ -18768,6 +19375,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1511bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1511b.jpg
+astropix_ids: eso|eso1511b
 
 credits> ESO/T. Kamiński; This picture shows the remains of the new star that
 was seen in the year 1670. It was created from a combination of visible-ligh...
@@ -18791,6 +19399,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1511dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1511d.jpg
+astropix_ids: eso|eso1511d
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This wide-field view shows the sky
 around the location of the historical exploding star Nova Vul 1670. The remains
@@ -18815,6 +19424,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1513bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1513b.jpg
+astropix_ids: eso|eso1513b
 
 credits> ESO/Digitized Sky Survey 2; This image shows the sky around the young
 star MWC 480 in the constellation of Taurus (The Bull). This picture was
@@ -18839,6 +19449,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1514aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1514a.jpg
+astropix_ids: eso|eso1514a
 
 credits> ESO; This image from the NASA/ESA Hubble Space Telescope shows the rich
 galaxy cluster Abell 3827. The strange blue structures surrou...
@@ -18862,10 +19473,11 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1516bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1516b.jpg
+astropix_ids: eso|eso1516b
 
-credits> ESA/Hubble &amp; NASA Image acknowle; This NASA/ESA Hubble Space
-Telescope image shows an elliptical galaxy known as IC 2006. Massive elliptical
-galaxies like these a...
+credits> ESA/Hubble & NASA Image acknowle; This NASA/ESA Hubble Space Telescope
+image shows an elliptical galaxy known as IC 2006. Massive elliptical galaxies
+like these a...
 
 wip: yes
 ---
@@ -18886,6 +19498,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1517cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1517c.jpg
+astropix_ids: eso|eso1517c
 
 credits> ESO/Digitized Sky Survey 2; This image shows the sky around the star 51
 Pegasi in the northern constellation of Pegasus (The Winged Horse). In 1995 the
@@ -18910,6 +19523,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1518bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1518b.jpg
+astropix_ids: eso|eso1518b
 
 credits> ESO; This colour view was created from observations of the Pillars of
 Creation made with the MUSE instrument on ESO’s Very Large Tele...
@@ -18933,6 +19547,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1518eL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1518e.jpg
+astropix_ids: eso|eso1518e
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This image is a colour composite of
 the Eagle Nebula (M 16) made from exposures from the Digitized Sky Survey 2
@@ -18957,6 +19572,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1519aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1519a.jpg
+astropix_ids: eso|eso1519a
 
 credits> ESO/Digitized Sky Survey. Ackno; This huge elliptical galaxy NGC 5128
 (also known as Centaurus A) is the closest such galaxy to the Earth, at a
@@ -18981,6 +19597,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1519cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1519c.jpg
+astropix_ids: eso|eso1519c
 
 credits> ESO,ESA/Hubble, NASA. Digitized ; This huge elliptical galaxy NGC 5128
 (also known as Centaurus A) is the closest such galaxy to the Earth, at a
@@ -19005,6 +19622,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1520cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1520c.jpg
+astropix_ids: eso|eso1520c
 
 credits> ESO/Digitized Sky Survey 2; This wide-field view shows the sky around
 the large but faint planetary nebula known as the Medusa Nebula. The full extent
@@ -19029,6 +19647,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1521aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1521a.jpg
+astropix_ids: eso|eso1521a
 
 credits> ESO; This richly coloured cloud of gas called RCW 34 is a site of star
 formation in the southern constellation of Vela (The Sails). T...
@@ -19052,6 +19671,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1522bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1522b.jpg
+astropix_ids: eso|eso1522b
 
 credits> ALMA (NRAO/ESO/NAOJ)/Mark Swinba; ALMA’s Long Baseline Campaign has
 produced a spectacularly detailed image of a distant galaxy being
@@ -19076,6 +19696,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1522cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1522c.jpg
+astropix_ids: eso|eso1522c
 
 credits> ALMA (NRAO/ESO/NAOJ)/Y. Tamura (; ALMA’s Long Baseline Campaign has
 produced a spectacularly detailed image of a distant galaxy being
@@ -19100,6 +19721,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1522dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1522d.jpg
+astropix_ids: eso|eso1522d
 
 credits> The NASA/ESA Hubble Space Telesc; ALMA’s Long Baseline Campaign has
 produced a spectacularly detailed image of a distant galaxy being
@@ -19124,6 +19746,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1523aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1523a.jpg
+astropix_ids: eso|eso1523a
 
 credits> ESO/P. Kervella; Some of the sharpest images ever made with ESO’s Very
 Large Telescope have for the first time revealed what appears to be an age...
@@ -19147,6 +19770,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1523bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1523b.jpg
+astropix_ids: eso|eso1523b
 
 credits> ESO/P. Kervella; Some of the sharpest images ever made with ESO’s Very
 Large Telescope have for the first time revealed what appears to be an age...
@@ -19170,6 +19794,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1523dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1523d.jpg
+astropix_ids: eso|eso1523d
 
 credits> ESO/Digitized Sky Survey 2; This image shows the region of sky in the
 southern constellation of Puppis surrounding the red giant star L2 Puppis. This
@@ -19194,6 +19819,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1525aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1525a.jpg
+astropix_ids: eso|eso1525a
 
 credits> Chris Mihos (Case Western Reserv; The huge halo around giant elliptical
 galaxy Messier 87 appears on this very deep image. An excess of light in the
@@ -19218,6 +19844,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1525bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1525b.jpg
+astropix_ids: eso|eso1525b
 
 credits> A. Longobardi (Max-Planck-Instit; The red and blue dots mark the
 position of the planetary nebulae whose motion revealed that Messier 87 has
@@ -19242,6 +19869,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1526aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1526a.jpg
+astropix_ids: eso|eso1526a
 
 credits> ESO/G. Beccari; This rich view of an array of colourful stars and gas
 was captured by the Wide Field Imager (WFI) camera, on the MPG/ESO 2.2-met...
@@ -19265,6 +19893,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1526cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1526c.jpg
+astropix_ids: eso|eso1526c
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This wide-field view of the sky
 around the cluster NGC 2367 was created from photographic material forming part
@@ -19289,6 +19918,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1528bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1528b.jpg
+astropix_ids: eso|eso1528b
 
 credits> Kilo-Degree Survey Collaboration; The first results have been released
 from a major new dark matter survey of the southern skies using ESO’s VLT Survey
@@ -19313,6 +19943,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1528cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1528c.jpg
+astropix_ids: eso|eso1528c
 
 credits> Kilo-Degree Survey Collaboration; The first results have been released
 from a major new dark matter survey of the southern skies using ESO’s VLT Survey
@@ -19337,6 +19968,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1530bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1530b.jpg
+astropix_ids: eso|eso1530b
 
 credits> ESO/R. Maiolino; This view is a combination of images from ALMA and the
 Very Large Telescope. The central object is a very distant galaxy, labell...
@@ -19360,6 +19992,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1531aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1531a.jpg
+astropix_ids: eso|eso1531a
 
 credits> ESO; This image from the New Technology Telescope at ESO’s La Silla
 Observatory shows Nova Centauri 2013 in July 2015 as the brightes...
@@ -19383,6 +20016,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1531dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1531d.jpg
+astropix_ids: eso|eso1531d
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This image shows the sky around the
 location of Nova Centauri 2013. The nova itself appears, in its pre-outburst
@@ -19407,6 +20041,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1532cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1532c.jpg
+astropix_ids: eso|eso1532c
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This image shows the sky around the
 location of ESO 378-1. This planetary nebula shows up clearly as a blue disc at
@@ -19431,6 +20066,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1534aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1534a.jpg
+astropix_ids: eso|eso1534a
 
 credits> ESO; This rich view of a tapestry of colourful stars was captured by
 the Wide Field Imager (WFI) camera, on the MPG/ESO 2.2-metre tel...
@@ -19454,6 +20090,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1534cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1534c.jpg
+astropix_ids: eso|eso1534c
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This wide-field view of the sky
 around the cluster IC 4651 was created from photographic material forming part
@@ -19478,6 +20115,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1535aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1535a.jpg
+astropix_ids: eso|eso1535a
 
 credits> ESO; The rich patchwork of gas clouds in this new image make up part of
 a huge stellar nursery nicknamed the Prawn Nebula (also known...
@@ -19501,6 +20139,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1536aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1536a.jpg
+astropix_ids: eso|eso1536a
 
 credits> ESO; The Sculptor Dwarf Galaxy, pictured in a new image from the Wide
 Field Imager camera, installed on the 2.2-metre MPG/ESO telesco...
@@ -19524,6 +20163,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1536cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1536c.jpg
+astropix_ids: eso|eso1536c
 
 credits> ESO/Digitized Sky Survey 2; This image of the sky around the Sculptor
 Dwarf Galaxy was created from pictures from the Digitized Sky Survey 2. The
@@ -19548,6 +20188,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1537aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1537a.jpg
+astropix_ids: eso|eso1537a
 
 credits> ESO; This image of the rose-coloured star forming region Messier 17 was
 captured by the Wide Field Imager on the MPG/ESO 2.2-metre te...
@@ -19571,6 +20212,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1538cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1538c.jpg
+astropix_ids: eso|eso1538c
 
 credits> ESO/Digitized Sky Survey 2; This image shows the sky around the nearby
 young star AU Microscopii. It was created from images forming part of the
@@ -19595,6 +20237,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1539aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1539a.jpg
+astropix_ids: eso|eso1539a
 
 credits> ESO; This image from the Wide Field Imager on the MPG/ESO 2.2-metre
 telescope shows part of the huge cloud of dust and gas known as t...
@@ -19618,6 +20261,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1539cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1539c.jpg
+astropix_ids: eso|eso1539c
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This rich landscape is part of the
 small constellation of Crux (The Southern Cross). The very bright star is Alpha
@@ -19642,6 +20286,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1546aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1546a.jpg
+astropix_ids: eso|eso1546a
 
 credits> ESO; The star VY Canis Majoris is a red hypergiant, one of the largest
 known stars in the Milky Way. It is 30–40 times the mass of th...
@@ -19665,6 +20310,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1546cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1546c.jpg
+astropix_ids: eso|eso1546c
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This wide-field view shows the sky
 around the very brilliant red hypergiant star VY Canis Majoris, one of the
@@ -19689,6 +20335,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1547aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1547a.jpg
+astropix_ids: eso|eso1547a
 
 credits> ESO; The spectacular aftermath of a 360 million year old cosmic
 collision is revealed in great detail in this image from ESO’s Very L...
@@ -19712,6 +20359,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1547cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1547c.jpg
+astropix_ids: eso|eso1547c
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This wide-field view shows the sky
 around the galaxy NGC 5291. This system has interacted with other galaxies and
@@ -19736,6 +20384,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1548bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1548b.jpg
+astropix_ids: eso|eso1548b
 
 credits> ESA/XXL consortium/Canada France; This image superimposes an X-ray
 image of a distant cluster (the blue pixellated image, from ESA's XMM-Newton
@@ -19760,6 +20409,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1548cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1548c.jpg
+astropix_ids: eso|eso1548c
 
 credits> XXL consortium/Canada France Haw; This distant cluster of galaxies was
 discovered by the XXL survey. It was found by its telltale X-ray emission coming
@@ -19784,6 +20434,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1548dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1548d.jpg
+astropix_ids: eso|eso1548d
 
 credits> ESA/XXL consortium/Canada France; This image superimposes an X-ray
 image of a distant cluster (the blue image, from ESA's XMM-Newton satellite) on
@@ -19808,6 +20459,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1603aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1603a.jpg
+astropix_ids: eso|eso1603a
 
 credits> ESO Acknowledgement: VST/Omegaca; This image, captured with the
 OmegaCAM camera on ESO’s VLT Survey Telescope in Chile, shows an unusually clean
@@ -19832,6 +20484,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1603cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1603c.jpg
+astropix_ids: eso|eso1603c
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This wide-field view shows the sky
 around the dwarf galaxy IC 1613 in the constellation of Cetus (The Sea Monster).
@@ -19856,6 +20509,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1604bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1604b.jpg
+astropix_ids: eso|eso1604b
 
 credits> ESO/NASA/ESA; The young star 2MASS J16281370-2431391 lies in the
 spectacular Rho Ophiuchi star formation region, about 400 light-years from Ea...
@@ -19879,6 +20533,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1604dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1604d.jpg
+astropix_ids: eso|eso1604d
 
 credits> ESO/Digitized Sky Survey 2 Ackno; This wide-field view shows a
 spectacular region of dark and bright clouds, forming part of a region of star
@@ -19903,6 +20558,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1605aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1605a.jpg
+astropix_ids: eso|eso1605a
 
 credits> ESO; A newly formed star lights up the surrounding cosmic clouds in
 this image from ESO’s La Silla Observatory in Chile. Dust particl...
@@ -19926,6 +20582,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1605cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1605c.jpg
+astropix_ids: eso|eso1605c
 
 credits> ESO/Digitized Sky Survey 2 Ackno; A newly formed star lights up the
 surrounding cosmic clouds to create the blue reflection nebula IC 2631 at the
@@ -19950,6 +20607,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1606fL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1606f.jpg
+astropix_ids: eso|eso1606f
 
 credits> ESO/ATLASGAL consortium/NASA/GLI; This picture shows the more familiar
 view in visible light, where most of the more distant structures are hidden from
@@ -19974,6 +20632,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1606gL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1606g.jpg
+astropix_ids: eso|eso1606g
 
 credits> ESO/ATLASGAL consortium/NASA/GLI; The top panel shows compact sources
 of submillimetre radiation detected by APEX as part of the ATLASGAL survey,
@@ -19998,6 +20657,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1606hL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1606h.jpg
+astropix_ids: eso|eso1606h
 
 credits> ESO/ATLASGAL consortium/NASA/GLI; This image shows the same region as
 seen in shorter, infrared, wavelengths by the NASA Spitzer Space Telescope.This
@@ -20022,6 +20682,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1606iL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1606i.jpg
+astropix_ids: eso|eso1606i
 
 credits> ESO/ATLASGAL consortium/NASA/GLI; This image shows the same part of sky
 again at even shorter wavelengths, the near-infrared, as seen by ESO’s VISTA
@@ -20046,6 +20707,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1608bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1608b.jpg
+astropix_ids: eso|eso1608b
 
 credits> ESO; The Very Large Telescope Interferometer at ESO’s Paranal
 Observatory in Chile has obtained the sharpest view ever of the dusty d...
@@ -20069,6 +20731,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1608dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1608d.jpg
+astropix_ids: eso|eso1608d
 
 credits> ESO/Digitized Sky Survey 2 Ackno; This colourful image shows the rich
 celestial landscape in the constellation of Vela (The Sails) around the aging
@@ -20093,6 +20756,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1610aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1610a.jpg
+astropix_ids: eso|eso1610a
 
 credits> ESO Acknowledgement: VST/Omegaca; This image, captured by ESO’s
 OmegaCAM on the VLT Survey Telescope, shows a lonely galaxy known as
@@ -20117,6 +20781,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1610cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1610c.jpg
+astropix_ids: eso|eso1610c
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This wide-field view shows the sky
 around the dwarf galaxy WLM in the constellation of Cetus (The Sea Monster).
@@ -20141,6 +20806,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1611aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1611a.jpg
+astropix_ids: eso|eso1611a
 
 credits> S. Andrews (Harvard-Smithsonian ; ALMA’s best image of a protoplanetary
 disc to date. This picture of the nearby young star TW Hydrae reveals the
@@ -20165,6 +20831,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1611cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1611c.jpg
+astropix_ids: eso|eso1611c
 
 credits> S. Andrews (Harvard-Smithsonian ; This ALMA image of the young nearby
 star TW Hydrae has a resolution of 1 AU (Astronomical Unit, the distance from
@@ -20189,6 +20856,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1616aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1616a.jpg
+astropix_ids: eso|eso1616a
 
 credits> ESO; In this image from ESO’s Very Large Telescope (VLT), light from
 blazing blue stars energises the gas left over from the stars’ r...
@@ -20212,6 +20880,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1620cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1620c.jpg
+astropix_ids: eso|eso1620c
 
 credits> ALMA (ESO/NAOJ/NRAO), NAOJ; Light from ionised oxygen detected by ALMA
 is shown in green. Light from ionised hydrogen detected by the Subaru Telescope
@@ -20236,6 +20905,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1624eL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1624e.jpg
+astropix_ids: eso|eso1624e
 
 credits> ESO/Digitized Sky Survey 2; This wide-field image shows a piece of the
 constellation of Centaurus (The Centaur) centred on the position of the triple
@@ -20260,6 +20930,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1624gL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1624g.jpg
+astropix_ids: eso|eso1624g
 
 credits> ESO/K. Wagner et al.; This composite image shows the newly discovered
 exoplanet HD 131399Ab in the triple-star system HD 131399. The image of the
@@ -20284,6 +20955,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1626bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1626b.jpg
+astropix_ids: eso|eso1626b
 
 credits> ALMA (ESO/NAOJ/NRAO)/L. Cieza; This image of the planet-forming disc
 around the young star V883 Orionis was obtained by ALMA in long-baseline mode.
@@ -20308,6 +20980,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1627cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1627c.jpg
+astropix_ids: eso|eso1627c
 
 credits> Digitized Sky Survey 2. Acknowle; This wide-field image from the
 Digitized Sky Survey 2 shows the rich starfields surrounding the exotic binary
@@ -20332,6 +21005,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1628cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1628c.jpg
+astropix_ids: eso|eso1628c
 
 credits> ESO/Digitized Sky Survey 2. Ackn; The small smattering of bright stars
 at the centre of this wide-field view is Messier 18, an open star cluster
@@ -20356,6 +21030,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1630aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1630a.jpg
+astropix_ids: eso|eso1630a
 
 credits> ESO/F. Ferraro; Peering through the thick dust clouds of the galactic
 bulge an international team of astronomers has revealed the unusual mix of...
@@ -20379,6 +21054,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1630bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1630b.jpg
+astropix_ids: eso|eso1630b
 
 credits> ESO/F. Ferraro; Peering through the thick dust clouds of the galactic
 bulge an international team of astronomers has revealed the unusual mix of...
@@ -20402,6 +21078,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1631aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1631a.jpg
+astropix_ids: eso|eso1631a
 
 credits> ESO/CARS survey; This image from the MUSE instrument on ESO’s Very
 Large Telescope shows the active galaxy Markarian 1018, which has a
@@ -20426,6 +21103,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1631bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1631b.jpg
+astropix_ids: eso|eso1631b
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This wide-field image shows the sky
 around the faint active galaxy Markarian 1018. The picture was assembled from
@@ -20450,6 +21128,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1633cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1633c.jpg
+astropix_ids: eso|eso1633c
 
 credits> NASA, ESA, G. Illingworth, D. Ma; This image, called the Hubble eXtreme
 Deep Field (XDF), combines Hubble observations taken over the past decade of a
@@ -20474,6 +21153,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1633dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1633d.jpg
+astropix_ids: eso|eso1633d
 
 credits> B. Saxton (NRAO/AUI/NSF); ALMA (; ALMA surveyed the Hubble Ultra Deep
 Field, uncovering new details of the star-forming history of the Universe. This
@@ -20498,6 +21178,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1633eL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1633e.jpg
+astropix_ids: eso|eso1633e
 
 credits> B. Saxton (NRAO/AUI/NSF); ALMA (; A trove of galaxies, rich in carbon
 monoxide (indicating star-forming potential) were imaged by ALMA (orange) in the
@@ -20522,6 +21203,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1635aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1635a.jpg
+astropix_ids: eso|eso1635a
 
 credits> ESO; This richly detailed view of the star formation region Messier 78,
 in the constellation of Orion (The Hunter), was taken with th...
@@ -20545,6 +21227,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1636aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1636a.jpg
+astropix_ids: eso|eso1636a
 
 credits> ESO/VVV Survey/D. Minniti; This image, captured with the VISTA infrared
 survey telescope, as part of the Variables in the Via Lactea (VVV) ESO public
@@ -20569,6 +21252,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1639aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1639a.jpg
+astropix_ids: eso|eso1639a
 
 credits> ESO/A. McLeod; This image was taken by the MUSE instrument, mounted on
 ESO’s Very Large Telescope and shows the region R44 within the Carina Ne...
@@ -20592,6 +21276,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1639cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1639c.jpg
+astropix_ids: eso|eso1639c
 
 credits> ESO/A. McLeod; This image was taken by the MUSE instrument, mounted on
 ESO’s Very Large Telescope and shows the region R18 within the Carina Ne...
@@ -20615,6 +21300,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1639dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1639d.jpg
+astropix_ids: eso|eso1639d
 
 credits> ESO/A. McLeod; This image was taken by the MUSE instrument, mounted on
 ESO’s Very Large Telescope and shows the region R37 within the Carina Ne...
@@ -20638,6 +21324,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1639eL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1639e.jpg
+astropix_ids: eso|eso1639e
 
 credits> ESO/A. McLeod; This image was taken by the MUSE instrument, mounted on
 ESO’s Very Large Telescope and shows the region R45 within the Carina Ne...
@@ -20661,6 +21348,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1639fL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1639f.jpg
+astropix_ids: eso|eso1639f
 
 credits> ESO/A. McLeod; This pillar is part of the massive star cluster Trumpler
 14, within the Carina Nebula, 7500 light-years away. The image was take...
@@ -20684,6 +21372,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1639gL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1639g.jpg
+astropix_ids: eso|eso1639g
 
 credits> ESO/A. McLeod; The prominent dark patches, in the central region and to
 the right of the image are a so called Bok globule: these are isolated ...
@@ -20707,6 +21396,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1639hL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1639h.jpg
+astropix_ids: eso|eso1639h
 
 credits> ESO/A. McLeod; This craggy fantasy mountaintop enshrouded by wispy
 clouds looks like a bizarre landscape. But it is indeed a pillar of gas and ...
@@ -20730,6 +21420,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1640cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1640c.jpg
+astropix_ids: eso|eso1640c
 
 credits> ESO, C. Ginski et al.; Using the ESO’s SPHERE instrument at the Very
 Large Telescope, a team of astronomer observed the planetary disc surrounding
@@ -20754,6 +21445,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1640dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1640d.jpg
+astropix_ids: eso|eso1640d
 
 credits> ESO, T. Stolker et al.; Using ESO’s SPHERE instrument at the Very Large
 Telescope, a team of astronomers observed the planetary disc surrounding the
@@ -20778,6 +21470,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1641bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1641b.jpg
+astropix_ids: eso|eso1641b
 
 credits> ESO/Digitized Sky Survey 2 Ackno; This wide field image shows the sky
 around the very faint neutron star RX J1856.5-3754 in the southern constellation
@@ -20802,6 +21495,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1641cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1641c.jpg
+astropix_ids: eso|eso1641c
 
 credits> ESO; Colour composite photo of the sky field around the lonely neutron
 star RX J1856.5-3754 and the related cone-shaped nebula. It is...
@@ -20825,6 +21519,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1645aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1645a.jpg
+astropix_ids: eso|eso1645a
 
 credits> ALMA(ESO/NAOJ/NRAO)/NASA/ESA and; The compound view shows a new ALMA
 Band 5 image of the colliding galaxy system Arp 220 (in red) on top of an image
@@ -20849,6 +21544,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1707aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1707a.jpg
+astropix_ids: eso|eso1707a
 
 credits> ESO; This colourful image from ESO’s Very Large Telescope shows NGC
 1055 in the constellation of Cetus (The Sea Monster). This large...
@@ -20872,6 +21568,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1711aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1711a.jpg
+astropix_ids: eso|eso1711a
 
 credits> ALMA (ESO/NAOJ/NRAO), J. Bally/H; Stellar explosions are most often
 associated with supernovae, the spectacular deaths of stars. But new ALMA
@@ -20896,6 +21593,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1711bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1711b.jpg
+astropix_ids: eso|eso1711b
 
 credits> ALMA (ESO/NAOJ/NRAO), J. Bally; Stellar explosions are most often
 associated with supernovae, the spectacular deaths of stars. But new ALMA
@@ -20920,6 +21618,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1720aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1720a.jpg
+astropix_ids: eso|eso1720a
 
 credits> ESO; ESO’s Very Large Telescope (VLT) has captured a magnificent
 face-on view of the barred spiral galaxy Messier 77. The image does ...
@@ -20943,6 +21642,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1720cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1720c.jpg
+astropix_ids: eso|eso1720c
 
 credits> NASA/ESA, Digitized Sky Survey 2; This image from the Digitized Sky
 Survey shows spiral galaxy Messier 77 and its surroundings. Messier 77 appears
@@ -20967,6 +21667,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1724aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1724a.jpg
+astropix_ids: eso|eso1724a
 
 credits> ESO/J. Richard (CRAL); The coupling of the AOF with MUSE gives access
 to both greater sharpness and a wide dynamic range when observing celestial
@@ -20991,6 +21692,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1724aaL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1724aa.jpg
+astropix_ids: eso|eso1724aa
 
 credits> ESO/P. Weilbacher; The image is how NGC 6369 is seen in natural sky
 conditions. This image is part of an image comparison....
@@ -21014,6 +21716,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1724abL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1724ab.jpg
+astropix_ids: eso|eso1724ab
 
 credits> ESO/P. Weilbacher; The image depicts the true power of the Adaptive
 Optics Facility (AOF), revealing much finer details in the faint planetary
@@ -21060,6 +21763,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1724caL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1724ca.jpg
+astropix_ids: eso|eso1724c,eso|eso1724ca
 
 credits> ESO/P. Weilbacher; The planetary nebula NGC 6563 resides in a crowded
 starry region of the sky. In natural sky conditions many of these stars remai...
@@ -21083,6 +21787,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1724cbL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1724cb.jpg
+astropix_ids: eso|eso1724cb
 
 credits> ESO/P. Weilbacher; The planetary nebula NGC 6563 resides in a crowded
 starry region of the sky. In natural sky conditions many of these stars remai...
@@ -21106,6 +21811,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1724hL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1724h.jpg
+astropix_ids: eso|eso1724h
 
 credits> ESO/P. Weilbacher (AIP); Known as the Little Ghost Nebula, NGC 6369 is
 a planetary nebula in the constellation Ophiuchus, the serpent-bearer. The
@@ -21130,6 +21836,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1724iL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1724i.jpg
+astropix_ids: eso|eso1724i
 
 credits> ESO/P. Weilbacher (AIP); ESO 338-4 is a starburst galaxy located in
 Sagittarius, the Archer. It is currently in the process of merging, with several
@@ -21154,6 +21861,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1725bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1725b.jpg
+astropix_ids: eso|eso1725b
 
 credits> ESO/GASP collaboration; Observations of “Jellyfish galaxies” with ESO’s
 Very Large Telescope have revealed a previously unknown way to fuel
@@ -21178,6 +21886,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1725dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1725d.jpg
+astropix_ids: eso|eso1725d
 
 credits> ESO/GASP collaboration; Observations of “Jellyfish galaxies” with ESO’s
 Very Large Telescope have revealed a previously unknown way to fuel
@@ -21202,6 +21911,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1726aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1726a.jpg
+astropix_ids: eso|eso1726a
 
 credits> ESO/K. Ohnaka; Using ESO’s Very Large Telescope Interferometer
 astronomers have constructed this remarkable image of the red supergiant star
@@ -21226,6 +21936,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1727bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1727b.jpg
+astropix_ids: eso|eso1727b
 
 credits> ALMA (ESO/NAOJ/NRAO)/E. Falgaron; This ALMA image shows the Cosmic
 Eyelash, a remote starburst galaxy that appears double and brightened by
@@ -21250,6 +21961,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1730aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1730a.jpg
+astropix_ids: eso|eso1730a
 
 credits> ALMA (ESO/NAOJ/NRAO)/F. Kerschba; This ALMA image reveals much finer
 structure in the U Antliae shell than has previously been possible. Around 2700
@@ -21274,6 +21986,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1730cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1730c.jpg
+astropix_ids: eso|eso1730c
 
 credits> ESO, Digitized Sky Survey 2. Ack; This image from the Digitized Sky
 Survey 2 shows the very red carbon star U Antliae and its surroundings....
@@ -21297,6 +22010,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1730dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1730d.jpg
+astropix_ids: eso|eso1730d
 
 credits> ALMA (ESO/NAOJ/NRAO), F. Kerschb; This image was created from ALMA data
 on the unusual red carbon star U Antliae and its surrounding shell of material.
@@ -21321,6 +22035,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1731aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1731a.jpg
+astropix_ids: eso|eso1731a
 
 credits> ESO/J. Walsh; The spectacular planetary nebula NGC 7009, or the Saturn
 Nebula, emerges from the darkness like a series of oddly-shaped bubbles...
@@ -21344,6 +22059,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1731eL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1731e.jpg
+astropix_ids: eso|eso1731e
 
 credits> ESO, Digitized Sky Survey 2. Ack; This image from the Digitized Sky
 Survey 2 shows the sky around the bright planetary nebula NGC 7009, often called
@@ -21368,6 +22084,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1733bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1733b.jpg
+astropix_ids: eso|eso1733b
 
 credits> ESO/A.J. Levan, N.R. Tanvir; This image from the VIMOS instrument on
 ESO’s Very Large Telescope at the Paranal Observatory in Chile shows the galaxy
@@ -21392,6 +22109,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1733dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1733d.jpg
+astropix_ids: eso|eso1733d
 
 credits> ESO/J.D. Lyman, A.J. Levan, N.R.; This image from the MUSE instrument
 on ESO’s Very Large Telescope at the Paranal Observatory in Chile shows the
@@ -21416,8 +22134,9 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1733hL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1733h.jpg
+astropix_ids: eso|eso1733h
 
-credits> ESO/S. Smartt &amp; T.-W. Chen; Image obtained by ESO's Gamma-ray Burst
+credits> ESO/S. Smartt & T.-W. Chen; Image obtained by ESO's Gamma-ray Burst
 Optical/Near-infrared Detector (GROND) attached to the MPG/ESO 2.2-metre
 telescope at La...
 
@@ -21440,6 +22159,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1733iL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1733i.jpg
+astropix_ids: eso|eso1733i
 
 credits> ESO and Digitized Sky Survey 2; This wide-field image generated from
 the Digitized Sky Survey 2 shows the sky around the galaxy NGC 4993. This galaxy
@@ -21464,6 +22184,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1736bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1736b.jpg
+astropix_ids: eso|eso1736b
 
 credits> Digitized Sky Survey 2. Acknowle; This image shows the sky around the
 red dwarf star Ross 128 in the constellation of Virgo (The Virgin). It was
@@ -21488,6 +22209,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1738aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1738a.jpg
+astropix_ids: eso|eso1738a
 
 credits> ESO/MUSE HUDF collaboration; This colour image shows the Hubble Ultra
 Deep Field region, a tiny but much-studied region in the constellation of
@@ -21512,6 +22234,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1738cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1738c.jpg
+astropix_ids: eso|eso1738c
 
 credits> ESO/MUSE HUDF team.; This compound image shows the Hubble Ultra Deep
 Field region and highlights in blue the glowing haloes of gas around many
@@ -21536,6 +22259,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1741aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1741a.jpg
+astropix_ids: eso|eso1741a
 
 credits> ESO; Astronomers using ESO’s Very Large Telescope have directly
 observed granulation patterns on the surface of a star outside the So...
@@ -21559,6 +22283,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1741bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1741b.jpg
+astropix_ids: eso|eso1741b
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This colourful image shows the sky
 around the bright pair of stars π1 Gruis (centre-right, very red) and π2 Gruis
@@ -21583,6 +22308,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1802eL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1802e.jpg
+astropix_ids: eso|eso1802e
 
 credits> ESA/NASA; This image from the NASA/ESA Hubble Space Telescope shows the
 central region of the rich globular star cluster NGC 3201 in the s...
@@ -21606,6 +22332,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1809aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1809a.jpg
+astropix_ids: eso|eso1809a
 
 credits> ESO/H. Drass/ALMA (ESO/NAOJ/NRAO; This spectacular and unusual image
 shows part of the famous Orion Nebula, a star formation region lying about 1350
@@ -21630,6 +22357,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1810aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1810a.jpg
+astropix_ids: eso|eso1810a
 
 credits> ESO/NASA, ESA and the Hubble Her; This new picture created from images
 from telescopes on the ground and in space tells the story of the hunt for an
@@ -21654,6 +22382,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1810bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1810b.jpg
+astropix_ids: eso|eso1810b
 
 credits> NASA, ESA and the Hubble Heritag; This picture from the NASA/ESA Hubble
 Space Telescope sets the scene for the story of the hunt for an elusive missing
@@ -21678,6 +22407,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1810cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1810c.jpg
+astropix_ids: eso|eso1810c
 
 credits> ESO/F. Vogt et al.; This new picture from the MUSE instrument on ESO’s
 Very Large Telescope in Chile shows how an elusive missing object was found a...
@@ -21701,6 +22431,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1810dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1810d.jpg
+astropix_ids: eso|eso1810d
 
 credits> ESO/NASA; This archival image from the NASA Chandra X-Ray Observatory
 shows how an elusive missing object was found amid a complex tangle ...
@@ -21724,6 +22455,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1815bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1815b.jpg
+astropix_ids: eso|eso1815b
 
 credits> NASA, ESA, S. Rodney (John Hopki; This image shows the huge galaxy
 cluster MACS J1149.5+223, whose light took over 5 billion years to reach us. The
@@ -21748,6 +22480,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1817bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1817b.jpg
+astropix_ids: eso|eso1817b
 
 credits> ESO; This gigantic star-forming region in the Milky Way’s neighbour
 galaxy the Large Magellanic Cloud is the birthplace of an astonis...
@@ -21771,6 +22504,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1818aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1818a.jpg
+astropix_ids: eso|eso1818a
 
 credits> ESO, ALMA (ESO/NAOJ/NRAO); Pinte; ALMA has uncovered convincing
 evidence that three young planets are in orbit around the infant star HD 163296.
@@ -21795,6 +22529,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1818dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1818d.jpg
+astropix_ids: eso|eso1818d
 
 credits> ESO/Digitized Sky Survey 2 Ackno; This wide-field image shows the
 surroundings of the young star HD 163296 in the rich constellation of
@@ -21819,6 +22554,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1821aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1821a.jpg
+astropix_ids: eso|eso1821a
 
 credits> ESO/A. Müller et al.; This spectacular image from the SPHERE instrument
 on ESO's Very Large Telescope is the first clear image of a planet caught in
@@ -21843,6 +22579,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1821bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1821b.jpg
+astropix_ids: eso|eso1821b
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This colourful image shows the sky
 around the faint orange dwarf star PDS 70 (in the middle of the image). The
@@ -21867,6 +22604,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1823aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1823a.jpg
+astropix_ids: eso|eso1823a
 
 credits> ESO/K. Muzic; New observations with ESO’s Very Large Telescope show the
 star cluster RCW 38 in all its glory. This image was taken during test...
@@ -21890,6 +22628,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1826aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1826a.jpg
+astropix_ids: eso|eso1826a
 
 credits> ALMA (ESO/NAOJ/NRAO), T. Kamińs; Composite image of CK Vulpeculae, the
 remains of a double-star collision. This impact launched radioactive molecules
@@ -21914,6 +22653,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1827aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1827a.jpg
+astropix_ids: eso|eso1827a
 
 credits> ESO/Spavone et al.; This deep image of the area of sky around the
 elliptical galaxy NGC 5018 offers a spectacular view of its tenuous streams of
@@ -21938,6 +22678,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1827eL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1827e.jpg
+astropix_ids: eso|eso1827e
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This image is a colour composite made
 from exposures from the Digitized Sky Survey 2 (DSS2)....
@@ -21961,6 +22702,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1828aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1828a.jpg
+astropix_ids: eso|eso1828a
 
 credits> ESO/J. Emerson/M. Irwin/J. Lewis; This spectacular image of the Carina
 nebula reveals the dynamic cloud of interstellar matter and thinly spread gas
@@ -21985,6 +22727,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1828bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1828b.jpg
+astropix_ids: eso|eso1828b
 
 credits> ESO/J. Emerson/M. Irwin/J. Lewis; This wider coverage area reveals even
 more stars from the crowded neighbourhood surrounding the Carina nebula.
@@ -22009,6 +22752,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1828cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1828c.jpg
+astropix_ids: eso|eso1828c
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This image is a colour composite made
 from exposures from the Digitized Sky Survey 2 (DSS2). The field of view is
@@ -22033,6 +22777,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1830aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1830a.jpg
+astropix_ids: eso|eso1830a
 
 credits> ESO; FORS2, an instrument mounted on ESO’s Very Large Telescope
 captured the spiral galaxy NGC 3981 in all its glory. The image, capt...
@@ -22056,6 +22801,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1830bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1830b.jpg
+astropix_ids: eso|eso1830b
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This image is a colour composite made
 from exposures from the Digitized Sky Survey 2 (DSS2). The field of view is
@@ -22080,10 +22826,11 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1832aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1832a.jpg
+astropix_ids: eso|eso1832a
 
-credits> ESA/Hubble &amp; NASA, ESO/ Lutz Wis; Deep observations made with the
-MUSE spectrograph on ESO’s Very Large Telescope have uncovered vast cosmic
-reservoirs of atomic ...
+credits> ESA/Hubble & NASA, ESO/ Lutz Wis; Deep observations made with the MUSE
+spectrograph on ESO’s Very Large Telescope have uncovered vast cosmic reservoirs
+of atomic ...
 
 wip: yes
 ---
@@ -22104,6 +22851,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1832bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1832b.jpg
+astropix_ids: eso|eso1832b
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This image is a colour composite made
 from exposures from the Digitized Sky Survey 2 (DSS2). The field of view is
@@ -22128,6 +22876,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1834aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1834a.jpg
+astropix_ids: eso|eso1834a
 
 credits> ESO; This vivid picture of an active star forming region — NGC 2467,
 otherwise known as the Skull and Crossbones nebula — is as sinis...
@@ -22151,6 +22900,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1836bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1836b.jpg
+astropix_ids: eso|eso1836b
 
 credits> ESO/Digitized Sky Survey 2. Ackn; Observations by ALMA and data from
 the MUSE spectrograph on ESO’s VLT have revealed a colossal fountain of
@@ -22175,6 +22925,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1837dL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1837d.jpg
+astropix_ids: eso|eso1837d
 
 credits> ESO/Digitized Sky Survey 2 Ackno; This wide-field image shows the
 surroundings of the red dwarf known as Barnard’s Star in the constellation of
@@ -22199,6 +22950,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1838aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1838a.jpg
+astropix_ids: eso|eso1838a
 
 credits> ESO/Callingham et al.; The VISIR instrument on ESO’s VLT captured this
 stunning image of a newly-discovered massive binary star system. Nicknamed Apep
@@ -22223,6 +22975,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1838cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1838c.jpg
+astropix_ids: eso|eso1838c
 
 credits> ESO/Digitized Sky Survey 2. Ackn; The image is a colour composite made
 from exposures from the Digitized Sky Survey 2 (DSS2), and shows the region
@@ -22247,6 +23000,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1839bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1839b.jpg
+astropix_ids: eso|eso1839b
 
 credits> SPECULOOS Team/E. Jehin/ESO; This first light image from the Europa
 telescope at the SPECULOOS Southern Observatory (SSO) shows the heart of the
@@ -22271,6 +23025,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1839hL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1839h.jpg
+astropix_ids: eso|eso1839h
 
 credits> SPECULOOS Team/E. Jehin/ESO; This first light image from the Europa
 telescope at the SPECULOOS Southern Observatory (SSO) shows M83, the Southern
@@ -22295,6 +23050,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1839iL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1839i.jpg
+astropix_ids: eso|eso1839i
 
 credits> SPECULOOS Team/E. Jehin/ESO; This first light image from the Callisto
 telescope at the SPECULOOS Southern Observatory (SSO) shows the famous Horsehead
@@ -22319,6 +23075,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1840aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1840a.jpg
+astropix_ids: eso|eso1840a
 
 credits> ESO/Schmid et al.; While testing a new subsystem on the SPHERE
 planet-hunting instrument on ESO’s Very Large telescope, astronomers were able
@@ -22343,6 +23100,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1902aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1902a.jpg
+astropix_ids: eso|eso1902a
 
 credits> ESO; The faint, ephemeral glow emanating from the planetary nebula ESO
 577-24 persists for only a short time — around 10,000 years, ...
@@ -22366,6 +23124,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1903aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1903a.jpg
+astropix_ids: eso|eso1903a
 
 credits> ESO, A McLeod et al.; This dazzling region of newly-forming stars in
 the Large Magellanic Cloud (LMC) was captured by the Multi Unit Spectroscopic
@@ -22390,6 +23149,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1903bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1903b.jpg
+astropix_ids: eso|eso1903b
 
 credits> ESO, A McLeod et al.; Deep within the glowing cloud of the HII region
 LHA 120-N 180B, MUSE has spotted a jet emitted by a fledgling star — a massive
@@ -22414,6 +23174,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1903cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1903c.jpg
+astropix_ids: eso|eso1903c
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This dazzling region of newly-forming
 stars in the Large Magellanic Cloud (LMC) was captured by the Multi Unit
@@ -22438,6 +23199,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1904aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1904a.jpg
+astropix_ids: eso|eso1904a
 
 credits> ESO; Hidden in one of the darkest corners of the Orion constellation,
 this Cosmic Bat is spreading its hazy wings through interstella...
@@ -22461,6 +23223,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1905cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1905c.jpg
+astropix_ids: eso|eso1905c
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This wide-field image shows the
 surroundings of the young star HR8799 in the constellation of Pegasus. This
@@ -22485,6 +23248,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1907bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1907b.jpg
+astropix_ids: eso|eso1907b
 
 credits> ESO; Messier 87 (M87) is an enormous elliptical galaxy located about 55
 million light years from Earth, visible in the constellation ...
@@ -22508,6 +23272,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1908aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1908a.jpg
+astropix_ids: eso|eso1908a
 
 credits> ESO; This image, a composite of several observations captured by ESO’s
 VLT Survey Telescope (VST), shows the space observatory Gaia a...
@@ -22645,6 +23410,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso9856bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso9856b.jpg
+astropix_ids: eso|eso9856b
 
 credits> ESO; This image displays a spectacular three-colour composite image of
 RCW38, obtained through three near-infrared filters. This is a...
@@ -22691,6 +23457,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso9920uL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso9920u.jpg
+astropix_ids: eso|eso9920u
 
 credits> ESO; Colour composite image of the galaxy cluster 1ES 0657-558, based
 on data taken in the B (blue; exposure 900 sec), V (green; 600 ...
@@ -22759,6 +23526,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-etamosaicnm2L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-etamosaicnm2.jpg
+astropix_ids: eso|eta,eso|etamosaicnm2
 
 credits> ESO/IDA/Danish 1.5 m/R.Gendler, ; The Carina Nebula is a large bright
 nebula that surrounds several clusters of stars. It contains two of the most
@@ -22783,6 +23551,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-galactic_center_hiL{1}X{2}Y{
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-galactic_center_hi.jpg
+astropix_ids: eso|galactic_center_hi
 
 credits> NRAO/AUI/NSF; The view of the centre of our galaxy with a closer view
 of the object known as Sagittarius A*, the bright radio source that corr...
@@ -22806,6 +23575,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-n70L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-n70.jpg
+astropix_ids: eso|n70
 
 credits> ESO; The N70 superbubble nebula in the Large Magellanic Cloud (LMC),
 imaged with the ESO Schmidt Telescope on La Silla....
@@ -22829,6 +23599,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-naco_ccL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-naco_cc.jpg
+astropix_ids: eso|naco_cc
 
 credits> ESO; A raw image straight from the NACO instrument on the VLT....
 
@@ -22851,6 +23622,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc104-47-schmidtL{1}X{2}Y{3
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-ngc104-47-schmidt.jpg
+astropix_ids: eso|ngc104-47-schmidt
 
 credits> ESO; A colour-corrected image of the the second largest and second
 brightest globular cluster, or tight grouping of stars, seen in Ea...
@@ -22874,6 +23646,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc1068-sercL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-ngc1068-serc.jpg
+astropix_ids: eso|ngc1068-serc
 
 credits> ESO; A survey of the sky captured on film by ESO's 1-m Schmidt
 Telescope. In the left-centre, the galaxy NGC 1068 is visible, among o...
@@ -22897,6 +23670,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc1232bL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-ngc1232b.jpg
+astropix_ids: eso|ngc1232b
 
 credits> ESO/IDA/Danish 1.5 m/R.Gendler and A. Hornstrup.; The striking, large
 spiral galaxy NGC 1232, and its distorted companion shaped like the greek letter
@@ -22921,6 +23695,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc1448-potwL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-ngc1448-potw.jpg
+astropix_ids: eso|ngc1448-potw
 
 credits> ESO; Portrayed in this beautiful image is the spiral galaxy NGC 1448,
 with a prominent disc of young and very bright stars surroundin...
@@ -22944,6 +23719,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc1532L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-ngc1532.jpg
+astropix_ids: eso|ngc1532
 
 credits> ESO/IDA/Danish 1.5 m/R.Gendler and J.-E. Ovaldsen; The pair of galaxies
 NGC 1531/2, engaged in a spirited waltz, is located about 70 million light-years
@@ -22968,6 +23744,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc2060-ccL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-ngc2060-cc.jpg
+astropix_ids: eso|ngc2060-cc
 
 credits> ESO; Located in the direction of the constellation Dorado in the Large
 Magellanic Cloud, the resplendent object known as NGC 2060 is ...
@@ -22991,6 +23768,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc2207L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-ngc2207.jpg
+astropix_ids: eso|ngc2207
 
 credits> ESO; In this image, two spiral galaxies, similar in looks to the Milky
 Way, are participating in a cosmic ballet, which, in a few bil...
@@ -23014,6 +23792,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc2280-potwL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-ngc2280-potw.jpg
+astropix_ids: eso|ngc2280-potw
 
 credits> ESO; This new image of the galaxy NGC 2280 shows the extent of its
 massive spiral arms that reach far into the surrounding space. The...
@@ -23037,6 +23816,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc2442L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-ngc2442.jpg
+astropix_ids: eso|ngc2442
 
 credits> ESO/IDA/Danish 1.5 m/R. Gendler, J.-E. Ovaldsen, C. C. Thöne and C.
 Féron; The distorted galaxy NGC 2442, also known as the Meathook Galaxy, is
@@ -23061,6 +23841,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc3132-ccL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-ngc3132-cc.jpg
+astropix_ids: eso|ngc3132-cc
 
 credits> ESO; NGC 3132, also referred to as the Eight-Burst or the Southern Ring
 Nebula, glows at a distance of about 2,000 light years in the...
@@ -23084,6 +23865,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc3201L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-ngc3201.jpg
+astropix_ids: eso|ngc3201
 
 credits> ESO; Colour-composite image of the globular cluster NGC 3201, obtained
 with the WFI instrument on the ESO/MPG 2.2-m telescope at La S...
@@ -23107,6 +23889,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc6781-potwL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-ngc6781-potw.jpg
+astropix_ids: eso|ngc6781-potw
 
 credits> ESO; Stars such as our Sun do not contain enough mass to finish their
 lives in the glorious explosions known as supernovae. However, ...
@@ -23152,6 +23935,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc_2997L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-ngc_2997.jpg
+astropix_ids: eso|ngc_2997
 
 credits> ESO; This is one of the first CCD images taken at ESO. It was obtained
 in the V filter, with the CCD camera at the 1.5-metre Danish T...
@@ -23175,6 +23959,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc_6188_paranalL{1}X{2}Y{3}
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-ngc_6188_paranal.jpg
+astropix_ids: eso|ngc_6188_paranal
 
 credits> ESO/J. Pérez; Impressive image of the NGC 6188 nebula, located some
 4000 light-years away, in the southern constellation of Ara (the Altar). T...
@@ -23198,6 +23983,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-omega-nebulaL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-omega-nebula.jpg
+astropix_ids: eso|omega-nebula
 
 credits> ESO; The Omega Nebula, also known as the Swan Nebula, Messier 17 (M17),
 or NGC 6618, as imaged by the ESO 3.6-metre telescope on La S...
@@ -23221,6 +24007,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-opo0708aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-opo0708a.jpg
+astropix_ids: eso|opo0708a
 
 credits> NASA, ESA, and The Hubble Herita; This image from the NASA/ESA Hubble
 Space Telescope shows the diverse collection of galaxies in the cluster Abell
@@ -23245,6 +24032,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-orion-hawk-iL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-orion-hawk-i.jpg
+astropix_ids: eso|orion-hawk-i
 
 credits> ESO; The central region of the Orion Nebula (M42, NGC 1976) as seen in
 the near-infrared by the High Acuity Wide field K-band Imager ...
@@ -23268,6 +24056,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-potw1007aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-potw1007a.jpg
+astropix_ids: eso|potw1007a
 
 credits> ESO/IDA/Danish 1.5 m/R. Gendler and C. Thöne; Portrayed in this image
 is the spiral galaxy NGC 4945, a close neighbour of the Milky Way. Belonging to
@@ -23292,6 +24081,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-potw1017aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-potw1017a.jpg
+astropix_ids: eso|potw1017a
 
 credits> Credit: ESO/IDA/Danish 1.5 m/ R. Gendler, U. G. Jørgensen, J.
 Skottfelt, K. Harpsøe; NGC 253, also known as the Sculptor Galaxy, is the
@@ -23316,6 +24106,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-potw1044aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-potw1044a.jpg
+astropix_ids: eso|potw1044a
 
 credits> ESO/R. Chini; Astronomers using data from ESO's Very Large Telescope
 (VLT), at the Paranal Observatory in Chile, have made an impressive compo...
@@ -23339,6 +24130,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-potw1447aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-potw1447a.jpg
+astropix_ids: eso|potw1447a
 
 credits> ESO/S. Ramstedt (Uppsala Univers; Studying red giant stars tells
 astronomers about the future of the Sun — and about how previous generations of
@@ -23363,6 +24155,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-raqr-nttL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-raqr-ntt.jpg
+astropix_ids: eso|raqr-ntt
 
 credits> Romano Corradi; R Aquarii observed using the New Technology Telescope
 in 1991. The white vertical line in the middle is caused by light from the...
@@ -23386,6 +24179,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-sn1992c_aL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-sn1992c_a.jpg
+astropix_ids: eso|sn1992c_a
 
 credits> ESO; This photo shows the newly discovered Supernova 1992C in the
 barred spiral galaxy NGC 3367. The supernova is the bright, star-li...
@@ -23409,6 +24203,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-sombreroL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-sombrero.jpg
+astropix_ids: eso|sombrero
 
 credits> ESO/IDA/Danish 1.5 m/R. Gendler and J.-E. Ovaldsen; One of most famous
 spiral galaxies is Messier 104, widely known as the "Sombrero" (the Mexican hat)
@@ -23433,6 +24228,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-tarantulaL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-tarantula.jpg
+astropix_ids: eso|tarantula
 
 credits> ESO/IDA/Danish 1.5 m/R. Gendler, C. C. Thöne, C. Féron, and J.-E.
 Ovaldsen; Located inside the Large Magellanic Cloud (LMC) – one of our closest
@@ -23481,6 +24277,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-vela-snr-schmidtourcompL{1}X
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-vela-snr-schmidtourcomp.jpg
+astropix_ids: eso|vela-snr-schmidtourcomp
 
 credits> ESO; A so-called Supernova Remnant (SNR) in the Vela constellation,
 captured by ESO's 1 m Schmidt Telescope at La Silla in Chile. The...
@@ -23504,6 +24301,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-wr124L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-wr124.jpg
+astropix_ids: eso|wr124
 
 credits> ESO; M1-67 is the youngest wind-nebula around a Wolf-Rayet star, called
 WR124, in our Galaxy. These Wolf-Rayet stars start their live...

--- a/cxprep/eso.txt
+++ b/cxprep/eso.txt
@@ -21741,6 +21741,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1724cL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1724c.jpg
+astropix_ids: eso|eso1724c
 
 credits>
 
@@ -21763,7 +21764,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1724caL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1724ca.jpg
-astropix_ids: eso|eso1724c,eso|eso1724ca
+astropix_ids: eso|eso1724ca
 
 credits> ESO/P. Weilbacher; The planetary nebula NGC 6563 resides in a crowded
 starry region of the sky. In natural sky conditions many of these stars remai...
@@ -23504,6 +23505,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-etaL{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eta.jpg
+astropix_ids: eso|eta
 
 credits>
 
@@ -23526,7 +23528,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/ESO-etamosaicnm2L{1}X{2}Y{3}.png
 copyright: Copyright European Southern Observatory
 license_id: CC-BY-4.0
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-etamosaicnm2.jpg
-astropix_ids: eso|eta,eso|etamosaicnm2
+astropix_ids: eso|etamosaicnm2
 
 credits> ESO/IDA/Danish 1.5 m/R.Gendler, ; The Carina Nebula is a large bright
 nebula that surrounds several clusters of stars. It contains two of the most

--- a/cxprep/hubble.txt
+++ b/cxprep/hubble.txt
@@ -4,6 +4,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001321{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=314237335
+astropix_ids: stsci|2005-37a
 
 credits> NASA, ESA, J. Hester and A. Loll (Arizona State University)
 
@@ -35,6 +36,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001331{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1538464660
+astropix_ids: stsci|2000-07a
 
 credits> NASA, Andrew Fruchter and the ERO Team [Sylvia Baggett (STScI), Richard
 Hook (ST-ECF), Zoltan Levay (STScI)]
@@ -67,6 +69,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002001{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=238365128
+astropix_ids: stsci|2002-23a
 
 credits> NASA and The Hubble Heritage Team (STScI/AURA); acknowledgment: R.
 Knacke (Penn State Erie)
@@ -89,6 +92,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002011{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=208805864
+astropix_ids: stsci|2007-09a
 
 credits> NASA, ESA, and K. Noll (STScI); acknowledgment: The Hubble Heritage
 Team (STScI/AURA)
@@ -111,6 +115,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002021{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1933237991
+astropix_ids: stsci|1997-07a
 
 credits> Massimo Stiavelli (STScI), and NASA
 
@@ -132,6 +137,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002031{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=366937003
+astropix_ids: stsci|1998-14c
 
 credits> E.J. Schreier (STScI), and NASA
 
@@ -153,6 +159,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002101{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1467229686
+astropix_ids: stsci|2004-31b
 
 credits> NASA, ESA, and The Hubble Heritage Team (STScI/AURA); acknowledgment :
 Y. Momany (University of Padua)
@@ -175,6 +182,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002111{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=343790965
+astropix_ids: stsci|1998-12b
 
 credits> Jim Flood (Amateur Astronomers Inc., Sperry Observatory), Max Mutchler
 (STScI)
@@ -197,6 +205,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002121{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1289590105
+astropix_ids: stsci|2000-12a
 
 credits> NASA, The Hubble Heritage Team (STScI/AURA)
 
@@ -239,6 +248,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002201{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1348024781
+astropix_ids: stsci|1994-52f
 
 credits> Mark Dickinson (STScI) and NASA
 
@@ -261,6 +271,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002211{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=599717539
+astropix_ids: stsci|2006-13a
 
 credits> NASA, ESA, and The Hubble Heritage Team (STScI/AURA); acknowledgment :
 P. McCullough (STScI)
@@ -283,6 +294,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002221{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1834034835
+astropix_ids: stsci|1997-34f
 
 credits> Brad Whitmore (STScI) and NASA
 
@@ -304,6 +316,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002231{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1575960859
+astropix_ids: stsci|2002-15d
 
 credits> NASA and The Hubble Heritage Team (STScI/AURA)
 
@@ -325,6 +338,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002301{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=833381153
+astropix_ids: stsci|2005-28b,stsci|2007-31b
 
 credits> NASA, ESA, and S. Beckwith (STScI) and the HUDF Team
 
@@ -346,6 +360,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002331{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=821568397
+astropix_ids: stsci|2003-10e
 
 credits> NASA, ESA and H.E. Bond (STScI)
 
@@ -367,6 +382,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003001{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=731739133
+astropix_ids: stsci|2005-25a
 
 credits> NASA, ESA and The Hubble Heritage Team (STScI/AURA); acknowledgment :
 J. Biretta (STScI)
@@ -389,6 +405,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003011{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1476420562
+astropix_ids: stsci|2006-45d
 
 credits> NASA, ESA, G. Miley and R. Overzier (Leiden Observatory), and the ACS
 Science Team
@@ -411,6 +428,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003021{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=287406697
+astropix_ids: stsci|2006-30a
 
 credits> NASA, ESA, and the Hubble Heritage (STScI/AURA)-ESA/Hubble
 Collaboration Acknowledgment: R. Fesen (Dartmouth College) and J. Long
@@ -434,6 +452,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003031{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1057672650
+astropix_ids: stsci|2002-19a
 
 credits> NASA and The Hubble Heritage Team (STScI/AURA); acknowledgment : A.
 Gomez (Cerro Tololo Inter-American Observatory)
@@ -456,6 +475,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003101{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1959271740
+astropix_ids: stsci|2002-13a
 
 credits> NASA, The NICMOS Group (STScI, ESA) and The NICMOS Science Team (Univ.
 of Arizona)
@@ -478,6 +498,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003111{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=820114430
+astropix_ids: stsci|2005-28c
 
 credits> NASA, ESA and B. Mobasher (STScI/ESA)
 
@@ -499,6 +520,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003121{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=39734206
+astropix_ids: stsci|2006-14a
 
 credits> NASA, ESA, and The Hubble Heritage Team (STScI/AURA); acknowledgment :
 J. Gallagher (University of Wisconsin), M. Mountain (STScI), and P. Puxley
@@ -522,6 +544,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003131{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=671562313
+astropix_ids: stsci|2003-01a
 
 credits> NASA, N. Benitez (JHU), T. Broadhurst (Racah Institute of Physics/The
 Hebrew University), H. Ford (JHU), M. Clampin (STScI), G. Hartig (STScI), G.
@@ -559,6 +582,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003201{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=67853438
+astropix_ids: stsci|2004-45a
 
 credits> NASA, ESA, and The Hubble Heritage Team (STScI)
 
@@ -580,6 +604,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003211{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=280385245
+astropix_ids: stsci|1999-04a
 
 credits> The Hubble Heritage Team (AURA/STScI/NASA)
 
@@ -601,6 +626,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003221{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=782436850
+astropix_ids: stsci|1994-02b
 
 credits> NASA, STScI
 
@@ -622,6 +648,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003231{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1406491029
+astropix_ids: stsci|2005-15a
 
 credits> NASA, ESA, HEIC, and The Hubble Heritage Team (STScI/AURA)
 Acknowledgment : Y.-H. Chu and R. M. Williams (UIUC)
@@ -644,6 +671,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003301{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=225462696
+astropix_ids: stsci|1998-21b
 
 credits> G. Fritz Benedict, Andrew Howell, Inger Jorgensen, David Chapell
 (University of Texas), Jeffery Kenney (Yale University), and Beverly J. Smith
@@ -677,6 +705,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003311{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=2121009947
+astropix_ids: stsci|2006-41a
 
 credits> NASA, ESA, and the Hubble Heritage Team (STScI/AURA); acknowledgment :
 Y.-H. Chu (University of Illinois, Urbana - Champaign) and Y. Nazé (Universite
@@ -700,6 +729,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003321{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=245563811
+astropix_ids: stsci|2002-12a
 
 credits> NASA and The Hubble Heritage Team (STScI/AURA); acknowledgment : D.
 Garnett (University of Arizona)
@@ -765,6 +795,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000010011{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1938488390
+astropix_ids: stsci|1999-41a
 
 credits> NASA and The Hubble Heritage Team (STScI)
 
@@ -786,6 +817,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000010021{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1365671883
+astropix_ids: stsci|2003-24a
 
 credits> NASA, The Hubble Heritage Team and A. Riess (STScI)
 
@@ -807,6 +839,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000010031{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=4543651
+astropix_ids: stsci|2001-04b
 
 credits> NASA, Rogier Windhorst (Arizona State University, Tempe, AZ), and the
 Hubble mid-UV team
@@ -829,6 +862,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000010101{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=186060776
+astropix_ids: stsci|2003-01d
 
 credits> NASA, N. Benitez (JHU), T. Broadhurst (The Hebrew University), H. Ford
 (JHU), M. Clampin(STScI), G. Hartig (STScI), G. Illingworth (UCO/Lick
@@ -852,6 +886,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000010111{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=72325296
+astropix_ids: stsci|2001-22a
 
 credits> Image Credits: NASA, Jayanne English (University of Manitoba), Sally
 Hunsberger (Pennsylvania State University), Zolt Levay (Space Telescope Science
@@ -879,6 +914,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000010121{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1751433174
+astropix_ids: stsci|2003-14a
 
 credits> NASA and The Hubble Heritage Team (STScI/AURA); acknowledgment : M.
 Donahue (STScI) and J. Trauger (JPL)
@@ -901,6 +937,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000010131{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1816569261
+astropix_ids: stsci|2002-11d
 
 credits> NASA, H. Ford (JHU), G. Illingworth (UCSC/LO), M.Clampin (STScI), G.
 Hartig (STScI), the ACS Science Team, and ESA The ACS Science Team: H. Ford, G.
@@ -939,6 +976,7 @@ url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000010201{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1298603559
+astropix_ids: stsci|1994-16b
 
 credits> Dr. John Hutchings, Dominion Astrophysical Observatory, NASA
 
@@ -960,6 +998,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000000132{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=41215651
+astropix_ids: stsci|2000-37a
 
 credits> Credits: NASA, Andrew S. Wilson (University of Maryland); Patrick L.
 Shopbell (Caltech); Chris Simpson (Subaru Telescope); Thaisa Storchi-Bergmann
@@ -984,6 +1023,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000000202{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1448911066
+astropix_ids: stsci|2002-21a
 
 credits> NASA and The Hubble Heritage Team (STScI/AURA); acknowledgment : Ray A.
 Lucas (STScI/AURA)
@@ -1007,6 +1047,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000000212{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=2003866348
+astropix_ids: stsci|1999-35a
 
 credits> NASA and The Hubble Heritage Team (AURA/STScI).
 
@@ -1028,6 +1069,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000000232{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=883482844
+astropix_ids: stsci|1993-11b
 
 credits> : B. Whitmore (STScI), and NASA Co-investigators: : Francois Schweizer
 of the Carnegie Institution of Washington, Washington, D.C., and Claus
@@ -1041,7 +1083,7 @@ place_uuid: 3179be1f-96ad-4567-8567-d547c0cdb2ee
 image_url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000000232{Q}?g=138
 outgoing_url: http://hubblesite.org/contents/news-releases/1993/news-1993-11.html
 
-text> NGC 7252: Spiral Disk and Globular Star Clusters at the Core of a
+text> NGC 7257: Spiral Disk and Globular Star Clusters at the Core of a
 Colliding Galaxy
 
 wip: yes
@@ -1052,6 +1094,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000000302{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1556539595
+astropix_ids: stsci|1994-10a
 
 credits> C.R. O'Dell/ Rice University NASA
 
@@ -1095,6 +1138,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000000322{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1627762254
+astropix_ids: stsci|2003-30b
 
 credits> NASA and The Hubble Heritage Team (AURA/STScI)
 
@@ -1116,6 +1160,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000000332{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=608618484
+astropix_ids: stsci|2002-18b
 
 credits> NASA and The Hubble Heritage Team (STScI/AURA)
 
@@ -1137,6 +1182,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001002{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=629006406
+astropix_ids: stsci|2003-01f
 
 credits> NASA, N. Benitez (JHU), T. Broadhurst (The Hebrew University), H. Ford
 (JHU), M. Clampin(STScI), G. Hartig (STScI), G. Illingworth (UCO/Lick
@@ -1160,6 +1206,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001012{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=497424603
+astropix_ids: stsci|2006-37b
 
 credits> NASA, ESA, and H. Richer (University of British Columbia)
 
@@ -1181,6 +1228,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001022{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=37951224
+astropix_ids: stsci|2005-09a
 
 credits> NASA, ESA, and The Hubble Heritage Team (STScI/AURA); acknowledgment :
 M. Gregg (Univ. Calif.-Davis and Inst. for Geophysics and Planetary Physics,
@@ -1204,6 +1252,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001032{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1115986707
+astropix_ids: stsci|1998-11g
 
 credits> Sun Kwok and Kate Su (University of Calgary), Bruce Hrivnak (Valparaiso
 University), and NASA
@@ -1226,6 +1275,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001102{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=912623430
+astropix_ids: stsci|2005-37b
 
 credits> NASA, ESA, CXC, JPL-Caltech, J. Hester and A. Loll (Arizona State
 Univ.), R. Gehrz (Univ. Minn.), and STScI
@@ -1248,6 +1298,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001122{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=266105601
+astropix_ids: stsci|2004-46a
 
 credits> NASA, ESA and A.Zijlstra (UMIST, Manchester, UK)
 
@@ -1270,6 +1321,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001202{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=400643711
+astropix_ids: stsci|2005-12g
 
 credits> NASA, ESA, and The Hubble Heritage Team (STScI/AURA)
 
@@ -1291,6 +1343,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001212{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1424292271
+astropix_ids: stsci|2003-30a
 
 credits> NASA and The Hubble Heritage Team (AURA/STScI); acknowledgment : D.
 Garnett (U. Arizona), J. Hester (ASU), and J. Westphal (Caltech)
@@ -1313,6 +1366,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001222{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=458717449
+astropix_ids: stsci|2000-25a
 
 credits> NASA and The Hubble Heritage Team (STScI/AURA)
 
@@ -1334,6 +1388,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001232{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=806070738
+astropix_ids: stsci|2006-33c
 
 credits> NASA, ESA, and G. Meylan (Ecole Polytechnique Federale de Lausanne)
 
@@ -1355,6 +1410,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001302{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=100313071
+astropix_ids: stsci|2001-39a
 
 credits> NASA, ESA, and The Hubble Heritage Team (STScI/AURA); acknowledgment :
 C. R. O'Dell (Vanderbilt University) and L. Bianchi (Johns Hopkins University
@@ -1388,6 +1444,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001312{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1968908752
+astropix_ids: stsci|1999-06a
 
 credits> Carl Grillmair (California Institute of Technology) and NASA
 
@@ -1409,6 +1466,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001322{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=652799754
+astropix_ids: stsci|2004-04b
 
 credits> NOAO/AURA/NSF and N.A. Sharp (NOAO)
 
@@ -1430,6 +1488,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001332{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=2046434536
+astropix_ids: stsci|2006-46a
 
 credits> NASA, ESA, and the Hubble Heritage Team (STScI/AURA)-ESA/Hubble
 Collaboration Acknowledgment: B. Whitmore (Space Telescope Science Institute)
@@ -1486,6 +1545,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000002012{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=115854051
+astropix_ids: stsci|2000-23b
 
 credits> Brian D. Moore and J. Jeff Hester (Arizona State University)
 
@@ -1549,6 +1609,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000002102{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1269492645
+astropix_ids: stsci|1998-39a
 
 credits> The Hubble Heritage Team (STScI/AURA/NASA)
 
@@ -1591,6 +1652,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000002132{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1353700001
+astropix_ids: stsci|2000-06a
 
 credits> NASA, The Hubble Heritage Team (AURA/STScI)
 
@@ -1622,6 +1684,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000002202{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=112642165
+astropix_ids: stsci|2001-05a
 
 credits> NASA, ESA and The Hubble Heritage Team (STScI/AURA); acknowledgment :
 R. Sahai (Jet Propulsion Lab) and B. Balick (University of Washington)
@@ -1644,6 +1707,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000002212{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=2020765031
+astropix_ids: stsci|2006-50b
 
 credits> NASA, ESA, and H. Bond (STScI)
 
@@ -1665,6 +1729,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000002222{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1015107212
+astropix_ids: stsci|2004-02c
 
 credits> F. Owen (NRAO), W. Keel (U. AL), M. Ledlow (Gemini Obs.), G. Morrison
 (UNM), V. Andersen (U. AL)
@@ -1687,10 +1752,11 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000002232{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=698170338
+astropix_ids: stsci|2004-29l
 
-credits> NASA, ESA, The Hubble Heritage Team (STScI/AURA); acknowledgment
+credits> NASA, ESA, The Hubble Heritage Team (STScI/AURA); acknowledgment: R.
+Sankrit and W. Blair (Johns Hopkins University)
 
-: R. Sankrit and W. Blair (Johns Hopkins University)
 wip: yes
 ---
 
@@ -1709,6 +1775,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000002302{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=495121632
+astropix_ids: stsci|2005-25b
 
 credits> NASA, ESA, R. Sahai and J. Trauger (Jet Propulsion Laboratory) and the
 WFPC2 Science Team
@@ -1731,6 +1798,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000002312{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=2093669744
+astropix_ids: stsci|2006-10b
 
 credits> NASA, ESA and the Hubble Heritage Team (STScI/AURA)
 
@@ -1752,6 +1820,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000002322{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1745837569
+astropix_ids: stsci|1997-34d
 
 credits> Brad Whitmore (STScI) and NASA
 
@@ -1773,6 +1842,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000002332{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1964128802
+astropix_ids: stsci|2004-35a
 
 credits> NASA, ESA, Y. Izotov (Main Astronomical Observatory, Kyiv, UA) and T.
 Thuan (University of Virginia)
@@ -1795,6 +1865,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000003012{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=945537932
+astropix_ids: stsci|1997-38d
 
 credits> Bruce Balick (University of Washington), Jason Alexander (University of
 Washington), Arsen Hajian (U.S. Naval Observatory), Yervant Terzian (Cornell
@@ -1819,6 +1890,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000003032{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=519826736
+astropix_ids: stsci|2004-15b
 
 credits> NASA, ESA, and The Hubble Heritage Team (AURA/STScI); acknowledgment :
 J. Higdon (Cornell U.) and I. Jordan (STScI)
@@ -1841,6 +1913,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000003102{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1016568421
+astropix_ids: stsci|2005-12a
 
 credits> NASA, ESA, S. Beckwith (STScI), and The Hubble Heritage Team
 (STScI/AURA)
@@ -1874,6 +1947,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000003112{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=245092634
+astropix_ids: stsci|2004-32b
 
 credits> NASA, ESA, C.R. O'Dell (Vanderbilt University), and M. Meixner, P.
 McCullough
@@ -1897,6 +1971,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000003122{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=324799737
+astropix_ids: stsci|2006-34b
 
 credits> NASA, ESA, and K. Sahu (STScI)
 
@@ -1939,6 +2014,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000003202{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1214982571
+astropix_ids: stsci|2005-20a
 
 credits> NASA, ESA, and The Hubble Heritage Team (STScI/AURA); acknowledgment :
 J. Blakeslee (JHU) and R. Thompson (University of Arizona)
@@ -1961,6 +2037,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000003212{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=378317252
+astropix_ids: stsci|2006-54b
 
 credits> NASA, ESA, and J. Maíz Apellániz (Instituto de Astrofísica de
 Andalucía, Spain)
@@ -1983,6 +2060,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000003222{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1708027286
+astropix_ids: stsci|2001-08f
 
 credits> NASA, ESA and R. de Grijs (Inst. of Astronomy, Cambridge, UK)
 
@@ -2004,6 +2082,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000003232{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=95225661
+astropix_ids: stsci|2006-26a
 
 credits> NASA, ESA, and C. Wilson (McMaster University, Hamilton, Ontario,
 Canada)
@@ -2026,6 +2105,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000003302{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=206860488
+astropix_ids: stsci|1995-44a
 
 credits> NASA, ESA, STScI, J. Hester and P. Scowen (Arizona State University)
 
@@ -2048,6 +2128,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000003312{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=2064571029
+astropix_ids: stsci|2002-15f
 
 credits> NASA and The Hubble Heritage Team (STScI/AURA)
 
@@ -2090,6 +2171,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000010002{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1566050308
+astropix_ids: stsci|1999-16a
 
 credits> The Hubble Heritage Team (AURA/STScI/NASA)
 
@@ -2112,6 +2194,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000010012{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1043943490
+astropix_ids: stsci|2001-16a
 
 credits> NASA, ESA, and D. Maoz (Tel-Aviv University and Columbia University)
 Members of the group of scientists involved in these observations are : Dan Maoz
@@ -2139,6 +2222,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000010022{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=382940296
+astropix_ids: stsci|2002-16a
 
 credits> NASA and Michael Corbin (CSC/STScI)
 
@@ -2160,6 +2244,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000010032{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1824514372
+astropix_ids: stsci|2004-29n
 
 credits> NASA, ESA, and The Hubble Heritage Team (STScI/AURA); acknowledgment :
 R. Sankrit and W. Blair (Johns Hopkins University)
@@ -2182,6 +2267,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000010102{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=887989858
+astropix_ids: stsci|1997-34e
 
 credits> Brad Whitmore (STScI) and NASA
 
@@ -2203,6 +2289,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000010112{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1930783597
+astropix_ids: stsci|2004-17g
 
 credits> NASA, ESA, and The Hubble Heritage Team (AURA/STScI); acknowledgment :
 F. Yusef-Zadeh (Northwestern Univ.)
@@ -2225,6 +2312,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000010122{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1488004255
+astropix_ids: stsci|2000-20a
 
 credits> NASA and The Hubble Heritage Team (STScI/AURA)
 
@@ -2247,6 +2335,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000010132{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1367037623
+astropix_ids: stsci|1997-38a
 
 credits> Bruce Balick (University of Washington), Vincent Icke (Leiden
 University, The Netherlands), Garrelt Mellema (Stockholm University), and NASA
@@ -2269,6 +2358,7 @@ url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000010202{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=2137405101
+astropix_ids: stsci|2006-07c
 
 credits> NASA, ESA, The Hubble Heritage Team, (STScI/AURA) and A. Riess (STScI)
 
@@ -2290,6 +2380,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000000133{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1550435984
+astropix_ids: stsci|2003-06a
 
 credits> NASA and The Hubble Heritage Team (STScI/AURA); acknowledgment : C.R.
 O'Dell (Vanderbilt University)
@@ -2322,6 +2413,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000000213{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=477678583
+astropix_ids: stsci|1994-09a
 
 credits> J. Hester/Arizona state University NASA.
 
@@ -2343,6 +2435,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000000223{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=429914356
+astropix_ids: stsci|1998-32d
 
 credits> Rodger I. Thompson (University of Arizona) and NASA
 
@@ -2364,6 +2457,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000000233{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1792135478
+astropix_ids: stsci|2003-04a
 
 credits> NASA, NRAO/AUI/NSF and W. Keel (University of Alabama, Tuscaloosa)
 
@@ -2385,6 +2479,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000000303{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=945534243
+astropix_ids: stsci|2001-11a
 
 credits> NASA, ESA, Mohammad Heydari-Malayeri (Observatoire de Paris, France)
 
@@ -2406,6 +2501,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000000313{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=133232146
+astropix_ids: stsci|1996-38a
 
 credits> A. Caulet (ST-ECF, ESA) and NASA
 
@@ -2427,6 +2523,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000000323{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=514266707
+astropix_ids: stsci|2001-34a
 
 credits> NASA, ESA & Mohammad Heydari-Malayeri (Observatoire de Paris, France)
 
@@ -2458,6 +2555,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000000333{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=5927599
+astropix_ids: stsci|2003-10i
 
 credits> NASA, ESA and H.E. Bond (STScI)
 
@@ -2479,6 +2577,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001013{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=440860809
+astropix_ids: stsci|2005-15c
 
 credits> NASA/JPL-Caltech/CXC/NOAO/AURA/NSF
 
@@ -2500,6 +2599,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001023{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1723505511
+astropix_ids: stsci|2004-04a
 
 credits> NASA and The Hubble Heritage Team (AURA/STScI); acknowledgment: S.
 Smartt (Institute of Astronomy) and D. Richstone (U. Michigan)
@@ -2522,6 +2622,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001033{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1468086014
+astropix_ids: stsci|1995-44c
 
 credits> NASA, ESA, STScI, J. Hester and P. Scowen (Arizona State University)
 
@@ -2544,6 +2645,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001103{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1500577972
+astropix_ids: stsci|2005-30a
 
 credits> NASA, ESA, and The Hubble Heritage Team (STScI/AURA); acknowledgment :
 J.C. Green (Univ. of Colorado) and the Cosmic Origins Spectrograph (COS) GTO
@@ -2568,6 +2670,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001113{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1241539651
+astropix_ids: stsci|2006-07a
 
 credits> NASA, ESA, The Hubble Heritage Team, (STScI/AURA) and A. Riess (STScI)
 
@@ -2589,6 +2692,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001123{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=868298296
+astropix_ids: stsci|2000-01a
 
 credits> NASA and The Hubble Heritage Team (STScI)
 
@@ -2610,6 +2714,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001133{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1715849777
+astropix_ids: stsci|2005-04a
 
 credits> NASA, ESA and A. Nota (STScI/ESA)
 
@@ -2631,6 +2736,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001203{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1921322152
+astropix_ids: stsci|2001-07a
 
 credits> NASA and The Hubble Heritage Team (STScI/AURA); acknowledgment : J.C.
 Howk (Johns Hopkins University) and B.D. Savage (University of
@@ -2664,10 +2770,11 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001213{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1198895501
+astropix_ids: stsci|2006-51b
 
-credits> Hubble and Chandra NASA, ESA, CXC, STScI, and B. McNamara (University
-of Waterloo) Very Large Array Telescope NRAO, and L. Birzan and team (Ohio
-University)
+credits> Hubble and Chandra images: NASA, ESA, CXC, STScI, and B. McNamara
+(University of Waterloo); Very Large Array Telescope image: NRAO, and L. Birzan
+and team (Ohio University)
 
 wip: yes
 ---
@@ -2687,6 +2794,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001223{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1861837915
+astropix_ids: stsci|1998-12c
 
 credits> Jim Flood (Amateur Astronomers Inc., Sperry Observatory), Max Mutchler
 (STScI)
@@ -2709,6 +2817,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001233{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1042310781
+astropix_ids: stsci|2001-33a
 
 credits> NASA and The Hubble Heritage Team (STScI/AURA); acknowledgment : A.
 Cool (SFSU)
@@ -2731,6 +2840,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001303{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=2113988973
+astropix_ids: stsci|2007-05c
 
 credits> NASA, ESA, and A. Pellerin (STScI)
 
@@ -2752,6 +2862,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001313{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=967639811
+astropix_ids: stsci|2003-01e
 
 credits> NASA, N. Benitez (JHU), T. Broadhurst (The Hebrew University), H. Ford
 (JHU), M. Clampin(STScI), G. Hartig (STScI), G. Illingworth (UCO/Lick
@@ -2775,6 +2886,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001323{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=249096520
+astropix_ids: stsci|1995-01a
 
 credits> J.P. Harrington and K.J. Borkowski (University of Maryland), and NASA
 
@@ -2796,6 +2908,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001333{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=38305263
+astropix_ids: stsci|2002-29a
 
 credits> NASA and The Hubble Heritage Team (STScI/AURA); acknowledgment: M.S.
 Oey (Lowell Observatory) and Y.-H. Chu (U. of Illinois)
@@ -2818,6 +2931,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002013{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1773372919
+astropix_ids: stsci|2004-01b
 
 credits> NASA, ESA, J. Blakeslee (Johns Hopkins University), M. Postman (Space
 Telescope Science Institute), and P. Rosati (European Southern Observatory)
@@ -2840,6 +2954,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002023{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=473401290
+astropix_ids: stsci|2002-10d
 
 credits> NASA and H. Richer (University of British Columbia)
 
@@ -2882,6 +2997,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002103{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=876521511
+astropix_ids: stsci|1996-17b
 
 credits> Nino Panagia (Space Telescope Science Institute and European Space
 Agency) and NASA
@@ -2904,6 +3020,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002113{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1554697191
+astropix_ids: stsci|2000-14a
 
 credits> NASA and The Hubble Heritage Team (STScI/AURA)
 
@@ -2947,6 +3064,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002203{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1467152379
+astropix_ids: stsci|1995-44b
 
 credits> NASA, ESA, STScI, J. Hester and P. Scowen (Arizona State University)
 
@@ -2978,6 +3096,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002213{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1630813240
+astropix_ids: stsci|2007-18a
 
 credits> NASA, ESA, A. Sarajedini (University of Florida) and G. Piotto
 (University of Padua [Padova]) Science Credit: NASA, ESA, and G. Piotto
@@ -3001,6 +3120,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002223{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1875554596
+astropix_ids: stsci|2004-26a
 
 credits> NASA, ESA, Y. Nazé (University of Liège, Belgium) and Y.-H. Chu
 (University of Illinois, Urbana)
@@ -3023,6 +3143,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002233{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=2134165724
+astropix_ids: stsci|2005-15f
 
 credits> X-ray: NASA/CXC/Rutgers/J.Warren et al.; Optical: NASA/STScI/U.
 Ill/Y.Chu; Radio: ATCA/U. Ill/J.Dickel et al.
@@ -3045,6 +3166,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002303{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1207397371
+astropix_ids: stsci|2006-38c
 
 credits> NASA, ESA, D. Bennett (University of Notre Dame), and J. Anderson (Rice
 University)
@@ -3067,6 +3189,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002313{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=677761630
+astropix_ids: stsci|1999-26a
 
 credits> The Hubble Heritage Team (AURA/ STScI/ NASA)
 
@@ -3088,6 +3211,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002323{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=169500302
+astropix_ids: stsci|2002-11e
 
 credits> NASA, H. Ford (JHU), G. Illingworth (UCSC/LO), M.Clampin (STScI), G.
 Hartig (STScI), the ACS Science Team, and ESA The ACS Science Team: H. Ford, G.
@@ -3116,6 +3240,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002333{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1970913046
+astropix_ids: stsci|2002-15h
 
 credits> NASA and The Hubble Heritage Team (STScI/AURA)
 
@@ -3137,6 +3262,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003003{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=282077515
+astropix_ids: stsci|1998-28a
 
 credits> The Hubble Heritage Team (AURA/STScI/NASA)
 
@@ -3158,6 +3284,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003023{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=131409215
+astropix_ids: stsci|2000-34a
 
 credits> NASA and The Hubble Heritage Team (STScI/AURA); acknowledgment : Roger
 Lynds (KPNO/NOAO)
@@ -3180,6 +3307,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003033{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1671298377
+astropix_ids: stsci|2003-01g
 
 credits> NASA, N. Benitez (JHU), T. Broadhurst (The Hebrew University), H. Ford
 (JHU), M. Clampin(STScI), G. Hartig (STScI), G. Illingworth (UCO/Lick
@@ -3203,6 +3331,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003103{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1761294343
+astropix_ids: stsci|2002-24a
 
 credits> Credits for X-ray Image: NASA/CXC/ASU/J. Hester et al. Credits for
 Optical Image: NASA/HST/ASU/J. Hester et al.
@@ -3225,6 +3354,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003113{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1198895778
+astropix_ids: stsci|2006-50c
 
 credits> NASA, ESA, and H. Bond (STScI)
 
@@ -3246,6 +3376,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003133{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=595276612
+astropix_ids: stsci|2005-01a
 
 credits> NASA, ESA, and The Hubble Heritage Team (STScI/AURA); acknowledgment :
 P. Knezek (WIYN)
@@ -3268,6 +3399,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003203{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=985356464
+astropix_ids: stsci|2007-08a
 
 credits> NASA, ESA, and The Hubble Heritage Team (STScI/AURA); acknowledgment :
 J. Blakeslee (Washington State University)
@@ -3290,6 +3422,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003213{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=549595493
+astropix_ids: stsci|2006-17b
 
 credits> European Space Agency & NASA Acknowledgment: E. Olszewski (University
 of Arizona)
@@ -3312,6 +3445,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003233{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=400514625
+astropix_ids: stsci|2006-51d
 
 credits> NASA, ESA, and B. McNamara (University of Waterloo and Ohio University)
 
@@ -3333,6 +3467,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003303{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1330205328
+astropix_ids: stsci|2003-15a
 
 credits> NASA, ESA and T.M. Brown (STScI)
 
@@ -3354,6 +3489,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003313{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1450706893
+astropix_ids: stsci|2003-10c
 
 credits> NASA, ESA and H.E. Bond (STScI)
 
@@ -3375,6 +3511,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003323{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1291268272
+astropix_ids: stsci|2003-20a
 
 credits> NASA and The Hubble Heritage Team (STScI/AURA); acknowledgment : Y.-H.
 Chu (UIUC), S. Kulkarni (Caltech), and R. Rothschild (UCSD)
@@ -3398,10 +3535,11 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003333{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=341641841
+astropix_ids: stsci|2001-37a
 
-credits> NASA and The Hubble Heritage Team (STScI/AURA); acknowledgment
+credits> NASA and The Hubble Heritage Team (STScI/AURA); acknowledgment: R.
+Windhorst (ASU)
 
-: R. Windhorst (ASU)
 wip: yes
 ---
 
@@ -3420,6 +3558,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000010003{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1739627836
+astropix_ids: stsci|2007-10a
 
 credits> NASA, ESA, P. Challis and R. Kirshner (Harvard-Smithsonian Center for
 Astrophysics)
@@ -3443,6 +3582,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000010023{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1619065951
+astropix_ids: stsci|2004-06a
 
 credits> ESA, NASA and P. Anders (Göttingen University Galaxy Evolution Group,
 Germany
@@ -3465,6 +3605,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000010033{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=150058649
+astropix_ids: stsci|2003-12b
 
 credits> NASA and J. Blakeslee (JHU)
 
@@ -3486,6 +3627,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000010103{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1953985119
+astropix_ids: stsci|1998-17a
 
 credits> S. R. Kulkarni and S. G. Djorgovski (Caltech), the Caltech GRB Team ,
 and NASA
@@ -3508,6 +3650,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000010113{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1031792422
+astropix_ids: stsci|2006-39a,stsci|2009-18d
 
 credits> X-ray: NASA/CXC/M.Markevitch et al. Optical: NASA/STScI;
 Magellan/U.Arizona/D.Clowe et al. Lensing Map: NASA/STScI; ESO WFI;
@@ -3531,6 +3674,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000010123{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=736525265
+astropix_ids: stsci|1995-49b
 
 credits> C.R. O'Dell/Rice University; NASA
 
@@ -3552,6 +3696,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000010133{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1315162865
+astropix_ids: stsci|1998-28d
 
 credits> The Hubble Heritage Team (AURA/STScI/NASA)
 
@@ -3573,6 +3718,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000010203{Q}?g=138
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=950951707
+astropix_ids: stsci|2003-28a
 
 credits> NASA and The Hubble Heritage Team (STScI/AURA)
 
@@ -3594,6 +3740,7 @@ url: http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000012133{Q}?g=182
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=1497902212
+astropix_ids: stsci|2006-30b
 
 credits> NASA, ESA, and the Hubble Heritage (STScI/AURA)-ESA/Hubble
 Collaboration Acknowledgment: R. Fesen (Dartmouth College) and J. Long
@@ -3617,6 +3764,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann0820L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-ann0820.jpg
+astropix_ids: esahubble|ann0820
 
 credits> NASA & ESA; Science operations with the NASA/ESA Hubble Space Telescope
 resumed over the weekend, four weeks after a problem with the scienc...
@@ -3640,6 +3788,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann0901aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-ann0901a.jpg
+astropix_ids: esahubble|ann0901a
 
 credits> NASA, ESA and the Hubble Heritag; The unique planetary nebula NGC 2818
 is nested inside the open star cluster NGC 2818A. Both the cluster and the
@@ -3664,6 +3813,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann0904aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-ann0904a.jpg
+astropix_ids: esahubble|ann0904a
 
 credits> NASA & ESA; In celebration of the International Year of Astronomy 2009,
 the NASA/ESA Hubble Space Telescope photographed the winning target ...
@@ -3687,6 +3837,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann0906aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-ann0906a.jpg
+astropix_ids: esahubble|ann0906a
 
 credits> NASA & ESA; The Hubble community bids farewell to the soon-to-be
 decommissioned Wide Field Planetary Camera 2 (WFPC2) onboard the Hubble Spa...
@@ -3710,6 +3861,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann0909aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-ann0909a.jpg
+astropix_ids: esahubble|ann0909a
 
 credits> NASA & ESA; After more than three months of calibration and testing,
 the NASA/ESA Hubble Space Telescope is reopening its rejuvenated eyes t...
@@ -3733,6 +3885,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann0910aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-ann0910a.jpg
+astropix_ids: esahubble|ann0910a
 
 credits> NASA & ESA; A bright and bizarre galaxy called NGC 2623 is the focus of
 this Hubblecast. The single galaxy is the product of the merger of ...
@@ -3756,6 +3909,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann0912aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-ann0912a.jpg
+astropix_ids: esahubble|ann0912a
 
 credits> NASA & ESA; A never-before-seen view of the turbulent heart of our
 Milky Way galaxy provided by the NASA/ESA Hubble Space Telescope and its ...
@@ -3779,6 +3933,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann1006aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-ann1006a.jpg
+astropix_ids: esahubble|ann1006a
 
 credits> NASA, ESA and Jesús Maíz Apell; This image is a screen shot from
 Hubblecast 37 featuring a spectacular new NASA/ESA Hubble Space Telescope image
@@ -3803,6 +3958,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann1105aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-ann1105a.jpg
+astropix_ids: esahubble|ann1105a
 
 credits> NASA, ESA, R. Gobat (Laboratoire; This image from the Near Infrared
 Camera and Multi-Object Spectrometer (NICMOS) onboard the NASA/ESA Hubble Space
@@ -3827,6 +3983,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann1108aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-ann1108a.jpg
+astropix_ids: esahubble|ann1108a
 
 credits> NASA, ESA and A. Fruchter (STScI; The NASA/ESA Hubble Space Telescope
 has pinpointed the source of one of the most puzzling blast of high-energy
@@ -3851,6 +4008,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann1110aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-ann1110a.jpg
+astropix_ids: esahubble|ann1110a
 
 credits> NASA, ESA and the Hubble Heritag; The Hubble Space Telescope has imaged
 the star field around the Cepheid variable V1 in M31. This image shows
@@ -3875,6 +4033,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann1111aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-ann1111a.jpg
+astropix_ids: esahubble|ann1111a
 
 credits> NASA, ESA and Pete Challis (Harv; This Hubble image of Supernova 1987A
 shows the brightening ring of supernova debris. The closest supernova seen in
@@ -3899,6 +4058,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann1121aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-ann1121a.jpg
+astropix_ids: esahubble|ann1121a
 
 credits> NASA, ESA, J. Kriss (STScI) and ; This image from the NASA/ESA Hubble
 Space Telescope shows the galaxy Markarian 509. The bright object at the centre
@@ -3923,6 +4083,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann1409aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-ann1409a.jpg
+astropix_ids: esahubble|ann1409a
 
 credits> NASA & ESA; Screenshot of Hubblecast 76: Merging galaxies and droplets
 of starbirth....
@@ -3946,6 +4107,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann1802aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-ann1802a.jpg
+astropix_ids: esahubble|ann1802a
 
 credits> ESA/Hubble; This is a still from Hubblecast 107, which explains the
 meaning of the colours in the spiral galaxy NGC 3344....
@@ -3969,6 +4131,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-eso1631aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-eso1631a.jpg
+astropix_ids: esahubble|eso1631a
 
 credits> ESO/CARS survey; The mystery of a rare change in the behaviour of the
 supermassive black hole at the centre of the distant galaxy Markarian 1018 ...
@@ -3992,6 +4155,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0309dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0309d.jpg
+astropix_ids: esahubble|heic0309d
 
 credits> European Space Agency, NASA, Jea; This is a 2.5-degree field around
 galaxy cluster CL0024+1654. The cluster galaxies are visible in the centre of
@@ -4016,6 +4180,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0407bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0407b.jpg
+astropix_ids: esahubble|heic0407b
 
 credits> ESA/NASA & Romano Corradi (ING); The Bug Nebula, NGC 6302, here imaged
 with the 3.6 metre telescope at ESO's La Silla Observatory by astronomer Romano
@@ -4040,6 +4205,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0414dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0414d.jpg
+astropix_ids: esahubble|heic0414d
 
 credits> ESA and Digitized Sky Survey 2; The image of the area around the Cat's
 Eye Nebula was composed from three Digitized Sky Survey 2 images taken through
@@ -4064,6 +4230,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0506cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0506c.jpg
+astropix_ids: esahubble|heic0506c
 
 credits> ESA/Hubble and Digitized Sky S; The Whirlpool Galaxy (M51a) with it's
 sparkling arms is the first galaxy found to have a spiral structure....
@@ -4087,6 +4254,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0510aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0510a.jpg
+astropix_ids: esahubble|heic0510a
 
 credits> Davide De Martin (ESA/Hubble), t; This image is a composite from black
 and white images taken with the Palomar Observatory's 48-inch (1.2 meter) Samuel
@@ -4111,6 +4279,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0512dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0512d.jpg
+astropix_ids: esahubble|heic0512d
 
 credits> ÷ 2002 R. Gendler, Photo by R. ; Image of M31 taken with a 12.5-inch
 Ritchey-Chrétien telescope by amateur astronomer Robert Gendler....
@@ -4134,6 +4303,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0513bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0513b.jpg
+astropix_ids: esahubble|heic0513b
 
 credits> NASA, ESA, B. Mobasher ( Space T; This image demonstrates how data from
 two space observatories, the Spitzer and Hubble Space Telescopes, are used to
@@ -4158,6 +4328,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0513cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0513c.jpg
+astropix_ids: esahubble|heic0513c
 
 credits> NASA, ESA, B. Mobasher ( Space T; This image demonstrates how data from
 two space observatories, the Spitzer and Hubble Space Telescopes, are used to
@@ -4182,6 +4353,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0513dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0513d.jpg
+astropix_ids: esahubble|heic0513d
 
 credits> NASA, ESA, B. Mobasher ( Space T; This image demonstrates how data from
 two space observatories, the Spitzer and Hubble Space Telescopes, are used to
@@ -4206,6 +4378,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0513eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0513e.jpg
+astropix_ids: esahubble|heic0513e
 
 credits> NASA, ESA, B. Mobasher ( Space T; This image demonstrates how data from
 two space observatories, the Spitzer and Hubble Space Telescopes, are used to
@@ -4230,6 +4403,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0514aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0514a.jpg
+astropix_ids: esahubble|heic0514a
 
 credits> NASA, ESA and A. Nota (ESA/STScI; This Hubble Space Telescope view
 shows one of the most dynamic and intricately detailed star-forming regions in
@@ -4254,6 +4428,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0514bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0514b.jpg
+astropix_ids: esahubble|heic0514b
 
 credits> NASA, ESA and A. Nota (ESA/STScI; Contained within the most massive and
 active star-forming region in the nearby galaxy, the Small Magellanic Cloud,
@@ -4278,6 +4453,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0514cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0514c.jpg
+astropix_ids: esahubble|heic0514c
 
 credits> ESA/Hubble and Digitized Sky Sur; The two-colour image shows an
 overview of the full Small Magellanic Cloud (SMC) and was composed from two
@@ -4302,6 +4478,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0515aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0515a.jpg
+astropix_ids: esahubble|heic0515a
 
 credits> NASA, ESA and Allison Loll/Jeff ; This new Hubble image - One among the
 largest ever produced with the Earth-orbiting observatory - shows gives the most
@@ -4326,6 +4503,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0515dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0515d.jpg
+astropix_ids: esahubble|heic0515d
 
 credits> ESA/Hubble and Digitized Sky Sur; This two-colour image shows 2.7 x 2.7
 degrees of the surroundings around the Crab Nebula. It was composed from
@@ -4350,6 +4528,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0516eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0516e.jpg
+astropix_ids: esahubble|heic0516e
 
 credits> ESA/Hubble and Digitized Sky Sur; The image shows an overview of Sirius
 B's surroundings and was composed from images from the Digitized Sky Survey 2.
@@ -4374,6 +4553,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0516fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0516f.jpg
+astropix_ids: esahubble|heic0516f
 
 credits> Akira Fujii; This ground-based image was taken by Japanese amateur
 astronomer Akira Fujii and shows a close-up of Sirius....
@@ -4397,6 +4577,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0601cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0601c.jpg
+astropix_ids: esahubble|heic0601c
 
 credits> NASA, ESA, M. Robberto ( Space T; A massive star is illuminating this
 small region, called M43, and sculpting the landscape of dust and gas.
@@ -4421,6 +4602,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0601dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0601d.jpg
+astropix_ids: esahubble|heic0601d
 
 credits> NASA, ESA, M. Robberto ( Space T; Packed into the centre of this region
 are bright lights of the Trapezium stars, the four heftiest stars in the Orion
@@ -4445,6 +4627,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0601eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0601e.jpg
+astropix_ids: esahubble|heic0601e
 
 credits> NASA, ESA, M. Robberto ( Space T; This dark red column shows an
 illuminated edge of the cavity wall....
@@ -4468,6 +4651,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0601fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0601f.jpg
+astropix_ids: esahubble|heic0601f
 
 credits> NASA, ESA, M. Robberto ( Space T; The faint red stars in this close-up
 image are the myriad brown dwarfs that Hubble spied for the first time in the
@@ -4492,6 +4676,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0601gL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0601g.jpg
+astropix_ids: esahubble|heic0601g
 
 credits> NASA, ESA, M. Robberto ( Space T; This glowing region reveals arcs and
 bubbles formed when stellar winds - streams of charged particles ejected by the
@@ -4516,6 +4701,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0601hL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0601h.jpg
+astropix_ids: esahubble|heic0601h
 
 credits> NASA, ESA, M. Robberto ( Space T; These dense, dark pillars of dust and
 gas are resisting erosion from intense ultraviolet light released by the Orion
@@ -4540,6 +4726,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0602aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0602a.jpg
+astropix_ids: esahubble|heic0602a
 
 credits> Image: European Space Agency & N; This new Hubble image reveals the
 gigantic Pinwheel galaxy, one of the best known examples of "grand design
@@ -4564,6 +4751,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0602cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0602c.jpg
+astropix_ids: esahubble|heic0602c
 
 credits> Image: European Space Agency & N; Background galaxies far behind the
 Pinwheel Galaxy. The galaxies are clearly "reddened" by the dust in the
@@ -4588,6 +4776,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0602dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0602d.jpg
+astropix_ids: esahubble|heic0602d
 
 credits> Image: European Space Agency & N; Dust lanes in the Pinwheel galaxy.
 The dust particles scatter blue light the most and therefore colour the light
@@ -4612,6 +4801,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0602eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0602e.jpg
+astropix_ids: esahubble|heic0602e
 
 credits> Image: European Space Agency & N; A selection of some of the millions
 of individual stars visible in Messier 101 with Hubble's sharp vision. In total
@@ -4636,6 +4826,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0602fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0602f.jpg
+astropix_ids: esahubble|heic0602f
 
 credits> Image: European Space Agency & N; An example of some of the 3000 bright
 clusters of sizzling newborn blue stars in the Pinwheel galaxy....
@@ -4659,6 +4850,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0602gL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0602g.jpg
+astropix_ids: esahubble|heic0602g
 
 credits> Image: European Space Agency & N; Another "grand design" spiral lies
 behind the Pinwheel Galaxy itself and is visible through its disk. Hubble's
@@ -4683,6 +4875,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0602hL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0602h.jpg
+astropix_ids: esahubble|heic0602h
 
 credits> Image: European Space Agency & N; Two distant galaxies behind Messier
 101 and a collection of individual foreground stars from one of its spiral
@@ -4707,6 +4900,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0602iL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0602i.jpg
+astropix_ids: esahubble|heic0602i
 
 credits> ESA/Hubble and Digitized Sky Sur; This two-colour image shows 3.7 x 2.7
 degrees of the surroundings around the Pinwheel Galaxy. It was composed from
@@ -4731,6 +4925,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0603bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0603b.jpg
+astropix_ids: esahubble|heic0603b
 
 credits> European Space Agency & NASA Ack; Hubble has captured the most detailed
 image to date of the open star cluster NGC 265 in the Small Magellanic Cloud.
@@ -4755,6 +4950,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0603cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0603c.jpg
+astropix_ids: esahubble|heic0603c
 
 credits> European Space Agency & NASA Ack; Hubble has captured the most detailed
 image to date of the open star cluster NGC 290 in the Small Magellanic Cloud.
@@ -4779,6 +4975,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0603dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0603d.jpg
+astropix_ids: esahubble|heic0603d
 
 credits> ESA/Hubble and Digitized Sky Sur; The two-colour image shows an
 overview of the full Small Magellanic Cloud (SMC) and was composed from two
@@ -4803,6 +5000,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0604aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0604a.jpg
+astropix_ids: esahubble|heic0604a
 
 credits> NASA, ESA and the Hubble Heritag; This mosaic image of the magnificent
 starburst galaxy, Messier 82 (M82) is the sharpest wide-angle view ever obtained
@@ -4827,6 +5025,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0604dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0604d.jpg
+astropix_ids: esahubble|heic0604d
 
 credits> NASA, ESA, CXC, and JPL-Caltech; Composite of images of the active
 galaxy Messier 82 from the three Great Observatories: Hubble Space Telescope,
@@ -4851,6 +5050,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0604eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0604e.jpg
+astropix_ids: esahubble|heic0604e
 
 credits> NASA/CXC/JHU/D.Strickland; Composite image of the active galaxy Messier
 82 from x-ray observations by Chandra X-Ray Observatory in three energy bands
@@ -4875,6 +5075,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0604fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0604f.jpg
+astropix_ids: esahubble|heic0604f
 
 credits> NASA/JPL-Caltech/C. Engelbracht ; Composite image of the active galaxy
 Messier 82 from infrared observations by Spitzer Space Telescope in three
@@ -4899,6 +5100,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0604hL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0604h.jpg
+astropix_ids: esahubble|heic0604h
 
 credits> ESA/Hubble and Digitized Sky Sur; The spiral galaxy M81 and the
 neighbour galaxy M82 are forming a physical pair. A few tens of million years
@@ -4923,6 +5125,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0606aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0606a.jpg
+astropix_ids: esahubble|heic0606a
 
 credits> European Space Agency, NASA, Ker; This NASA/ESA Hubble Space Telescope
 image is the first-ever picture of a distant quasar lensed into five images. The
@@ -4947,6 +5150,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0606bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0606b.jpg
+astropix_ids: esahubble|heic0606b
 
 credits> European Space Agency, NASA, Ker; This full-size Hubble image shows
 galaxy cluster SDSS J1004+4112 that was discovered as part of the Sloan Digital
@@ -4971,6 +5175,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0606cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0606c.jpg
+astropix_ids: esahubble|heic0606c
 
 credits> ESA/Hubble and Digitized Sky Sur; This two-colour image shows an
 overview of region of sky where galaxy cluster SDSS J1004+4112 is located. It is
@@ -4995,6 +5200,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0607aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0607a.jpg
+astropix_ids: esahubble|heic0607a
 
 credits> NASA, ESA; The latest photo from the Hubble Space Telescope, presented
 at the 2006 General Assembly of the International Astronomical Union...
@@ -5018,6 +5224,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0607bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0607b.jpg
+astropix_ids: esahubble|heic0607b
 
 credits> NASA, ESA; The latest photo from the Hubble Space Telescope, presented
 at the 2006 General Assembly of the International Astronomical Union...
@@ -5041,6 +5248,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0607dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0607d.jpg
+astropix_ids: esahubble|heic0607d
 
 credits> Davide De Martin (ESA/Hubble), t; Part of the LMC centered on LH 95.
 This image is a colour composite taken by the Digitized Sky Survey (DSS), the
@@ -5065,6 +5273,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0609aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0609a.jpg
+astropix_ids: esahubble|heic0609a
 
 credits> NASA, ESA, and the Hubble Herita; A new image taken with the NASA/ESA
 Hubble Space Telescope provides a detailed look at the tattered remains of a
@@ -5089,6 +5298,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0609bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0609b.jpg
+astropix_ids: esahubble|heic0609b
 
 credits> ESA/Hubble and Digitized Sky Sur; The two-colour image shows an
 overview of area of Cas A and was composed from two images from the Digitized
@@ -5113,6 +5323,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0612dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0612d.jpg
+astropix_ids: esahubble|heic0612d
 
 credits> NASA, ESA, K. Sahu (STScI) and t; This is an image of one-half of the
 Hubble Space Telescope field of view in the Sagittarius Window Eclipsing
@@ -5137,6 +5348,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0612eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0612e.jpg
+astropix_ids: esahubble|heic0612e
 
 credits> NASA, ESA, K. Sahu (STScI) and t; This is an excerpt of the Hubble
 Space Telescope field of view in the Sagittarius Window Eclipsing Extrasolar
@@ -5161,6 +5373,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0614aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0614a.jpg
+astropix_ids: esahubble|heic0614a
 
 credits> NASA, ESA, G. Mile; This image is a composite of many separate
 exposures made by the ACS instrument on the Hubble Space Telescope using several
@@ -5185,6 +5398,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0614bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0614b.jpg
+astropix_ids: esahubble|heic0614b
 
 credits> NASA, ESA, G. Mile; This image shows the full ACS overview of the
 region around the Spiderweb Galaxy (just to the right of the center). The galaxy
@@ -5209,6 +5423,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0614cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0614c.jpg
+astropix_ids: esahubble|heic0614c
 
 credits> Digitized Sky Survey 2 and ESA/H; This image is a colour composite made
 from exposures from the Digitized Sky Survey 2 (DSS2). The field of view is 2.8
@@ -5233,6 +5448,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0615aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0615a.jpg
+astropix_ids: esahubble|heic0615a
 
 credits> NASA, ESA, and the Hubbl; This Hubble image of the Antennae galaxies is
 the sharpest yet of this merging pair of galaxies. As the two galaxies smash
@@ -5257,6 +5473,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0615cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0615c.jpg
+astropix_ids: esahubble|heic0615c
 
 credits> NOAO/AURA/NSF, B. Twardy, B. Twa; This photo of the Antennae galaxies
 was taken with one of the NOAO telescopes from the ground....
@@ -5280,6 +5497,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0615dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0615d.jpg
+astropix_ids: esahubble|heic0615d
 
 credits> ESA/Hubble and Digitized Sky Sur; This image is a colour composite made
 from exposures from the Digitized Sky Survey 2 (DSS2). The field of view is 2.8
@@ -5304,6 +5522,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0616bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0616b.jpg
+astropix_ids: esahubble|heic0616b
 
 credits> NASA, ESA, and G. Meylan (École; A seven year study with the NASA/ESA
 Hubble Space Telescope has provided astronomers with the best observational
@@ -5328,6 +5547,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0616cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0616c.jpg
+astropix_ids: esahubble|heic0616c
 
 credits> Very Large Telescope/European So; A photo of the globular star cluster
 47 Tucanae taken with the Very Large Telescope, in Chile. It is one of the
@@ -5352,6 +5572,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0616dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0616d.jpg
+astropix_ids: esahubble|heic0616d
 
 credits> ESA/Hubble (Davide De Martin), t; This image of 47 Tucanae is a colour
 composite taken by the Digitized Sky Survey (DSS), the field of view is 2.4x2.8
@@ -5376,6 +5597,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0617bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0617b.jpg
+astropix_ids: esahubble|heic0617b
 
 credits> NASA, ESA and H. Bond (STScI ); The light echo around the star V838
 Monocerotis as seen by the Hubble Space Telescope in November 2005....
@@ -5399,6 +5621,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0617cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0617c.jpg
+astropix_ids: esahubble|heic0617c
 
 credits> NASA, ESA and H. Bond (STScI ); The light echo around the star V838
 Monocerotis as seen by the Hubble Space Telescope in September 2006....
@@ -5422,6 +5645,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0619aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0619a.jpg
+astropix_ids: esahubble|heic0619a
 
 credits> NASA, ESA and Jesús Maíz Apell; The star cluster Pismis 24 lies in the
 core of the large emission nebula NGC 6357 that extends one degree on the sky in
@@ -5446,6 +5670,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0619cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0619c.jpg
+astropix_ids: esahubble|heic0619c
 
 credits> NASA, ESA and Jesœs Ma­z Apell; Looking closer at Pismis 24-1 with
 Hubble's ACS High Resolution Channel: it becomes clear that it is in reality two
@@ -5470,6 +5695,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0619dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0619d.jpg
+astropix_ids: esahubble|heic0619d
 
 credits> NASA, ESA and Jesœs Ma­z Apell; ACS HRC image close-up showing the two
 stars of Pismis 24-1. It was thought to have an incredibly large mass of 200 to
@@ -5494,6 +5720,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0619eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0619e.jpg
+astropix_ids: esahubble|heic0619e
 
 credits> Davide De Martin (ESA/Hubble), t; Part of the constellation Scorpius
 centred on NGC 6357 which has star cluster Pismis 24 in its centre. This image
@@ -5518,6 +5745,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0701gL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0701g.jpg
+astropix_ids: esahubble|heic0701g
 
 credits> NASA, ESA and A. Koekemoer (STSc; This image shows the full COSMOS
 field at one tenth resolution. COSMOS - the Cosmic Evolution Survey - is the
@@ -5542,6 +5770,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0701hL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0701h.jpg
+astropix_ids: esahubble|heic0701h
 
 credits> NASA, ESA and A. Koekemoer (STSc; This image shows an excerpt of the
 COSMOS survey in full resolution. COSMOS - the Cosmic Evolution Survey - is the
@@ -5566,6 +5795,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0701iL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0701i.jpg
+astropix_ids: esahubble|heic0701i
 
 credits> NASA, ESA and A. Koekemoer (STSc; This image shows an excerpt of the
 COSMOS survey in full resolution. COSMOS - the Cosmic Evolution Survey - is the
@@ -5590,6 +5820,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0701jL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0701j.jpg
+astropix_ids: esahubble|heic0701j
 
 credits> Davide De Martin (ESA/Hubble), t; This image shows the COSMOS field and
 is a colour composite made from Digitized Sky Survey 2 (DSS2) exposure. The
@@ -5614,6 +5845,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0701kL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0701k.jpg
+astropix_ids: esahubble|heic0701k
 
 credits> NASA, ESA and R. Massey (Califor; This composite shows three different
 components of the COSMOS survey: The normal matter (in red) determined mainly by
@@ -5638,6 +5870,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0702aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0702a.jpg
+astropix_ids: esahubble|heic0702a
 
 credits> NASA, ESA and the Hubble Heritag; This image depicts bright blue newly
 formed stars that are blowing a cavity in the centre of a fascinating
@@ -5662,6 +5895,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0702bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0702b.jpg
+astropix_ids: esahubble|heic0702b
 
 credits> Davide De Martin (ESA/Hubble), t; This image shows the area around N90
 and is a colour composite made from Digitized Sky Survey 2 (DSS2) exposure. The
@@ -5686,6 +5920,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0703aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0703a.jpg
+astropix_ids: esahubble|heic0703a
 
 credits> NASA, ESA, and K. Noll (STScI); This image of NGC 2440 shows the
 colourful "last hurrah" of a star like our Sun. The star is ending its life by
@@ -5710,6 +5945,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0704aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0704a.jpg
+astropix_ids: esahubble|heic0704a
 
 credits> NASA, ESA, and R. Kirshner (Harv; Two decades ago, astronomers spotted
 one of the brightest exploding stars in more than 400 years. Since that first
@@ -5734,6 +5970,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0704cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0704c.jpg
+astropix_ids: esahubble|heic0704c
 
 credits> NASA, ESA, and R. Kirshner (Harv; This photo album of images from
 NASA/ESA Hubble Space Telescope shows a ring of gas beginning to glow around an
@@ -5758,6 +5995,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0705aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0705a.jpg
+astropix_ids: esahubble|heic0705a
 
 credits> NASA, ESA, Jean-Paul Kneib (Labo; While looking at the galaxy cluster
 Abell 2667, astronomers found an odd-looking spiral galaxy (shown here in the
@@ -5782,6 +6020,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0705bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0705b.jpg
+astropix_ids: esahubble|heic0705b
 
 credits> NASA, Spitzer Space Telescope; This infrared image was taken by NASA's
 Spitzer Space Telescope.and shows a part of the galaxy cluster Abell 2667. The
@@ -5806,6 +6045,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0705cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0705c.jpg
+astropix_ids: esahubble|heic0705c
 
 credits> Davide De Martin (ESA/Hubble), t; Part of the constellation Sculptor
 centred on galaxy cluster. This image is a colour composite taken by the
@@ -5830,6 +6070,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0706aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0706a.jpg
+astropix_ids: esahubble|heic0706a
 
 credits> NASA, ESA; The barred spiral galaxy NGC 1672, showing up clusters of
 hot young blue stars along its spiral arms, and clouds of hydrogen gas...
@@ -5853,6 +6094,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0706bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0706b.jpg
+astropix_ids: esahubble|heic0706b
 
 credits> Davide De Martin (ESA/Hubble), t; A 2.7 x 2.9 degree wide field
 ground-based image of NGC 1672's region in the Southern constellation of Dorado.
@@ -5877,6 +6119,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0707gL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0707g.jpg
+astropix_ids: esahubble|heic0707g
 
 credits> N. Smith and NOAO/AURA/NSF; This image shows a ground-based view of the
 giant star-forming region in the southern sky known as the Carina Nebula,
@@ -5901,6 +6144,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0708aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0708a.jpg
+astropix_ids: esahubble|heic0708a
 
 credits> European Space Agency, NASA, G. ; This NASA/ESA Hubble Space Telescope
 image of a dense swarm of stars shows the central region of the globular cluster
@@ -5925,6 +6169,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0708cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0708c.jpg
+astropix_ids: esahubble|heic0708c
 
 credits> Davide De Martin (ESA/Hubble), t; The globular cluster NGC 2808 as seen
 in the Digitized Sky Survey 2 (DSS2). The image is a colour composite from DSS2
@@ -5949,6 +6194,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0709bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0709b.jpg
+astropix_ids: esahubble|heic0709b
 
 credits> NASA, ESA, M.J. Jee and H. Ford ; An international team of astronomers
 using the NASA/ESA Hubble Space Telescope has discovered a ghostly ring of dark
@@ -5973,6 +6219,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0709dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0709d.jpg
+astropix_ids: esahubble|heic0709d
 
 credits> Davide De Martin (ESA/Hubble), t; ZwCl0024+1652 as seen in the
 Digitized Sky Survey 2 (DSS2). The image is a colour composite from DSS2 images.
@@ -5997,6 +6244,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0710bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0710b.jpg
+astropix_ids: esahubble|heic0710b
 
 credits> NASA, ESA and A. Zezas (Harvard-; This image combines data from the
 Hubble Space Telescope, the Spitzer Space Telescope and the Galaxy Evolution
@@ -6021,6 +6269,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0710dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0710d.jpg
+astropix_ids: esahubble|heic0710d
 
 credits> NASA, ESA and the Hubble Heritag; Inner bulge and nucleus of M81....
 
@@ -6043,6 +6292,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0710eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0710e.jpg
+astropix_ids: esahubble|heic0710e
 
 credits> NASA, ESA and the Hubble Heritag; Southern arm of M81 including a chain
 of HII regions....
@@ -6066,6 +6316,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0710fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0710f.jpg
+astropix_ids: esahubble|heic0710f
 
 credits> NASA, ESA and the Hubble Heritag; OB Associations in outer northern arm
 of M81....
@@ -6089,6 +6340,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0710gL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0710g.jpg
+astropix_ids: esahubble|heic0710g
 
 credits> NASA, ESA and the Hubble Heritag; Bulge-disk transition in M81 and
 chain of HII regions....
@@ -6112,6 +6364,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0710hL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0710h.jpg
+astropix_ids: esahubble|heic0710h
 
 credits> NASA, ESA and the Hubble Heritag; HII shell of M81 and background
 galaxies....
@@ -6135,6 +6388,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0710iL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0710i.jpg
+astropix_ids: esahubble|heic0710i
 
 credits> NASA, ESA and the Hubble Heritag; Southern extremity of the galaxy
 M81....
@@ -6158,6 +6412,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0710jL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0710j.jpg
+astropix_ids: esahubble|heic0710j
 
 credits> NASA, ESA and the Hubble Heritag; Background group of galaxies....
 
@@ -6180,6 +6435,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0711aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0711a.jpg
+astropix_ids: esahubble|heic0711a
 
 credits> NASA, ESA, A. Aloisi (STScI/ESA); Hundreds of thousands of vibrant blue
 and red stars are visible in this new image of galaxy NGC 4449 taken by the
@@ -6204,6 +6460,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0712aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0712a.jpg
+astropix_ids: esahubble|heic0712a
 
 credits> NASA, ESA, and the Hubble Herita; This image shows a small portion of
 the Veil Nebula - the shattered remains of a supernova that exploded some
@@ -6228,6 +6485,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0712bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0712b.jpg
+astropix_ids: esahubble|heic0712b
 
 credits> NASA, ESA, and the Hubble Herita; This image is a stunning close-up of
 the Veil Nebula - the shattered remains of a supernova that exploded some
@@ -6252,6 +6510,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0712cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0712c.jpg
+astropix_ids: esahubble|heic0712c
 
 credits> NASA, ESA, and the Hubble Herita; This image shows a beautiful portion
 of the Veil Nebula - the shattered remains of a supernova that exploded some
@@ -6276,6 +6535,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0712gL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0712g.jpg
+astropix_ids: esahubble|heic0712g
 
 credits> NASA, ESA, the Hubble Heritage (; A wide-field image of the Veil
 Nebula, made as a colour composite from individual exposures from the Digitized
@@ -6300,6 +6560,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0714bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0714b.jpg
+astropix_ids: esahubble|heic0714b
 
 credits> NASA, ESA, and N. Pirzkal (Europ; Building block galaxy at redshift of
 4.00 from Hubble Ultra Deep Field image....
@@ -6323,6 +6584,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0714cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0714c.jpg
+astropix_ids: esahubble|heic0714c
 
 credits> NASA, ESA, and N. Pirzkal (Europ; Building block galaxy at redshift of
 4.88 from Hubble Ultra Deep Field image....
@@ -6346,6 +6608,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0714dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0714d.jpg
+astropix_ids: esahubble|heic0714d
 
 credits> NASA, ESA, and N. Pirzkal (Europ; Building block galaxy at redshift of
 4.90 from Hubble Ultra Deep Field image....
@@ -6369,6 +6632,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0714eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0714e.jpg
+astropix_ids: esahubble|heic0714e
 
 credits> NASA, ESA, and N. Pirzkal (Europ; Building block galaxy at redshift of
 5.42 from Hubble Ultra Deep Field image....
@@ -6392,6 +6656,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0714fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0714f.jpg
+astropix_ids: esahubble|heic0714f
 
 credits> NASA, ESA, and N. Pirzkal (Europ; Building block galaxy at redshift of
 5.76 from Hubble Ultra Deep Field image....
@@ -6415,6 +6680,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0714gL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0714g.jpg
+astropix_ids: esahubble|heic0714g
 
 credits> NASA, ESA, and N. Pirzkal (Europ; The Hubble Ultra Deep Field Image....
 
@@ -6437,6 +6703,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0715cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0715c.jpg
+astropix_ids: esahubble|heic0715c
 
 credits> NASA, ESA, and the Digitized Sky; A wide-field image in the region of
 NGC 3603 taken on the ground by the Digitized Sky Survey 2. The glowing clouds
@@ -6461,6 +6728,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0716aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0716a.jpg
+astropix_ids: esahubble|heic0716a
 
 credits> NASA, ESA, and A. Aloisi (Europe; The NASA/ESA Hubble Space Telescope
 quashed the possibility that what was previously believed to be a toddler galaxy
@@ -6485,6 +6753,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0716cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0716c.jpg
+astropix_ids: esahubble|heic0716c
 
 credits> NASA, ESA, and the Digitized Sky; A wide field image of the sky around
 the galaxy I Zwicky 18 taken on the ground by the Digitized Sky Survey 2. The
@@ -6509,6 +6778,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0717aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0717a.jpg
+astropix_ids: esahubble|heic0717a
 
 credits> NASA, ESA, and The Hubble Herita; Arp 87 is a stunning pair of
 interacting galaxies. Stars, gas, and dust flow from the large spiral galaxy,
@@ -6533,6 +6803,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0717bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0717b.jpg
+astropix_ids: esahubble|heic0717b
 
 credits> NASA, ESA, and the Digitized Sky; An image of the region of sky around
 Arp 87. The interacting galaxies can just be seen towards the centre of the
@@ -6557,6 +6828,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0719aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0719a.jpg
+astropix_ids: esahubble|heic0719a
 
 credits> NASA, ESA, and The Hubble Herita; In the new Hubble image of the galaxy
 M74 we can also see a smattering of bright pink regions decorating the spiral
@@ -6581,6 +6853,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0719bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0719b.jpg
+astropix_ids: esahubble|heic0719b
 
 credits> NASA, ESA, and the Digitized Sky; An image of the region of sky around
 M74, the "Phantom Galaxy", from the Digitized Sky Survey 2. The field-of-view is
@@ -6605,6 +6878,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0720dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0720d.jpg
+astropix_ids: esahubble|heic0720d
 
 credits> NASA, ESA, and the Digitized Sky; A wide star field image of the region
 around HD 189733b. In the centre is the star HD 189733 and just to the right is
@@ -6629,6 +6903,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0801bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0801b.jpg
+astropix_ids: esahubble|heic0801b
 
 credits> NASA, ESA, and D. de Mello (Cath; A GALEX ultraviolet image of the
 interacting galaxies M81 and M82, which lie 12 million light-years away in the
@@ -6653,6 +6928,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0801cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0801c.jpg
+astropix_ids: esahubble|heic0801c
 
 credits> NASA, ESA, and D. de Mello (Cath; A Hubble Space Telescope visible
 light image of bright blue star clusters found along a wispy bridge of gas that
@@ -6677,6 +6953,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0801dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0801d.jpg
+astropix_ids: esahubble|heic0801d
 
 credits> NASA, ESA, and D. de Mello (Cath; A Hubble Space Telescope visible
 light close-up of bright blue star clusters in Arp's Loop in the M81-M82 galaxy
@@ -6701,6 +6978,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0801eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0801e.jpg
+astropix_ids: esahubble|heic0801e
 
 credits> NASA, ESA, and D. de Mello (Cath; A Hubble Space Telescope visible
 light close-up of bright blue star clusters in Arp's Loop in the M81-M82 galaxy
@@ -6725,6 +7003,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0801fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0801f.jpg
+astropix_ids: esahubble|heic0801f
 
 credits> NASA, ESA, and D. de Mello (Cath; A Hubble Space Telescope visible
 light close-up of bright blue star clusters in Arp's Loop in the M81-M82 galaxy
@@ -6749,6 +7028,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0801gL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0801g.jpg
+astropix_ids: esahubble|heic0801g
 
 credits> NASA, ESA, and the Hubble Herita; This loose collection of stars is
 actually a dwarf irregular galaxy, called Holmberg IX. It resides just off the
@@ -6773,6 +7053,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0802bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0802b.jpg
+astropix_ids: esahubble|heic0802b
 
 credits> Hubble images: NASA, ESA, C. Heymans (University of British Columbia,
 Vancouver), M. Gray (University of Nottingham, U.K.), M. Barden (Innsbruck), and
@@ -6799,6 +7080,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0802cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0802c.jpg
+astropix_ids: esahubble|heic0802c
 
 credits> Hubble images: NASA, ESA, C. Heymans (University of British Columbia,
 Vancouver), M. Gray (University of Nottingham, U.K.), M. Barden (Innsbruck), and
@@ -6825,6 +7107,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0802dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0802d.jpg
+astropix_ids: esahubble|heic0802d
 
 credits> Hubble images: NASA, ESA, C. Heymans (University of British Columbia,
 Vancouver), M. Gray (University of Nottingham, U.K.), M. Barden (Innsbruck), and
@@ -6851,6 +7134,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0802eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0802e.jpg
+astropix_ids: esahubble|heic0802e
 
 credits> Hubble images: NASA, ESA, C. Heymans (University of British Columbia,
 Vancouver), M. Gray (University of Nottingham, U.K.), M. Barden (Innsbruck), and
@@ -6877,6 +7161,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0802fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0802f.jpg
+astropix_ids: esahubble|heic0802f
 
 credits> Hubble images: NASA, ESA, C. Heymans (University of British Columbia,
 Vancouver), M. Gray (University of Nottingham, U.K.), M. Barden (Innsbruck), and
@@ -6903,6 +7188,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0803bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0803b.jpg
+astropix_ids: esahubble|heic0803b
 
 credits> NASA, ESA, and R. Gavazzi and T.; This is an image of gravitational
 lens system SDSSJ0946+1006 as photographed by Hubble Space Telescope's Advanced
@@ -6927,6 +7213,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0803cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0803c.jpg
+astropix_ids: esahubble|heic0803c
 
 credits> NASA, ESA, and R. Gavazzi and T.; This is a close-up of a gravitational
 lens showing two concentric partial ring-like structures after subtracting the
@@ -6951,6 +7238,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0804aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0804a.jpg
+astropix_ids: esahubble|heic0804a
 
 credits> NASA, ESA and the Hubble Heritag; The NASA/ESA Hubble Space Telescope
 has captured a new image of the galaxy NGC 1132 which is, most likely, a cosmic
@@ -6975,6 +7263,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0804bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0804b.jpg
+astropix_ids: esahubble|heic0804b
 
 credits> NASA, ESA, M. West (ESO, Chile),; This image of the elliptical galaxy
 NGC 1132 combines an image from NASA's Chandra X-Ray Observatory obtained in
@@ -6999,6 +7288,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0804dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0804d.jpg
+astropix_ids: esahubble|heic0804d
 
 credits> NASA, ESA, and Digitized Sky Sur; This is a wide-field view of the
 region around NGC 1132, in the constellation of Eridanus, the River. The
@@ -7023,6 +7313,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0805eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0805e.jpg
+astropix_ids: esahubble|heic0805e
 
 credits> NASA; ESA; L. Bradley (Johns Hop; The gravity of the cluster's trillion
 stars acts as a cosmic "zoom lens", bending and magnifying the light of the
@@ -7047,6 +7338,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0805fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0805f.jpg
+astropix_ids: esahubble|heic0805f
 
 credits> NASA; ESA; L. Bradley (Johns Hop; The distant galaxy, dubbed A1689-zD1,
 appears as a greyish-white smudge in the close-up view taken with Hubble's
@@ -7071,6 +7363,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0805gL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0805g.jpg
+astropix_ids: esahubble|heic0805g
 
 credits> NASA; ESA; L. Bradley (Johns Hop; The distant galaxy, dubbed A1689-zD1,
 appears as a whitish blob in the Spitzer IRAC close-up view. The galaxy is
@@ -7095,6 +7388,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0806dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0806d.jpg
+astropix_ids: esahubble|heic0806d
 
 credits> NASA, ESA, C. Faure (Zentrum fü; An Einstein ring can be seen in this
 image from the COSMOS project. An Einstein ring is a complete circle image of a
@@ -7119,6 +7413,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0806eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0806e.jpg
+astropix_ids: esahubble|heic0806e
 
 credits> NASA, ESA, C. Faure (Zentrum fü; This lens is an example of the rich
 diversity of 67 strong gravitational lenses found in the COSMOS survey. The
@@ -7143,6 +7438,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0806fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0806f.jpg
+astropix_ids: esahubble|heic0806f
 
 credits> NASA, ESA, C. Faure (Zentrum fü; An Einstein ring can be seen in this
 image of the gravitational lens 5921+0638 from the COSMOS survey. An Einstein
@@ -7167,6 +7463,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0806gL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0806g.jpg
+astropix_ids: esahubble|heic0806g
 
 credits> NASA, ESA, C. Faure (Zentrum fü; This is a triple gravitational lens,
 an example of the rich diversity of the 67 strong gravitational lenses found in
@@ -7191,6 +7488,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0806hL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0806h.jpg
+astropix_ids: esahubble|heic0806h
 
 credits> NASA, ESA, C. Faure (Zentrum fü; This lens is an example of the rich
 diversity of 67 strong gravitational lenses found in the COSMOS survey. The
@@ -7215,6 +7513,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0806iL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0806i.jpg
+astropix_ids: esahubble|heic0806i
 
 credits> NASA, ESA, C. Faure (Zentrum fü; This lens is an example of the rich
 diversity of 67 strong gravitational lenses found in the COSMOS survey. It shows
@@ -7239,6 +7538,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0807bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0807b.jpg
+astropix_ids: esahubble|heic0807b
 
 credits> NASA, ESA, and the Digitized Sky; A wide star field image of the region
 around HD 189733b. The star HD 189733 is located in the centre, just to the left
@@ -7263,6 +7563,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0808aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0808a.jpg
+astropix_ids: esahubble|heic0808a
 
 credits> NASA, ESA & Stephen Smartt (Quee; NGC 2397, pictured in this image from
 Hubble, is a classic spiral galaxy with long prominent dust lanes along the
@@ -7287,6 +7588,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0809aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0809a.jpg
+astropix_ids: esahubble|heic0809a
 
 credits> NASA, ESA and the Hubble Heritag; A new discovery has resolved some of
 the mystery surrounding Omega Centauri, the largest and brightest globular
@@ -7311,6 +7613,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0809bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0809b.jpg
+astropix_ids: esahubble|heic0809b
 
 credits> NASA, ESA, and the Digitized Sky; A wide star field image of the region
 around Omega Centauri (NGC 5139). The field-of-view is approximately 4.6 x 4.1
@@ -7335,6 +7638,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810afL{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0810af.jpg
+astropix_ids: esahubble|heic0810af
 
 credits> NASA, ESA, the Hubble Heritage T; Arp 302 consists of a pair of very
 gas-rich spiral galaxies in their early stages of interaction: VV 340A is seen
@@ -7359,6 +7663,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810agL{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0810ag.jpg
+astropix_ids: esahubble|heic0810ag
 
 credits> NASA, ESA, the Hubble Heritage T; Arp 256 is a stunning system of two
 spiral galaxies in an early stage of merging. The Hubble image displays two
@@ -7383,6 +7688,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810ahL{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0810ah.jpg
+astropix_ids: esahubble|heic0810ah
 
 credits> NASA, ESA, the Hubble Heritage T; NGC 6670 is a gorgeous pair of
 overlapping edge-on galaxies. Scientists believe that NGC 6670 has already
@@ -7407,6 +7713,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810ajL{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0810aj.jpg
+astropix_ids: esahubble|heic0810aj
 
 credits> NASA, ESA, the Hubble Heritage T; ESO 593-8 is an impressive pair of
 interacting galaxies with a feather-like galaxy crossing a companion galaxy. The
@@ -7431,6 +7738,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810akL{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0810ak.jpg
+astropix_ids: esahubble|heic0810ak
 
 credits> NASA, ESA, the Hubble Heritage T; NGC 454 is galaxy pair comprising a
 large red elliptical galaxy and an irregular gas-rich blue galaxy. The system is
@@ -7455,6 +7763,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810alL{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0810al.jpg
+astropix_ids: esahubble|heic0810al
 
 credits> NASA, ESA, the Hubble Heritage T; UGC 8335 is a strongly interacting
 pair of spiral galaxies resembling two ice skaters. The interaction has united
@@ -7479,6 +7788,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810amL{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0810am.jpg
+astropix_ids: esahubble|heic0810am
 
 credits> NASA, ESA, the Hubble Heritage T; This Hubble image displays a
 beautiful pair of interacting spiral galaxies with swirling arms. The smaller of
@@ -7503,6 +7813,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810anL{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0810an.jpg
+astropix_ids: esahubble|heic0810an
 
 credits> NASA, ESA, the Hubble Heritage T; This galaxy features a single
 nucleus, a containing a blue central disc with delicate fine structure in the
@@ -7527,6 +7838,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810aoL{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0810ao.jpg
+astropix_ids: esahubble|heic0810ao
 
 credits> NASA, ESA, the Hubble Heritage T; This Hubble image of ESO 77-14 is a
 stunning snapshot of a celestial dance performed by a pair of similar-sized
@@ -7551,6 +7863,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810apL{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0810ap.jpg
+astropix_ids: esahubble|heic0810ap
 
 credits> NASA, ESA, the Hubble Heritage T; Arp 272 is a remarkable collision
 between two spiral galaxies, NGC 6050 and IC 1179, and is part of the Hercules
@@ -7575,6 +7888,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810aqL{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0810aq.jpg
+astropix_ids: esahubble|heic0810aq
 
 credits> NASA, ESA, the Hubble Heritage T; NGC 520 is the product of a collision
 between two disc galaxies that started 300 million years ago. It exemplifies the
@@ -7599,6 +7913,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810arL{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0810ar.jpg
+astropix_ids: esahubble|heic0810ar
 
 credits> NASA, ESA, the Hubble Heritage T; NGC 3256 is an impressive example of
 a peculiar galaxy that is actually the relict of a collision of two separate
@@ -7623,6 +7938,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810asL{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0810as.jpg
+astropix_ids: esahubble|heic0810as
 
 credits> NASA, ESA, the Hubble Heritage T; This system consists of a pair of
 galaxies, dubbed IC 694 and NGC 3690, which made a close pass some 700 million
@@ -7647,6 +7963,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810atL{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0810at.jpg
+astropix_ids: esahubble|heic0810at
 
 credits> NASA, ESA, the Hubble Heritage T; Arp 240 is an astonishing galaxy
 pair, composed of spiral galaxies of similar mass and size, NGC 5257 and NGC
@@ -7671,6 +7988,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810auL{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0810au.jpg
+astropix_ids: esahubble|heic0810au
 
 credits> NASA, ESA, the Hubble Heritage T; IC 883 displays a very disturbed,
 complex central region with two tidal tails of approximately the same length
@@ -7695,6 +8013,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810avL{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0810av.jpg
+astropix_ids: esahubble|heic0810av
 
 credits> NASA, ESA, the Hubble Heritage T; Markarian 273 is a galaxy with a
 bizarre structure that somewhat resembles a toothbrush. The Hubble image shows
@@ -7719,6 +8038,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810awL{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0810aw.jpg
+astropix_ids: esahubble|heic0810aw
 
 credits> NASA, ESA, the Hubble Heritage T; ESO 99-4 is a galaxy with a highly
 peculiar shape that is probably the remnant of an earlier merger process that
@@ -7743,6 +8063,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810axL{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0810ax.jpg
+astropix_ids: esahubble|heic0810ax
 
 credits> NASA, ESA, the Hubble Heritage T; The galaxy system NGC 1614 has a
 bright optical centre and two clear inner spiral arms that are fairly
@@ -7767,6 +8088,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810ayL{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0810ay.jpg
+astropix_ids: esahubble|heic0810ay
 
 credits> NASA, ESA, the Hubble Heritage T; NGC 6090 is a beautiful pair of
 spiral galaxies with an overlapping central region and two long tidal tails
@@ -7791,6 +8113,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810azL{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0810az.jpg
+astropix_ids: esahubble|heic0810az
 
 credits> NASA, ESA, the Hubble Heritage T; This is a beautiful face-on spiral
 galaxy with two long arms extending from the central bulge and curving back
@@ -7815,6 +8138,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0812bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0812b.jpg
+astropix_ids: esahubble|heic0812b
 
 credits> NASA, ESA & Ivo Saviane (Europea; The Hubble ACS image shows a portion
 of the southern tidal tail of the Antennae galaxies. The main visible component
@@ -7839,6 +8163,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0812cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0812c.jpg
+astropix_ids: esahubble|heic0812c
 
 credits> Robert Gendler; This ground-based image was taken by Robert Gendler and
 shows the two merging Antennae Galaxies (NGC 4038 and NGC 4039) and thei...
@@ -7862,6 +8187,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0812dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0812d.jpg
+astropix_ids: esahubble|heic0812d
 
 credits> ESA/Hubble and Digitized Sky Sur; This image is a colour composite made
 from exposures from the Digitized Sky Survey 2 (DSS2). The field of view is 2.8
@@ -7886,6 +8212,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0813aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0813a.jpg
+astropix_ids: esahubble|heic0813a
 
 credits> NASA, ESA, and the Hubble Herita; Hubble's Advanced Camera for Surveys
 has viewed a large portion of the Coma Cluster, stretching across several
@@ -7910,6 +8237,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0813bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0813b.jpg
+astropix_ids: esahubble|heic0813b
 
 credits> NASA, ESA, and the Hubble Herita; On the right, a spiral galaxy in the
 Coma Cluster....
@@ -7933,6 +8261,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0813cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0813c.jpg
+astropix_ids: esahubble|heic0813c
 
 credits> NASA, ESA, and the Hubble Herita; Varied galaxy types in the Coma
 Cluster....
@@ -7956,6 +8285,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0813dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0813d.jpg
+astropix_ids: esahubble|heic0813d
 
 credits> NASA, ESA, and the Hubble Herita; Lenticular galaxy in the Coma Cluster
 with numerous background galaxies....
@@ -7979,6 +8309,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0813eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0813e.jpg
+astropix_ids: esahubble|heic0813e
 
 credits> NASA, ESA, and the Digitized Sky; A wide star field image of the region
 around the Coma Cluster (Abell 1656). The field-of-view is approximately 2.7 x
@@ -8003,6 +8334,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0814aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0814a.jpg
+astropix_ids: esahubble|heic0814a
 
 credits> NASA, ESA, and Johan Richard (Ca; The picture shows Abell 2218, a rich
 galaxy cluster composed of thousands of individual galaxies. It sits about 2.1
@@ -8027,6 +8359,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0814bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0814b.jpg
+astropix_ids: esahubble|heic0814b
 
 credits> NASA, ESA, and Johan Richard (Ca; Located in the northern celestial
 hemisphere, Abell 1703 is composed of over one hundred different galaxies that
@@ -8051,6 +8384,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0814cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0814c.jpg
+astropix_ids: esahubble|heic0814c
 
 credits> NASA, ESA, and Johan Richard (Ca; ZwCl 1358+62 is located 3.7 billion
 light-years from Earth (z=0.33) and is made up of at least 150 individual
@@ -8075,6 +8409,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0814dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0814d.jpg
+astropix_ids: esahubble|heic0814d
 
 credits> NASA, ESA, and Johan Richard (Ca; Located 2.7 billion light-years from
 the Earth (redshift 0.23), Abell 2390 is located in the constellation Pegasus.
@@ -8099,6 +8434,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0815bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0815b.jpg
+astropix_ids: esahubble|heic0815b
 
 credits> ESA, NASA and E. Peng (Peking Un; Virgo cluster galaxy NGC 4660, na
 elliptical located about 50 million light-years from Earth. Hubble's "eye" is so
@@ -8123,6 +8459,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0815cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0815c.jpg
+astropix_ids: esahubble|heic0815c
 
 credits> ESA, NASA and E. Peng (Peking Un; Virgo cluster galaxy NGC 4458.
 Hubble's "eye" is so sharp that it was able to pick out the fuzzy globular
@@ -8147,6 +8484,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0815dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0815d.jpg
+astropix_ids: esahubble|heic0815d
 
 credits> ESA, NASA and E. Peng (Peking Un; Virgo cluster galaxy IC 3506.
 Hubble's "eye" is so sharp that it was able to pick out the fuzzy globular
@@ -8171,6 +8509,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0815eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0815e.jpg
+astropix_ids: esahubble|heic0815e
 
 credits> ESA, NASA and E. Peng (Peking Un; Virgo cluster galaxy VCC 1993.
 Hubble's "eye" is so sharp that it was able to pick out the fuzzy globular
@@ -8195,6 +8534,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0815fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0815f.jpg
+astropix_ids: esahubble|heic0815f
 
 credits> NASA, ESA, and the Hubble Herita; The monstrous elliptical galaxy M87
 is the home of several trillion stars, a supermassive black hole, and family of
@@ -8219,6 +8559,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0815iL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0815i.jpg
+astropix_ids: esahubble|heic0815i
 
 credits> NASA, ESA, and the Digitized Sky; Virgo cluster of galaxies image taken
 with the Palomar Observatory 48-inch Schmidt telescope as part of the Digitized
@@ -8243,6 +8584,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0815jL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0815j.jpg
+astropix_ids: esahubble|heic0815j
 
 credits> NASA, ESA, and Z. ; This image is a composite of visible (or optical),
 radio, and X-ray data of the giant elliptical galaxy, M87. M87 lies at a dis...
@@ -8266,6 +8608,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0816aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0816a.jpg
+astropix_ids: esahubble|heic0816a
 
 credits> NASA, ESA and M. Livio (STScI); In commemoration of the NASA/ESA Hubble
 Space Telescope completing its 100 000th orbit around the Earth in its 18th year
@@ -8290,6 +8633,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0817bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0817b.jpg
+astropix_ids: esahubble|heic0817b
 
 credits> NASA, ESA, NRAO and L. Frattare ; The behemoth galaxy NGC 1275, also
 known as Perseus A, lies at the centre of Perseus Galaxy Cluster. By combining
@@ -8314,6 +8658,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0817cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0817c.jpg
+astropix_ids: esahubble|heic0817c
 
 credits> NASA, ESA, and the Digitized Sky; Located around 235 million
 light-years away from Earth, The Perseus Galaxy Cluster is one of the closest to
@@ -8338,6 +8683,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0818aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0818a.jpg
+astropix_ids: esahubble|heic0818a
 
 credits> NASA, ESA, CXC, M. Bradac (Unive; This astounding view of galaxy
 cluster MACSJ0025 demonstrates how ordinary matter and mysterious dark matter
@@ -8362,6 +8708,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0819bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0819b.jpg
+astropix_ids: esahubble|heic0819b
 
 credits> NASA, ESA, J. Dalcanton and B. W; NGC 253 is one of brightest spiral
 galaxies in the night sky, easily visible with small telescopes, and it is
@@ -8386,6 +8733,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0819cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0819c.jpg
+astropix_ids: esahubble|heic0819c
 
 credits> NASA, ESA, J. Dalcanton and B. W; In this view of the spiral galaxy NGC
 300, young, blue stars are concentrated in spiral arms that sweep diagonally
@@ -8410,6 +8758,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0819dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0819d.jpg
+astropix_ids: esahubble|heic0819d
 
 credits> NASA, ESA, J. Dalcanton and B. W; The dark clumps of material scattered
 around the bright nucleus of NGC 3077 are pieces of wreckage from the galaxy's
@@ -8434,6 +8783,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0819eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0819e.jpg
+astropix_ids: esahubble|heic0819e
 
 credits> NASA, ESA, J. Dalcanton and B. W; This image shows a swarm of young,
 blue stars in the diffuse dwarf irregular galaxy NGC 4163. It is a member of a
@@ -8458,6 +8808,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0819fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0819f.jpg
+astropix_ids: esahubble|heic0819f
 
 credits> NASA, ESA, J. Dalcanton and B. W; Hubble's Advanced Camera for Surveys
 shows individual as well as clusters of stars in the spiral galaxy NGC 300,
@@ -8482,6 +8833,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0819gL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0819g.jpg
+astropix_ids: esahubble|heic0819g
 
 credits> NASA, ESA, J. Dalcanton and B. W; Hubble's Advanced Camera for Surveys
 shows individual stars, clusters of stars and nebulae in the spiral galaxy NGC
@@ -8506,6 +8858,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0819hL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0819h.jpg
+astropix_ids: esahubble|heic0819h
 
 credits> NASA, ESA, J. Dalcanton and B. W; Hubble's Advanced Camera for Surveys
 shows individual stars and clusters of stars in the spiral galaxy NGC 300,
@@ -8530,6 +8883,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0820aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0820a.jpg
+astropix_ids: esahubble|heic0820a
 
 credits> NASA, ESA and M. Livio (STScI); The NASA/ESA Hubble Space Telescope is
 back in business. Just a couple of days after the orbiting observatory was
@@ -8554,6 +8908,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0821fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0821f.jpg
+astropix_ids: esahubble|heic0821f
 
 credits> NASA, ESA, and the Digitized Sky; This image shows Fomalhaut, the star
 around which the newly discovered planet orbits. Fomalhaut is much hotter than
@@ -8578,6 +8933,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0822aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0822a.jpg
+astropix_ids: esahubble|heic0822a
 
 credits> NASA, ESA and Jesús Maíz Apell; The image shows a pair of colossal
 stars, WR 25 and Tr16-244, located within the open cluster Trumpler 16. This
@@ -8602,6 +8958,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0822bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0822b.jpg
+astropix_ids: esahubble|heic0822b
 
 credits> NASA, ESA and Jesús Maíz Apell; WR 25 and Tr16-244, at the bottom of
 the image, are located within the open cluster Trumpler 16. This cluster is
@@ -8626,6 +8983,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0822cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0822c.jpg
+astropix_ids: esahubble|heic0822c
 
 credits> NASA, ESA and Jesús Maíz Apell; In WR 25 two of the stars are so close
 to each other that they look like a single object, but Hubble's Advanced Camera
@@ -8650,6 +9008,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0901aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0901a.jpg
+astropix_ids: esahubble|heic0901a
 
 credits> NASA, ESA and K. Cook (Lawrence ; This very deep image taken with the
 NASA/ESA Hubble Space Telescope shows the spiral galaxy NGC 4921 along with a
@@ -8674,6 +9033,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0901cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0901c.jpg
+astropix_ids: esahubble|heic0901c
 
 credits> NASA, ESA, and the Digitized Sky; A wide-field image of the region
 around the Coma Galaxy Cluster (Abell 1656) constructed from the images in the
@@ -8698,6 +9058,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0902aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0902a.jpg
+astropix_ids: esahubble|heic0902a
 
 credits> NASA, ESA and R. Sharples (Unive; The three pictured galaxies - NGC
 7173 (middle left), NCG 7174 (middle right) and NGC 7176 (lower right) - are
@@ -8722,6 +9083,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0903bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0903b.jpg
+astropix_ids: esahubble|heic0903b
 
 credits> NASA, ESA and C. Conselice (Univ; This object, [CGW2003]
 J031931.7+4131, is one of four dwarf galaxies that is part of a census of small
@@ -8746,6 +9108,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0903cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0903c.jpg
+astropix_ids: esahubble|heic0903c
 
 credits> NASA, ESA and C. Conselice (Univ; This object, [CGW2003]
 J031910.4+4129, is one of four dwarf galaxies that is part of a census of small
@@ -8770,6 +9133,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0903dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0903d.jpg
+astropix_ids: esahubble|heic0903d
 
 credits> NASA, ESA and C. Conselice (Univ; This object, [CGW2003]
 J031900.4+4129, is one of four dwarf galaxies that is part of a census of small
@@ -8794,6 +9158,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0903eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0903e.jpg
+astropix_ids: esahubble|heic0903e
 
 credits> NASA, ESA and C. Conselice (Univ; This object, [CGW2003]
 J031905.2+4134, is one of four dwarf galaxies that is part of a census of small
@@ -8818,6 +9183,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0905bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0905b.jpg
+astropix_ids: esahubble|heic0905b
 
 credits> NASA, ESA, and the Digitized Sky; A wide-field image of the region
 around NGC 7049 constructed from the images in the Digitized Sky Survey. The
@@ -8842,6 +9208,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0906aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0906a.jpg
+astropix_ids: esahubble|heic0906a
 
 credits> NASA, ESA and the Hubble Heritag; This brilliant image, courtesy of
 NASA/ESA's Hubble Space Telescope, is a fitting 19th anniversary tribute to the
@@ -8866,6 +9233,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0910bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0910b.jpg
+astropix_ids: esahubble|heic0910b
 
 credits> NASA, ESA, the Hubble SM4 ERO Te; The NASA/ESA Hubble Space Telescope's
 newly repaired Advanced Camera for Surveys (ACS) has peered across almost five
@@ -8890,6 +9258,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0910eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0910e.jpg
+astropix_ids: esahubble|heic0910e
 
 credits> NASA, ESA and the Hubble SM4 ERO; Composed of gas and dust, the
 pictured pillar resides in a tempestuous stellar nursery called the Carina
@@ -8914,6 +9283,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0910fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0910f.jpg
+astropix_ids: esahubble|heic0910f
 
 credits> NASA, ESA and the Hubble SM4 ERO; Composed of gas and dust, the
 pictured pillar resides in a tempestuous stellar nursery called the Carina
@@ -8938,6 +9308,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0910gL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0910g.jpg
+astropix_ids: esahubble|heic0910g
 
 credits> NASA, ESA and the Hubble SM4 ERO; The NASA/ESA Hubble Space Telescope
 snapped this panoramic view of a colourful assortment of 100 000 stars residing
@@ -8962,6 +9333,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0910jL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0910j.jpg
+astropix_ids: esahubble|heic0910j
 
 credits> NASA, ESA and the Hubble SM4 ERO; The wispy, glowing, magenta
 structures in this NASA/ESA Hubble Space Telescope image are the remains of a
@@ -8986,6 +9358,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0910mL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0910m.jpg
+astropix_ids: esahubble|heic0910m
 
 credits> NASA, ESA, the Hubble SM4 ERO Te; This image is a colour composite made
 from exposures from the Digitized Sky Survey 2 (DSS2). The field of view is
@@ -9010,6 +9383,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0910nL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0910n.jpg
+astropix_ids: esahubble|heic0910n
 
 credits> NASA, ESA and the Hubble SM4 ERO; Rings of brilliant blue stars
 encircle the bright, active core of this spiral galaxy, whose monster black hole
@@ -9034,6 +9408,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0910tL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0910t.jpg
+astropix_ids: esahubble|heic0910t
 
 credits> NASA, ESA and Digitized Sky Surv; This image is a colour composite made
 from exposures from the Digitized Sky Survey 2 (DSS2). The field of view is
@@ -9058,6 +9433,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0911bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0911b.jpg
+astropix_ids: esahubble|heic0911b
 
 credits> NASA & ESA; Hubble's Advanced Camera for Surveys (ACS) allows
 astronomers to study an interesting and important phenomenon called ram
@@ -9082,6 +9458,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0911cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0911c.jpg
+astropix_ids: esahubble|heic0911c
 
 credits> NASA & ESA; The image of NGC 4402 highlights some telltale signs of ram
 pressure stripping such as the curved, or convex, appearance of the ...
@@ -9105,6 +9482,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0911dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0911d.jpg
+astropix_ids: esahubble|heic0911d
 
 credits> NASA, ESA and the Digitized Sky ; A wide-field image of the region
 around NGC 4522 constructed from the images in the Digitized Sky Survey. The
@@ -9129,6 +9507,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0911fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0911f.jpg
+astropix_ids: esahubble|heic0911f
 
 credits> NASA, ESA and the Digitized Sky ; A wide-field image of the region
 around NGC 4402 constructed from the images in the Digitized Sky Survey. The
@@ -9153,6 +9532,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0912aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0912a.jpg
+astropix_ids: esahubble|heic0912a
 
 credits> NASA, ESA and A. Evans (Stony Br; Not surprisingly, interacting
 galaxies have a dramatic effect on each other. Studies have revealed that as
@@ -9177,6 +9557,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0912bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0912b.jpg
+astropix_ids: esahubble|heic0912b
 
 credits> NASA, ESA and the Digitized Sky ; A wide-field image of the region
 around NGC 2623 constructed from Digitized Sky Survey 2 images. The field of
@@ -9201,6 +9582,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0913aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0913a.jpg
+astropix_ids: esahubble|heic0913a
 
 credits> NASA/ESA and Jesús Maíz Apell; This image is a "close-up' view from the
 NASA/ESA Hubble Space Telescope of NGC 4755, or the Jewel Box cluster. Several
@@ -9225,6 +9607,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0913bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0913b.jpg
+astropix_ids: esahubble|heic0913b
 
 credits> ESO; The FORS1 instrument on the ESO Very Large Telescope (VLT) at
 ESO's Paranal Observatory was used to take this exquisitely sharp ...
@@ -9248,6 +9631,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0913cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0913c.jpg
+astropix_ids: esahubble|heic0913c
 
 credits> ESO; This image of the well-known NGC 4755 cluster or Jewel Box was
 taken with the Wide Field Imager (WFI) on the MPG/ESO 2.2-metre t...
@@ -9271,6 +9655,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0913dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0913d.jpg
+astropix_ids: esahubble|heic0913d
 
 credits> ESO, ESA/Hubble and Digitized Sk; A wide-field image of the region
 around NGC 4755 constructed from the data from Digitized Sky Survey 2. The
@@ -9295,6 +9680,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0914aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0914a.jpg
+astropix_ids: esahubble|heic0914a
 
 credits> NASA & ESA; Still an astrophysical mystery, the evolution of the bulges
 in spiral galaxies led astronomers to the edge-on galaxy NGC 4710. W...
@@ -9318,6 +9704,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0914bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0914b.jpg
+astropix_ids: esahubble|heic0914b
 
 credits> NASA & ESA; Still an astrophysical mystery, the evolution of the bulges
 in spiral galaxies led astronomers to the edge-on galaxy NGC 4710. W...
@@ -9341,6 +9728,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0914cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0914c.jpg
+astropix_ids: esahubble|heic0914c
 
 credits> NASA, ESA and Digitized Sky Surv; A wide-field image of the region
 around NGC 4710 constructed from Digitized Sky Survey 2 data. The field of view
@@ -9365,6 +9753,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0915aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0915a.jpg
+astropix_ids: esahubble|heic0915a
 
 credits> NASA & ESA; This close-up of an area in the northwest region of the
 large Iris Nebula seems to be clogged with cosmic dust. With bright ligh...
@@ -9388,6 +9777,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0915bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0915b.jpg
+astropix_ids: esahubble|heic0915b
 
 credits> NASA, ESA and Digitized Sky Surv; A wide-field image of the region
 around NGC 7023 constructed from Digitized Sky Survey 2 data. The field of view
@@ -9412,6 +9802,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0916aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0916a.jpg
+astropix_ids: esahubble|heic0916a
 
 credits> NASA, ESA, G. Illingworth (UCO/L; In 2004, Hubble created the deepest
 visible-light image of the Universe and now, with its brand-new camera, Hubble
@@ -9436,6 +9827,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0918aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0918a.jpg
+astropix_ids: esahubble|heic0918a
 
 credits> NASA/ ESA; This brilliant image of Messier 30 (M 30) was taken by
 Hubble's Advanced Camera for Surveys (ACS). Messier 30 formed 13 billion ...
@@ -9459,6 +9851,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0918cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic0918c.jpg
+astropix_ids: esahubble|heic0918c
 
 credits> ESO and Digitized Sky Survey 2Ac; This wide-field image of the sky
 around the globular cluster Messier 30 was created from photographs forming part
@@ -9483,6 +9876,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1001bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1001b.jpg
+astropix_ids: esahubble|heic1001b
 
 credits> NASA, ESA, G. Illingworth (UCO/L; This Hubble image taken by the
 observatory’s new Wide Field Camera 3 in Infrared highlights some of the oldest
@@ -9507,6 +9901,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1001cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1001c.jpg
+astropix_ids: esahubble|heic1001c
 
 credits> NASA, ESA, G. Illingworth (UCO/L; This Hubble image taken by the
 observatory's new Wide Field Camera 3 in infrared light highlights some of the
@@ -9531,6 +9926,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1004aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1004a.jpg
+astropix_ids: esahubble|heic1004a
 
 credits> NASA, ESA and Michael West (ESO); This image from the Advanced Camera
 for Surveys aboard the NASA/ESA Hubble Space Telescope highlights the large and
@@ -9555,6 +9951,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1005aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1005a.jpg
+astropix_ids: esahubble|heic1005a
 
 credits> NASA, ESA, P. Simon (University ; This image shows a smoothed
 reconstruction of the total (mostly dark) matter distribution in the COSMOS
@@ -9579,6 +9976,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1005dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1005d.jpg
+astropix_ids: esahubble|heic1005d
 
 credits> ESA/Hubble & Digitized Sky Surve; This image shows the COSMOS field and
 is a colour composite made from Digitized Sky Survey 2 (DSS2) exposure. The
@@ -9603,6 +10001,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1006aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1006a.jpg
+astropix_ids: esahubble|heic1006a
 
 credits> NASA, ESA and the Hubble Heritag; Hubble has snapped a spectacular view
 of M 66, the largest "player" of the Leo Triplet, and a galaxy with an unusual
@@ -9627,6 +10026,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1006bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1006b.jpg
+astropix_ids: esahubble|heic1006b
 
 credits> NASA, ESA and and Digitized Sky ; This wide-field image of the sky
 around the spiral galaxy Messier 66 was created from photographs forming part of
@@ -9651,6 +10051,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1007aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1007a.jpg
+astropix_ids: esahubble|heic1007a
 
 credits> NASA, ESA, M. Livio and the Hubb; This craggy fantasy mountaintop
 enshrouded by wispy clouds looks like a bizarre landscape from Tolkien’s The
@@ -9675,6 +10076,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1007cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1007c.jpg
+astropix_ids: esahubble|heic1007c
 
 credits> NASA, ESA and M. Livio and the H; This craggy fantasy mountaintop
 enshrouded by wispy clouds looks like a bizarre landscape from Tolkien’s The
@@ -9699,6 +10101,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1007eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1007e.jpg
+astropix_ids: esahubble|heic1007e
 
 credits> NASA, ESA, and M. Livio, The Hub; The NASA/ESA Hubble Space Telescope
 captured this billowing cloud of cold interstellar gas and dust rising from a
@@ -9723,6 +10126,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1007fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1007f.jpg
+astropix_ids: esahubble|heic1007f
 
 credits> NASA, ESA, M. Livio and the Hubb; This is a NASA Hubble Space Telescope
 near-infrared image of a pillar of gas and dust, three light-years tall, that is
@@ -9747,6 +10151,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1008bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1008b.jpg
+astropix_ids: esahubble|heic1008b
 
 credits> NASA, ESA, J. Walsh (ST-ECF) and; The young star, only one million to
 two million years old, may have travelled about 375 light-years from its
@@ -9771,6 +10176,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1008cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1008c.jpg
+astropix_ids: esahubble|heic1008c
 
 credits> ESOAcknowledgments: J. Alves (Ca; Within this image is the runaway
 heavyweight star, called 30 Dor #016. It is 90 times more massive than the Sun
@@ -9795,6 +10201,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1009aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1009a.jpg
+astropix_ids: esahubble|heic1009a
 
 credits> NASA, ESA and Wolfgang Brandner ; The core of the star cluster in NGC
 3603 is shown in great detail in an image from the Wide Field Planetary Camera 2
@@ -9819,6 +10226,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1009cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1009c.jpg
+astropix_ids: esahubble|heic1009c
 
 credits> NASA, ESA and the Hubble Heritag; This view of the rich star formation
 region NGC 3603 and its massive compact central star cluster was taken with the
@@ -9843,6 +10251,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1011aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1011a.jpg
+astropix_ids: esahubble|heic1011a
 
 credits> NASA, ESA and Jesús Maíz Apell; This broad vista of young stars and gas
 clouds in our neighbouring galaxy, the Large Magellanic Cloud, was captured by
@@ -9867,6 +10276,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1011cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1011c.jpg
+astropix_ids: esahubble|heic1011c
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This wide field view of part of the
 Large Magellanic Cloud includes the location of the N11 star formation region.
@@ -9891,6 +10301,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1012aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1012a.jpg
+astropix_ids: esahubble|heic1012a
 
 credits> NASA, ESA and Orsola De Marco (M; A colourful star-forming region is
 featured in this stunning new NASA/ESA Hubble Space Telescope image of NGC 2467.
@@ -9915,6 +10326,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1013aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1013a.jpg
+astropix_ids: esahubble|heic1013a
 
 credits> ESA/Hubble and NASA; This picture, taken by Hubble’s Advanced Camera
 for Surveys, shows NGC 4696, the largest galaxy in the Centaurus Cluster. The
@@ -9939,6 +10351,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1015aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1015a.jpg
+astropix_ids: esahubble|heic1015a
 
 credits> NASA, ESA.; This close-up shot of the centre of the Lagoon Nebula
 (Messier 8) clearly shows the delicate structures formed when the powerful...
@@ -9962,6 +10375,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1018aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1018a.jpg
+astropix_ids: esahubble|heic1018a
 
 credits> NASA, ESA, and the Hubble Herita; This delicate shell, photographed by
 the NASA/ESA Hubble Space Telescope, appears to float serenely in the depths of
@@ -9986,6 +10400,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1018bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1018b.jpg
+astropix_ids: esahubble|heic1018b
 
 credits> NASA, ESA, the Hubble Heritage T; This delicate shell, photographed by
 the NASA/ESA Hubble Space Telescope, appears to float serenely in the depths of
@@ -10010,6 +10425,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1102aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1102a.jpg
+astropix_ids: esahubble|heic1102a
 
 credits> NASA, ESA, William Keel (Univers; In this image by the NASA/ESA Hubble
 Space Telescope, an unusual, ghostly green blob of gas appears to float near a
@@ -10034,6 +10450,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1102bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1102b.jpg
+astropix_ids: esahubble|heic1102b
 
 credits> NASA, ESA, and the Hubble Herita; A number of galaxies are seen in this
 Hubble infrared image of the area surrounding the space oddity, Hanny’s
@@ -10058,6 +10475,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1103bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1103b.jpg
+astropix_ids: esahubble|heic1103b
 
 credits> NASA, ESA, G. Illingworth (Unive; Astronomers have used Hubble to spot
 what they think is the furthest and one of the very earliest galaxies ever seen
@@ -10082,6 +10500,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1103cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1103c.jpg
+astropix_ids: esahubble|heic1103c
 
 credits> NASA, ESA, G. Illingworth (Unive; Astronomers have used Hubble to spot
 what they think is the furthest and one of the very earliest galaxies ever seen
@@ -10106,6 +10525,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1104aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1104a.jpg
+astropix_ids: esahubble|heic1104a
 
 credits> NASA, ESA and the Hubble Heritag; Star formation is one of the most
 important processes in shaping the Universe; it plays a pivotal role in the
@@ -10130,6 +10550,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1104bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1104b.jpg
+astropix_ids: esahubble|heic1104b
 
 credits> NASA, ESA and the Digitized Sky ; This image shows the area around
 flocculent spiral galaxy NGC 2841. It is produced from Digitised Sky Survey 2
@@ -10154,6 +10575,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1105aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1105a.jpg
+astropix_ids: esahubble|heic1105a
 
 credits> NASA, ESA; Hubble has taken this stunning close-up shot of part of the
 Tarantula Nebula. This star-forming region of ionised hydrogen gas i...
@@ -10177,6 +10599,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1105dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1105d.jpg
+astropix_ids: esahubble|heic1105d
 
 credits> NASA, ESA, Digitized Sky Survey ; This ground-based view of the
 Tarantula Nebula shows the nebula in its entirety. It is the brightest region of
@@ -10201,6 +10624,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1106aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1106a.jpg
+astropix_ids: esahubble|heic1106a
 
 credits> NASA, ESA, J. Richard (CRAL) and; The giant galaxy cluster in the
 centre of this image contains so much dark matter mass that its gravity bends
@@ -10225,6 +10649,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1106dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1106d.jpg
+astropix_ids: esahubble|heic1106d
 
 credits> ESA/Hubble & Digitized Sky Surve; This ground-based view shows the area
 of sky around the lensing cluster Abell 383. Lensing clusters are clusters of
@@ -10249,6 +10674,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1107aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1107a.jpg
+astropix_ids: esahubble|heic1107a
 
 credits> NASA, ESA and the Hubble Heritag; This image of a pair of interacting
 galaxies called Arp 273 was released to celebrate the 21st anniversary of the
@@ -10273,6 +10699,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1108aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1108a.jpg
+astropix_ids: esahubble|heic1108a
 
 credits> NASA, ESA; This close-up Hubble view of the Meathook Galaxy (NGC 2442)
 focuses on the more compact of its two asymmetric spiral arms as wel...
@@ -10296,6 +10723,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1108bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1108b.jpg
+astropix_ids: esahubble|heic1108b
 
 credits> ESO; This picture of the Meathook Galaxy (NGC 2442) was taken by the
 Wide Field Imager on the MPG/ESO 2.2-metre telescope at La Silla...
@@ -10319,6 +10747,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1108cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1108c.jpg
+astropix_ids: esahubble|heic1108c
 
 credits> ESA/Hubble & Digitized Sky Surve; This wide-field view from the
 Digitized Sky Survey shows the neighbourhood of the Meathook Galaxy (NGC 2442).
@@ -10343,6 +10772,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1109aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1109a.jpg
+astropix_ids: esahubble|heic1109a
 
 credits> NASA, ESA and the Hubble Heritag; Galaxy NGC 4214, pictured here in an
 image from the NASA/ESA Hubble Space Telescope’s newest camera, is an ideal
@@ -10367,6 +10797,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1109bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1109b.jpg
+astropix_ids: esahubble|heic1109b
 
 credits> NASA, ESA, Digitized Sky Survey ; This ground-based image of the area
 around NGC 4214 shows this dwarf irregular galaxy in its context. The NASA/ESA
@@ -10391,6 +10822,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1110aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1110a.jpg
+astropix_ids: esahubble|heic1110a
 
 credits> NASA, ESA, and the Hubble Herita; Centaurus A, also known as NGC 5128,
 is well known for its dramatic dusty lanes of dark material. Hubble’s new
@@ -10415,6 +10847,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1111aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1111a.jpg
+astropix_ids: esahubble|heic1111a
 
 credits> NASA, ESA, ESO, CXC, and D. Coe ; This image combines visible light
 exposures of galaxy cluster Abell 2744 taken by the NASA/ESA Hubble Space
@@ -10439,6 +10872,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1111bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1111b.jpg
+astropix_ids: esahubble|heic1111b
 
 credits> NASA, ESA, ESO and D. Coe (STScI; This image of galaxy cluster Abell
 2744 combines data from the NASA/ESA Hubble Space Telescope’s Advanced Camera
@@ -10463,6 +10897,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1111cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1111c.jpg
+astropix_ids: esahubble|heic1111c
 
 credits> NASA, ESA and D. Coe (STScI)/J. ; This Hubble image, taken by the
 Advanced Camera for Surveys, shows the central part of merging galaxy cluster
@@ -10487,6 +10922,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1111dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1111d.jpg
+astropix_ids: esahubble|heic1111d
 
 credits> ESO and D. Coe (STScI)/J. Merten; This image, made with the European
 Southern Observatory’s Very Large Telescope (VLT), shows a wide view of merging
@@ -10511,6 +10947,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1111eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1111e.jpg
+astropix_ids: esahubble|heic1111e
 
 credits> ESA/Hubble & Digitized Sky Surve; This ground-based view shows the area
 of sky around the merging galaxy cluster Abell 2744, which has been given the
@@ -10535,6 +10972,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1112fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1112f.jpg
+astropix_ids: esahubble|heic1112f
 
 credits> ESA/Hubble & Digitized Sky Surve; This ground-based image shows the
 full extent of the Andromeda Galaxy, also known as Messier 31 or M 31. The
@@ -10559,6 +10997,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1114aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1114a.jpg
+astropix_ids: esahubble|heic1114a
 
 credits> NASA & ESA; The NASA/ESA Hubble Space Telescope has captured this image
 of dwarf irregular galaxy Holmberg II. The galaxy is dominated by ...
@@ -10582,6 +11021,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1114bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1114b.jpg
+astropix_ids: esahubble|heic1114b
 
 credits> NASA, ESA, Digitized Sky Survey ; This image from a ground-based
 telescope shows a wide view around galaxy Holmberg II. Holmberg II is dominated
@@ -10606,6 +11046,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1116aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1116a.jpg
+astropix_ids: esahubble|heic1116a
 
 credits> NASA, ESA and J.A. Muñoz (Unive; This picture shows a quasar that has
 been gravitationally lensed by a galaxy in the foreground, which can be seen as
@@ -10630,6 +11071,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1202aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1202a.jpg
+astropix_ids: esahubble|heic1202a
 
 credits> NASA & ESA; The NASA/ESA Hubble Space Telescope has taken a picture of
 the barred spiral galaxy NGC 1073, which is found in the constellatio...
@@ -10653,6 +11095,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1202cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1202c.jpg
+astropix_ids: esahubble|heic1202c
 
 credits> NASA, ESA, Digitized Sky Survey ; This image from a ground-based
 telescope shows the location of and region surrounding NGC 1073.Several other
@@ -10677,6 +11120,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1203bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1203b.jpg
+astropix_ids: esahubble|heic1203b
 
 credits> NASA, ESA, and S. Farrell (Unive; This spectacular edge-on galaxy,
 called ESO 243-49, is home to an intermediate-mass black hole that may have been
@@ -10701,6 +11145,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1205aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1205a.jpg
+astropix_ids: esahubble|heic1205a
 
 credits> NASA & ESA; This image from the NASA/ESA Hubble Space Telescope shows
 the globular cluster Messier 9. Hubble’s image resolves stars right in...
@@ -10724,6 +11169,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1207aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1207a.jpg
+astropix_ids: esahubble|heic1207a
 
 credits> NASA & ESA; The NASA/ESA Hubble Space Telescope has made detailed
 observations of the dwarf galaxy NGC 2366. While it lacks the elegant spir...
@@ -10747,6 +11193,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1207bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1207b.jpg
+astropix_ids: esahubble|heic1207b
 
 credits> NASA, ESA, Digitized Sky Survey ; This image from the Digitized Sky
 Survey 2 shows a wide field of view around the dwarf galaxy NGC 2366....
@@ -10770,6 +11217,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1208aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1208a.jpg
+astropix_ids: esahubble|heic1208a
 
 credits> NASA, ESA, the Hubble Heritage (; The NASA/ESA Hubble Space Telescope
 has produced an incredibly detailed image of a pair of overlapping galaxies
@@ -10794,6 +11242,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1210aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1210a.jpg
+astropix_ids: esahubble|heic1210a
 
 credits> NASA, ESA and the Hubble Heritag; The NASA/ESA Hubble Space Telescope
 has captured a new image of Herbig-Haro 110, a geyser of hot gas flowing from a
@@ -10818,6 +11267,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1211aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1211a.jpg
+astropix_ids: esahubble|heic1211a
 
 credits> NASA, ESA, and T. Brown (STScI); Astronomers used the NASA/ESA Hubble
 Space Telescope to unmask the dim, star-starved dwarf galaxy Leo IV. This Hubble
@@ -10842,6 +11292,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1215aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1215a.jpg
+astropix_ids: esahubble|heic1215a
 
 credits> NASA, ESA, Harald Ebeling (Unive; This enormous image shows Hubble’s
 view of massive galaxy cluster MACS J0717.5+3745. The large field of view is a
@@ -10866,6 +11317,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1215bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1215b.jpg
+astropix_ids: esahubble|heic1215b
 
 credits> NASA, ESA, Harald Ebeling(Univer; This enormous image shows Hubble’s
 view of massive galaxy cluster MACS J0717.5+3745. The large field of view is a
@@ -10890,6 +11342,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1218aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1218a.jpg
+astropix_ids: esahubble|heic1218a
 
 credits> NASA, ESA; An almost complete circle of bright pink nebulae skirts
 around a spiral galaxy in this NASA/ESA Hubble Space Telescope image of ...
@@ -10913,6 +11366,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1218cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1218c.jpg
+astropix_ids: esahubble|heic1218c
 
 credits> NASA, ESA, Digitized Sky Survey ; This image from a ground-based
 telescope shows the region around NGC 922, a galaxy with a bright ring of
@@ -10937,6 +11391,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1301aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1301a.jpg
+astropix_ids: esahubble|heic1301a
 
 credits> NASA, ESA. Acknowledgement: Josh; Nearly 200 000 light-years from
 Earth, the Large Magellanic Cloud, a satellite galaxy of the Milky Way, floats
@@ -10961,6 +11416,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1302aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1302a.jpg
+astropix_ids: esahubble|heic1302a
 
 credits> NASA, ESA, the Hubble Heritage T; This image combines Hubble
 observations of M 106 with additional information captured by amateur
@@ -10985,6 +11441,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1303aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1303a.jpg
+astropix_ids: esahubble|heic1303a
 
 credits> NASA, ESA, and J. Muzerolle (STS; This infrared image from the NASA/ESA
 Hubble Space Telescope shows an image of protostellar object LRLL 54361 and its
@@ -11009,6 +11466,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1303bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1303b.jpg
+astropix_ids: esahubble|heic1303b
 
 credits> NASA, ESA, and J. Muzerolle (STS; This infrared image from the NASA/ESA
 Hubble Space Telescope shows an image of protostellar object LRLL 54361. The
@@ -11033,6 +11491,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1304aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1304a.jpg
+astropix_ids: esahubble|heic1304a
 
 credits> NASA & ESA. Acknowledgement: N. ; Abell 68, pictured here in infrared
 light, is a galaxy cluster. The effect of its gravity on light means it boosts
@@ -11057,6 +11516,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1305aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1305a.jpg
+astropix_ids: esahubble|heic1305a
 
 credits> NASA, ESA & A. van der Hoeven; The NASA/ESA Hubble Space Telescope has
 captured this vivid image of spiral galaxy Messier 77 — a galaxy in the
@@ -11081,6 +11541,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1310dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1310d.jpg
+astropix_ids: esahubble|heic1310d
 
 credits> NASA, ESA, Digitized Sky Survey ; This image from the Digitized Sky
 Survey shows the Ring Nebula (Messier 57) and its surroundings....
@@ -11104,6 +11565,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1311aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1311a.jpg
+astropix_ids: esahubble|heic1311a
 
 credits> NASA, ESA and the Hubble Heritag; This image shows the two galaxies
 interacting. NGC 2936, once a standard spiral galaxy, and NGC 2937, a smaller
@@ -11128,6 +11590,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1311bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1311b.jpg
+astropix_ids: esahubble|heic1311b
 
 credits> NASA, ESA, Digitized Sky Survey ; This image from the Digitized Sky
 Survey shows the area around a pair of merging galaxies known as Arp 142 in the
@@ -11152,6 +11615,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1402aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1402a.jpg
+astropix_ids: esahubble|heic1402a
 
 credits> NASA, ESA, E. Sabbi (STScI); This new Hubble image shows a cosmic
 creepy-crawly known as the Tarantula Nebula in infrared light. This region is
@@ -11176,6 +11640,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1402bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1402b.jpg
+astropix_ids: esahubble|heic1402b
 
 credits> NASA, ESA, E. Sabbi (STScI); This new Hubble image shows a cosmic
 creepy-crawly known as the Tarantula Nebula in visible, infrared and ultraviolet
@@ -11200,6 +11665,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1406aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1406a.jpg
+astropix_ids: esahubble|heic1406a
 
 credits> NASA, ESA, and the Hubble Herita; To celebrate its 24th year in orbit,
 the NASA/ESA Hubble Space Telescope has released this beautiful new image of
@@ -11224,6 +11690,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1415aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1415a.jpg
+astropix_ids: esahubble|heic1415a
 
 credits> ESA/Hubble, NASA, ; This image shows the stunning elliptical galaxy
 Centaurus A. Recently, astronomers have used the NASA/ESA Hubble Space
@@ -11248,6 +11715,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1415cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1415c.jpg
+astropix_ids: esahubble|heic1415c
 
 credits> ESA/Hubble, NASA A; This image shows one of the areas of Centaurus A's
 halo probed by the NASA/ESA Hubble Space Telescope's Advanced Camera for Surv...
@@ -11271,6 +11739,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1415dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1415d.jpg
+astropix_ids: esahubble|heic1415d
 
 credits> ESA/Hubble, NASA A; This image shows one of the areas of Centaurus A's
 halo probed by the NASA/ESA Hubble Space Telescope's Advanced Camera for Sur...
@@ -11294,6 +11763,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1416aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1416a.jpg
+astropix_ids: esahubble|heic1416a
 
 credits> ESA/Hubble, NASA, HST Frontier F; This image from the NASA/ESA Hubble
 Space Telescope shows the galaxy cluster MACS J0416.1–2403. This is one of six
@@ -11318,6 +11788,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1416cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1416c.jpg
+astropix_ids: esahubble|heic1416c
 
 credits> ESA/Hubble, NASA, HST Frontier F; This image shows the galaxy MCS
 J0416.1–2403, one of six clusters targeted by the Hubble Frontier Fields
@@ -11342,6 +11813,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1420dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1420d.jpg
+astropix_ids: esahubble|heic1420d
 
 credits> NASA, ESA, Digitized Sky Survey ; This image, taken with ground-based
 telescopes, shows the region of sky containing the star HAT-P-11. Not visible
@@ -11366,6 +11838,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1423cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1423c.jpg
+astropix_ids: esahubble|heic1423c
 
 credits> NASA, ESA Acknowledgement: A. Z; This image, taken with the NASA/ESA
 Hubble Space Telescope, shows one of three images of the same very distant
@@ -11390,6 +11863,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1423dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1423d.jpg
+astropix_ids: esahubble|heic1423d
 
 credits> NASA, ESA Acknowledgement: A. Z; This image, taken with the NASA/ESA
 Hubble Space Telescope, shows one of three images of the same very distant
@@ -11414,6 +11888,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1423eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1423e.jpg
+astropix_ids: esahubble|heic1423e
 
 credits> NASA, ESA Acknowledgement: A. Z; This image, taken with the NASA/ESA
 Hubble Space Telescope, shows one of three images of the same very distant
@@ -11438,6 +11913,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1424aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1424a.jpg
+astropix_ids: esahubble|heic1424a
 
 credits> ESA/Hubble and NAS; The NASA/ESA Hubble Space Telescope has snapped a
 striking view of a multiple star system called XZ Tauri, its neighbour HL
@@ -11462,6 +11938,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1424cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1424c.jpg
+astropix_ids: esahubble|heic1424c
 
 credits> NASA, ESA, Digitized Sky Survey ; This image from the Digitized Sky
 Survey shows the area around multiple star system XZ Tauri. XZ Tauri is blowing
@@ -11486,6 +11963,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1425dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1425d.jpg
+astropix_ids: esahubble|heic1425d
 
 credits> NASA, ESA, S. Larsen (Radboud Un; This NASA/ESA Hubble Space Telescope
 image shows the globular cluster Fornax 2 in the dwarf galaxy Fornax. New
@@ -11534,6 +12012,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1501eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1501e.jpg
+astropix_ids: esahubble|heic1501e
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This image is a colour composite of
 the Eagle Nebula (M 16) made from exposures from the Digitized Sky Survey 2
@@ -11558,6 +12037,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1502bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1502b.jpg
+astropix_ids: esahubble|heic1502b
 
 credits> NASA, ESA, Digitized Sky Survey; This image from the Digitized Sky
 Survey shows the area around the Andromeda galaxy — otherwise known as M31....
@@ -11581,6 +12061,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1503aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1503a.jpg
+astropix_ids: esahubble|heic1503a
 
 credits> ESA, NASA Acknowledgement: A. Ga; NGC 7714 is a spiral galaxy 100
 million light-years from Earth — a relatively close neighbour in cosmic terms.
@@ -11605,6 +12086,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1505bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1505b.jpg
+astropix_ids: esahubble|heic1505b
 
 credits> NASA, ESA, S. Rodney (John Hopki; This image shows the huge galaxy
 cluster MACS J1149.5+223, whose light took over 5 billion years to reach us. The
@@ -11629,6 +12111,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1505cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1505c.jpg
+astropix_ids: esahubble|heic1505c
 
 credits> NASA, ESA, S. Rodney (John Hopki; This image shows four different
 images of the same supernova whose light has been distorted and magnified by the
@@ -11653,6 +12136,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1506bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1506b.jpg
+astropix_ids: esahubble|heic1506b
 
 credits> NASA, ESA, D. Harvey (École Pol; This is a NASA/ESA Hubble Space
 Telescope image of the galaxy cluster Abell 370. Shown in blue on the image is a
@@ -11677,6 +12161,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1506cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1506c.jpg
+astropix_ids: esahubble|heic1506c
 
 credits> NASA, ESA, D. Harvey (École Pol; This is a NASA/ESA Hubble Space
 Telescope image of the galaxy cluster Abell 2744. Shown in blue on the image is
@@ -11701,6 +12186,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1506dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1506d.jpg
+astropix_ids: esahubble|heic1506d
 
 credits> NASA, ESA, D. Harvey (École Pol; This is a NASA/ESA Hubble Space
 Telescope image of the galaxy cluster MACS J0152.5-2852. Shown in blue on the
@@ -11725,6 +12211,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1506eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1506e.jpg
+astropix_ids: esahubble|heic1506e
 
 credits> NASA, ESA, D. Harvey (École Pol; This is a NASA/ESA Hubble Space
 Telescope image of the galaxy cluster MACS J0416.1–2403. Shown in blue on the
@@ -11749,6 +12236,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1506fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1506f.jpg
+astropix_ids: esahubble|heic1506f
 
 credits> NASA, ESA, D. Harvey (École Pol; This is a NASA/ESA Hubble Space
 Telescope image of the galaxy cluster MACS J0717.5+3745. Shown in blue on the
@@ -11773,6 +12261,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1506gL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1506g.jpg
+astropix_ids: esahubble|heic1506g
 
 credits> NASA, ESA, D. Harvey (École Pol; This is a NASA/ESA Hubble Space
 Telescope image of the galaxy cluster ZwCl 1358+62. Shown in blue on the image
@@ -11797,6 +12286,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1507bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1507b.jpg
+astropix_ids: esahubble|heic1507b
 
 credits> NASA, ESA, W. Keel (University o; This new NASA/ESA Hubble Space
 Telescope image shows ghostly green filaments, lying within the galaxy Teacup
@@ -11821,6 +12311,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1507cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1507c.jpg
+astropix_ids: esahubble|heic1507c
 
 credits> NASA, ESA, W. Keel (University o; Twisting in the darkness like a
 disturbed double helix, NGC 5972 exhibits a remarkable structure of ionised gas,
@@ -11845,6 +12336,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1507dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1507d.jpg
+astropix_ids: esahubble|heic1507d
 
 credits> NASA, ESA, W. Keel (University o; This new NASA/ESA Hubble Space
 Telescope image shows ghostly green filaments, lying within galaxy 2MASX
@@ -11869,6 +12361,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1507eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1507e.jpg
+astropix_ids: esahubble|heic1507e
 
 credits> NASA, ESA, W. Keel (University o; This new NASA/ESA Hubble Space
 Telescope image shows ghostly green filaments, lying within galaxy UGC 7342.
@@ -11893,6 +12386,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1507fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1507f.jpg
+astropix_ids: esahubble|heic1507f
 
 credits> NASA, ESA, W. Keel (University o; This new NASA/ESA Hubble Space
 Telescope image shows ghostly green filaments, lying within galaxy NGC 5252.
@@ -11917,6 +12411,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1507gL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1507g.jpg
+astropix_ids: esahubble|heic1507g
 
 credits> NASA, ESA, W. Keel (University o; This new NASA/ESA Hubble Space
 Telescope image shows ghostly green filaments, lying within galaxy Mrk 1498.
@@ -11941,6 +12436,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1507hL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1507h.jpg
+astropix_ids: esahubble|heic1507h
 
 credits> NASA, ESA, W. Keel (University o; This new NASA/ESA Hubble Space
 Telescope image shows ghostly green filaments, lying within galaxy UGC 11185.
@@ -11965,6 +12461,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1507iL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1507i.jpg
+astropix_ids: esahubble|heic1507i
 
 credits> NASA, ESA, W. Keel (University o; This new NASA/ESA Hubble Space
 Telescope image shows ghostly green filaments, lying within galaxy 2MASX
@@ -11989,6 +12486,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1508aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1508a.jpg
+astropix_ids: esahubble|heic1508a
 
 credits> ESA/Hubble & NASA Image acknowle; This NASA/ESA Hubble Space Telescope
 image shows an elliptical galaxy known as IC 2006. Massive elliptical galaxies
@@ -12013,6 +12511,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1509bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1509b.jpg
+astropix_ids: esahubble|heic1509b
 
 credits> NASA, ESA, Digitized Sky Survey ; This image from the Digitized Sky
 Survey shows star cluster Westerlund 2 and its surroundings. A new image of
@@ -12037,6 +12536,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1509cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1509c.jpg
+astropix_ids: esahubble|heic1509c
 
 credits> NASA, ESA, the Hubble Heritage T; This image shows the sparkling
 centerpiece of Hubble's 25th anniversary tribute. Westerlund 2 is a giant
@@ -12061,6 +12561,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1509dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1509d.jpg
+astropix_ids: esahubble|heic1509d
 
 credits> NASA, ESA, the Hubble Heritage T; This image shows the star-forming
 region Gum 29 which surrounds star cluster Westerlund 2. This is a section of
@@ -12085,6 +12586,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1509eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1509e.jpg
+astropix_ids: esahubble|heic1509e
 
 credits> NASA, ESA, the Hubble Heritage T; This image shows an example of the
 pillars that surround the star cluster Westerlund 2. These pillars are composed
@@ -12109,6 +12611,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1509fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1509f.jpg
+astropix_ids: esahubble|heic1509f
 
 credits> NASA, ESA, the Hubble Heritage T; The red dots scattered throughout the
 cosmic landscape captured in this NASA/ESA Hubble Space Telescope image are a
@@ -12133,6 +12636,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1510bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1510b.jpg
+astropix_ids: esahubble|heic1510b
 
 credits> NASA, ESA, and the Hubble Herita; This NASA/ESA Hubble Space Telescope
 image shows the central region of a globular cluster known as NGC 104 — or, more
@@ -12157,6 +12661,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1510cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1510c.jpg
+astropix_ids: esahubble|heic1510c
 
 credits> NASA, ESA, and H. Richer and J. ; This NASA/ESA Hubble Space Telescope
 image shows the central region of a globular cluster known as NGC 104 — or, more
@@ -12181,6 +12686,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1511cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1511c.jpg
+astropix_ids: esahubble|heic1511c
 
 credits> NASA, ESA, M. Chiaberge (STScI); This image taken with the NASA/ESA
 Hubble Space Telescope shows the galaxy 3C 297, which was part of a large survey
@@ -12205,6 +12711,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1511dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1511d.jpg
+astropix_ids: esahubble|heic1511d
 
 credits> NASA, ESA, M. Chiaberge (STScI); This image taken with the NASA/ESA
 Hubble Space Telescope shows the galaxy 3C 454.1 which was part of a large
@@ -12229,6 +12736,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1511eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1511e.jpg
+astropix_ids: esahubble|heic1511e
 
 credits> NASA, ESA, M. Chiaberge (STScI); This image taken with the NASA/ESA
 Hubble Space Telescope shows the galaxy 3C 356 which was part of a large survey
@@ -12253,6 +12761,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1513aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1513a.jpg
+astropix_ids: esahubble|heic1513a
 
 credits> NASA, ESA; This NASA/ESA Hubble Space Telescope image shows galaxy NGC
 6503. The galaxy, which lies about 18 million light-years away is at...
@@ -12276,6 +12785,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1513bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1513b.jpg
+astropix_ids: esahubble|heic1513b
 
 credits> NASA, ESA, Digitized Sky Survey ; This image shows the area around
 galaxy NGC 6503. The galaxy, which lies about 18 000 000 light-years away is at
@@ -12300,6 +12810,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1514aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1514a.jpg
+astropix_ids: esahubble|heic1514a
 
 credits> NASA, ESA, ESO Acknowledgement: ; This new NASA/ESA Hubble Space
 Telescope image shows four of the seven members of galaxy group HCG 16. This
@@ -12324,6 +12835,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1514bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1514b.jpg
+astropix_ids: esahubble|heic1514b
 
 credits> NASA, ESA, Digitized Sky Survey ; This image shows a ground-based
 wide-field view of the region around HCG 16 from the Digitized Sky Survey 2....
@@ -12347,6 +12859,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1516aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1516a.jpg
+astropix_ids: esahubble|heic1516a
 
 credits> NASA, ESA, P. Goudfrooij (STScI); The ghostly shells of galaxy ESO
 381-12 are captured here in a new image from the NASA/ESA Hubble Space
@@ -12371,6 +12884,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1516bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1516b.jpg
+astropix_ids: esahubble|heic1516b
 
 credits> NASA, ESA, Digitized Sky Survey ; This image from the Digitized Sky
 Survey shows the area around galaxy ESO 381-12. The strikingly uneven structure
@@ -12395,6 +12909,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1517aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1517a.jpg
+astropix_ids: esahubble|heic1517a
 
 credits> NASA, ESA, J. Trauger (Jet Propu; This new NASA/ESA Hubble Space
 Telescope image shows the Lagoon Nebula, an object with a deceptively tranquil
@@ -12419,6 +12934,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1518aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1518a.jpg
+astropix_ids: esahubble|heic1518a
 
 credits> ESA/Hubble & NASA Acknowledgemen; The Twin Jet Nebula, or PN M2-9, is a
 striking example of a bipolar planetary nebula. Bipolar planetary nebulae are
@@ -12443,6 +12959,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1518bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1518b.jpg
+astropix_ids: esahubble|heic1518b
 
 credits> NASA, ESA, Digitized Sky Survey ; This image shows the region of sky
 around the planetary nebula called the Twin Jet Nebula. The bipolar planetary
@@ -12467,6 +12984,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1519aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1519a.jpg
+astropix_ids: esahubble|heic1519a
 
 credits> NASA/STScI/ESA/JPL-Caltech/McGil; This image, using data from Spitzer
 and the Hubble Space Telescope, shows the galaxy cluster SpARCS1049....
@@ -12490,6 +13008,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1519cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1519c.jpg
+astropix_ids: esahubble|heic1519c
 
 credits> NASA, ESA, Digitized Sky Survey ; This image shows the region of sky
 around the the distant galaxy cluster SpARCS1049+56. It took the light of the
@@ -12514,6 +13033,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1520bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1520b.jpg
+astropix_ids: esahubble|heic1520b
 
 credits> NASA, ESA, Digitized Sky Survey ; This image shows the Veil supernova
 remnant and the surrounding sky. Due to the size of the Nebula the NASA/ESA
@@ -12538,6 +13058,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1521bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1521b.jpg
+astropix_ids: esahubble|heic1521b
 
 credits> ESO/Digitized Sky Survey 2; This image shows the sky around the nearby
 young star AU Microscopii. It was created from images forming part of the
@@ -12562,6 +13083,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1523aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1523a.jpg
+astropix_ids: esahubble|heic1523a
 
 credits> NASA, ESA and the HST Frontier F; This image from the NASA/ESA Hubble
 Space Telescope shows the galaxy cluster MACS J0416.1–2403. This is one of six
@@ -12586,6 +13108,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1523bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1523b.jpg
+astropix_ids: esahubble|heic1523b
 
 credits> NASA, ESA and the HST Frontier F; This image from the NASA/ESA Hubble
 Space Telescope shows the galaxy cluster MACSJ0717.5+3745. This is one of six
@@ -12610,6 +13133,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1523cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1523c.jpg
+astropix_ids: esahubble|heic1523c
 
 credits> NASA, ESA and the HST Frontier F; Abell 2744, nicknamed Pandora’s
 Cluster, was the first of six targets within the Frontier Fields programme,
@@ -12634,6 +13158,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1526aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1526a.jpg
+astropix_ids: esahubble|heic1526a
 
 credits> ESA/Hubble & NASA, D. Padgett (G; The two lightsabre-like streams
 crossing the image are jets of energised gas, ejected from the poles of a young
@@ -12681,6 +13206,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1602aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1602a.jpg
+astropix_ids: esahubble|heic1602a
 
 credits> NASA & ESA; This image shows the elliptical galaxy NGC 4889 in front of
 hundreds of background galaxies, and deeply embedded within the Coma...
@@ -12704,6 +13230,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1602bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1602b.jpg
+astropix_ids: esahubble|heic1602b
 
 credits> NASA, ESA, Digitized Sky Survey ; This image shows a ground-based
 wide-field view of the region around NGC 4889 from the Digitized Sky Survey
@@ -12728,6 +13255,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1605aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1605a.jpg
+astropix_ids: esahubble|heic1605a
 
 credits> NASA, ESA, P Crowther (Universit; The image shows the central region of
 the Tarantula Nebula in the Large Magellanic Cloud. The young and dense star
@@ -12752,6 +13280,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1606aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1606a.jpg
+astropix_ids: esahubble|heic1606a
 
 credits> NASA, ESA, and the Hubble Herita; This infrared image from the NASA/ESA
 Hubble Space Telescope shows the centre of the Milky Way, 27 000 light-years
@@ -12776,6 +13305,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1607bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1607b.jpg
+astropix_ids: esahubble|heic1607b
 
 credits> NASA, ESA, Digitized Sky Survey ; This image shows the ground-based
 view of NGC 1600 and some of the other galaxies of the group it is located
@@ -12800,6 +13330,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1608bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1608b.jpg
+astropix_ids: esahubble|heic1608b
 
 credits> NASA, ESA, Digitized Sky Survey ; This ground-based image shows the
 Bubble Nebula and its surroundings, including the interstellar cloud which is
@@ -12824,6 +13355,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1611cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1611c.jpg
+astropix_ids: esahubble|heic1611c
 
 credits> NASA, ESA, and L. Frattare (STSc; Cepheid variable stars in this spiral
 galaxy, known as UGC 9391, and a Type Ia supernova (not visible in this image)
@@ -12848,6 +13380,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1612aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1612a.jpg
+astropix_ids: esahubble|heic1612a
 
 credits> NASA, ESA, and D. Elmegreen (Vas; In this new image from the NASA/ESA
 Hubble Space Telescope, a firestorm of star birth is lighting up one end of the
@@ -12872,6 +13405,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1612bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1612b.jpg
+astropix_ids: esahubble|heic1612b
 
 credits> NASA, ESA, Digitized Sky Surv; This ground-based image shows the
 tadpole galaxy LEDA 36252 and its surroundings....
@@ -12895,6 +13429,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1614aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1614a.jpg
+astropix_ids: esahubble|heic1614a
 
 credits> NASA, ESA; While many other images of the famous Crab Nebula nebula
 have focused on the filaments in the outer part of the nebula, this ima...
@@ -12918,6 +13453,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1615aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1615a.jpg
+astropix_ids: esahubble|heic1615a
 
 credits> NASA, ESA, and J. Lotz (STScI); Abell S1063, a galaxy cluster, was
 observed by the NASA/ESA Hubble Space Telescope as part of the Frontier Fields
@@ -12942,6 +13478,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1615bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1615b.jpg
+astropix_ids: esahubble|heic1615b
 
 credits> NASA, ESA, and J. Lotz (STScI); This part of the sky was observed in
 parallel with the galaxy cluster Abell S1063 and is also part of the Frontier
@@ -12966,6 +13503,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1615cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1615c.jpg
+astropix_ids: esahubble|heic1615c
 
 credits> NASA, ESA, Digitized Sky Survey ; This ground-based image shows the
 galaxy cluster Abell S1063 and its surroundings....
@@ -13013,6 +13551,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1617aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1617a.jpg
+astropix_ids: esahubble|heic1617a
 
 credits> NASA/ESA/Hubble/F. Ferraro; Peering through the thick dust clouds of
 the galactic bulge an international team of astronomers has revealed the unusual
@@ -13037,6 +13576,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1617bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1617b.jpg
+astropix_ids: esahubble|heic1617b
 
 credits> ESO/Digitized Sky Survey 2; This wide-field image, based on data from
 Digitized Sky Survey 2, shows the whole region around the stellar grouping
@@ -13061,6 +13601,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1618aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1618a.jpg
+astropix_ids: esahubble|heic1618a
 
 credits> ESA/Hubble & NASA; This image of the Stingray nebula, a planetary
 nebula 2700 light-years from Earth, was taken with the Wide Field and Planetary
@@ -13085,6 +13626,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1621aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1621a.jpg
+astropix_ids: esahubble|heic1621a
 
 credits> NASA, ESA/Hubble, A. Fabian; This picture, taken by Hubble’s Wide Field
 Camera 3 (WFC3), shows NGC 4696, the largest galaxy in the Centaurus Cluster.
@@ -13109,6 +13651,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1621bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1621b.jpg
+astropix_ids: esahubble|heic1621b
 
 credits> NASA, ESA, Digitized Sky Survey ; This ground-based image shows the
 galaxy NGC 4696 and its surroundings....
@@ -13132,6 +13675,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1623aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1623a.jpg
+astropix_ids: esahubble|heic1623a
 
 credits> NASA, ESA, STScI, K. Sandstrom (; This glowing nebula, named NGC 248,
 is located within the Small Magellanic Cloud, a satellite galaxy of the Milky
@@ -13156,6 +13700,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1702aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1702a.jpg
+astropix_ids: esahubble|heic1702a
 
 credits> ESA/Hubble, NASA, Suyu et al.; HE0435-1223, located in the centre of
 this wide-field image, is among the five best lensed quasars discovered to date.
@@ -13180,6 +13725,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1702cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1702c.jpg
+astropix_ids: esahubble|heic1702c
 
 credits> ESA/Hubble, NASA, Suyu et al.; B1608+656 is among the five best lensed
 quasars discovered to date. The two foreground galaxies smeared the light of the
@@ -13204,6 +13750,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1702dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1702d.jpg
+astropix_ids: esahubble|heic1702d
 
 credits> ESA/Hubble, NASA, Suyu et al.; RXJ1131-1231 is among the five best
 lensed quasars discovered to date. The foreground galaxy smears the image of the
@@ -13228,6 +13775,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1702eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1702e.jpg
+astropix_ids: esahubble|heic1702e
 
 credits> ESA/Hubble, NASA, Suyu et al.; HE0435-1223 is among the five best
 lensed quasars discovered to date. The foreground galaxy creates four almost
@@ -13252,6 +13800,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1702fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1702f.jpg
+astropix_ids: esahubble|heic1702f
 
 credits> ESA/Hubble, NASA, Suyu et al.; WFI2033-4723 is among the five best
 lensed quasars discovered to date. The foreground galaxy creates four distinct
@@ -13276,6 +13825,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1702gL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1702g.jpg
+astropix_ids: esahubble|heic1702g
 
 credits> ESA/Hubble, NASA, Suyu et al.; HE1104-1805 is among the five best
 lensed quasars discovered to date. The foreground galaxy in the centre of the
@@ -13300,6 +13850,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1704cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1704c.jpg
+astropix_ids: esahubble|heic1704c
 
 credits> ALMA: ESO/NAOJ/NRAO/A. Angelich ; Astronomers combined observations
 from three different observatoriesto produce this multiwavelength image of the
@@ -13324,6 +13875,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1705aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1705a.jpg
+astropix_ids: esahubble|heic1705a
 
 credits> NASA, ESA/Hubble; This composite image of the Kleinmann-Low Nebula,
 part of the Orion Nebula complex, is composed of several pointings of the
@@ -13348,6 +13900,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1706aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1706a.jpg
+astropix_ids: esahubble|heic1706a
 
 credits> NASA, ESA, and M. Chiaberge (STS; The galaxy 3C186, located about 8
 billion years from Earth, is most likely the result of a merger of two galaxies.
@@ -13372,6 +13925,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1707aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1707a.jpg
+astropix_ids: esahubble|heic1707a
 
 credits> ESA/Hubble, NASA; This image, taken with the NASA/ESA Hubble Space
 Telescope, shows the supernova remnant SNR 0509-68.7, also known as N103B (top
@@ -13396,6 +13950,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1709bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1709b.jpg
+astropix_ids: esahubble|heic1709b
 
 credits> NASA, ESA, and M. Mutchler (STSc; While one instrument of Hubble
 observed the target for its 27th anniversary — the galaxies NGC 4302 and NGC
@@ -13420,6 +13975,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1709cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1709c.jpg
+astropix_ids: esahubble|heic1709c
 
 credits> NASA, ESA, Digitized Sky Survey ; This ground-based image shows the two
 galaxies NGC 4298 and NGC 4302 and their surroundings....
@@ -13514,6 +14070,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1710eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1710e.jpg
+astropix_ids: esahubble|heic1710e
 
 credits> ESA/Hubble, Sloan Digital Sky Su; Astronomers used the Sloan Digital
 Sky Survey (SDSS), carried out by a 2.5-metre wide-angle optical telescope at
@@ -13538,6 +14095,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1710fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1710f.jpg
+astropix_ids: esahubble|heic1710f
 
 credits> ESA/Hubble, W. M. Keck Observato; The adaptive-optics instruments on
 the W.M. Keck Observatory on Mauna Kea, Hawaii, were able to resolve the
@@ -13562,6 +14120,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1711aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1711a.jpg
+astropix_ids: esahubble|heic1711a
 
 credits> NASA, ESA/Hubble, HST Frontier F; With the final observation of the
 distant galaxy cluster Abell 370 — some five billion light-years away — the
@@ -13586,6 +14145,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1711bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1711b.jpg
+astropix_ids: esahubble|heic1711b
 
 credits> NASA, ESA/Hubble, HST Frontier F; While one eye of Hubble was observing
 its main target, the massive galaxy cluster Abell 370, the second eye — another
@@ -13610,6 +14170,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1711dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1711d.jpg
+astropix_ids: esahubble|heic1711d
 
 credits> ESA/Hubble; This image of Abell 370 was released in 2009. Compared to
 the new image, which contains more observation time, less structures a...
@@ -13633,6 +14194,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1712bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1712b.jpg
+astropix_ids: esahubble|heic1712b
 
 credits> NASA, ESA, Digitized Sky Survey ; This image shows the sky around the
 two interacting galaxies NGC 1512 and NGC 1510. NGC 1512 is clearly visible in
@@ -13657,6 +14219,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1716aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1716a.jpg
+astropix_ids: esahubble|heic1716a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This image, taken with the NASA/ESA
 Hubble Space Telescope, shows the galaxy NGC 4490. The scattered and warped
@@ -13681,6 +14244,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1717cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1717c.jpg
+astropix_ids: esahubble|heic1717c
 
 credits> NASA and ESA; The lenticular galaxy NGC 4993 is located about 130
 million light-years from Earth. On 17 August 2017 the Laser Interferometer G...
@@ -13704,6 +14268,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1717dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1717d.jpg
+astropix_ids: esahubble|heic1717d
 
 credits> NASA, ESA, Digitized Sky Survey ; This image shows the sky around the
 lenticular galaxy NGC 4993. Within this galaxy Hubble discovered the first
@@ -13728,6 +14293,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1719aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1719a.jpg
+astropix_ids: esahubble|heic1719a
 
 credits> ESA/Hubble & NASA; This image shows a small part of the Sculptor Dwarf
 Galaxy, a satellite galaxy of the Milky Way, situated only about 300 000 lig...
@@ -13751,6 +14317,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1719bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1719b.jpg
+astropix_ids: esahubble|heic1719b
 
 credits> ESA/Hubble & NASA; This image shows a small part of the Sculptor Dwarf
 Galaxy, a satellite galaxy of the Milky Way, situated only about 300 000 lig...
@@ -13774,6 +14341,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1719cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1719c.jpg
+astropix_ids: esahubble|heic1719c
 
 credits> ESA/Hubble, Digitized Sky Survey; The Sculptor Dwarf Galaxy is one of
 the Milky Way’s neighbouring dwarf galaxies. Like all large galaxies, the Milky
@@ -13798,6 +14366,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1719dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1719d.jpg
+astropix_ids: esahubble|heic1719d
 
 credits> ESA/Hubble, Digitized Sky Survey; This image of the sky around the
 Sculptor Dwarf Galaxy was created from images from the Digitized Sky Survey 2.
@@ -13822,6 +14391,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1720aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1720a.jpg
+astropix_ids: esahubble|heic1720a
 
 credits> ESA/Hubble, NASA; NGC 5256 is a pair of galaxies in its final stage of
 merging. It was previously observed by Hubble as part of a collection of 59...
@@ -13845,6 +14415,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1720bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1720b.jpg
+astropix_ids: esahubble|heic1720b
 
 credits> ESA, NASA, Digitized Sky Survey ; This wide-field image shows the pair
 of galaxies known as NGC 5256 and their surroundings as seen from the ground. In
@@ -13869,6 +14440,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1803aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1803a.jpg
+astropix_ids: esahubble|heic1803a
 
 credits> ESA/Hubble, NASA; This image of the spiral galaxy NGC 3344, located
 about 20 million light-years from Earth, is a composite of images taken
@@ -13893,6 +14465,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1806aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1806a.jpg
+astropix_ids: esahubble|heic1806a
 
 credits> NASA, ESA, and P. van Dokkum (Ya; NGC 1052-DF2 resides about 65 million
 light-years away in the NGC 1052 Group, which is dominated by a massive
@@ -13917,6 +14490,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1806bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1806b.jpg
+astropix_ids: esahubble|heic1806b
 
 credits> ESA/Hubble, NASA, Digitized Sky ; This image shows the sky around the
 ultra diffuse galaxy NGC 1052-DF2. It was created from images forming part of
@@ -13941,6 +14515,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1808aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1808a.jpg
+astropix_ids: esahubble|heic1808a
 
 credits> NASA, ESA, STScI; To celebrate its 28th anniversary in space the
 NASA/ESA Hubble Space Telescope took this amazing and colourful image of the
@@ -13965,6 +14540,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1808bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1808b.jpg
+astropix_ids: esahubble|heic1808b
 
 credits> NASA, ESA, STScI; To celebrate its 28th anniversary in space the
 NASA/ESA Hubble Space Telescope took this amazing and colourful image of the
@@ -13989,6 +14565,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1808eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1808e.jpg
+astropix_ids: esahubble|heic1808e
 
 credits> NASA, ESA, STScI; To celebrate its 28th anniversary in space the
 NASA/ESA Hubble Space Telescope took this amazing and colourful image of the
@@ -14013,6 +14590,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1810aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1810a.jpg
+astropix_ids: esahubble|heic1810a
 
 credits> NASA, ESA, and the LEGUS team; This image shows the galaxy NGC 6744,
 about 30 million light-years away. It is one of 50 galaxies observed as part of
@@ -14037,6 +14615,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1810bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1810b.jpg
+astropix_ids: esahubble|heic1810b
 
 credits> NASA, ESA, and the LEGUS team; UGCA 281 is a blue compact dwarf galaxy
 located in the constellation of Canes Venatici. Within it, two giant star
@@ -14061,6 +14640,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1810cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1810c.jpg
+astropix_ids: esahubble|heic1810c
 
 credits> NASA, ESA, and the LEGUS team; The spiral galaxy Messier 66 is located
 at a distance of about 35 million light-years in the constellation of Leo (The
@@ -14085,6 +14665,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1810dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1810d.jpg
+astropix_ids: esahubble|heic1810d
 
 credits> NASA, ESA, and the LEGUS team; The dwarf galaxy DDO 68, also known as
 UGC 5340, lies about 40 million light-years away from Earth. Due to its
@@ -14109,6 +14690,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1811aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1811a.jpg
+astropix_ids: esahubble|heic1811a
 
 credits> ESA/Hubble, NASA; This image, taken with the Wide Field Camera 3 (WFC3)
 and the Advanced Camera for Surveys (ACS), both installed on the NASA/ESA ...
@@ -14132,6 +14714,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1816aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1816a.jpg
+astropix_ids: esahubble|heic1816a
 
 credits> NASA, ESA, A. Koekemoer, M. Jauz; The galaxy cluster Abell 370 was the
 first target of the BUFFALO survey, which aims to search for some of the first
@@ -14156,6 +14739,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1819bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1819b.jpg
+astropix_ids: esahubble|heic1819b
 
 credits> ESO; This image shows the Serpens Nebula as seen by the HAWK-I
 instrument installed on the Very Large Telescope of the European South...
@@ -14179,6 +14763,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1820aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1820a.jpg
+astropix_ids: esahubble|heic1820a
 
 credits> NASA, ESA, and M. Montes (Univer; Abell S1063, a galaxy cluster, was
 observed by the NASA/ESA Hubble Space Telescope as part of the Frontier Fields
@@ -14203,6 +14788,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1901bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1901b.jpg
+astropix_ids: esahubble|heic1901b
 
 credits> NASA, ESA, and M. Durbin, J. Dal; This image shows NGC 604, located
 within the Triangulum Galaxy. Some 1500 light-years across, this is one of the
@@ -14227,6 +14813,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1901cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1901c.jpg
+astropix_ids: esahubble|heic1901c
 
 credits> NASA, ESA, and M. Durbin, J. Dal; NGC 595 is is a gigantic region of
 ionised hydrogen in the Triangulum Galaxy, about three million light-years away.
@@ -14251,6 +14838,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1901dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1901d.jpg
+astropix_ids: esahubble|heic1901d
 
 credits> NASA, ESA, and M. Durbin, J. Dal; IC 142 is a region of ionised
 hydrogen and a large stellar association in the Triangulum Galaxy. A stellar
@@ -14275,6 +14863,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1901fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1901f.jpg
+astropix_ids: esahubble|heic1901f
 
 credits> ESO/Digitized Sky Survey 2. Ackn; This wide-field view of the sky
 around the nearby galaxy Messier 33 was assembled from images forming part of
@@ -14299,6 +14888,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1903aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1903a.jpg
+astropix_ids: esahubble|heic1903a
 
 credits> ESA/Hubble, NASA, Bedin et al.; This image, taken with Hubble’s
 Advanced Camera for Surveys shows a part the globular cluster NGC 6752. Behind
@@ -14323,6 +14913,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1903cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1903c.jpg
+astropix_ids: esahubble|heic1903c
 
 credits> ESA/Hubble, NASA, Bedin et al.; This image, taken with the NASA/ESA
 Hubble Space Telescope, shows a part of the globular cluster NGC 6752. The
@@ -14347,6 +14938,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1903dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1903d.jpg
+astropix_ids: esahubble|heic1903d
 
 credits> ESA/Digitized Sky Survey 2Acknow; This image shows a ground-based
 wide-field view of the region around NGC 6752 from the Digitized Sky Survey
@@ -14371,6 +14963,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1907aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1907a.jpg
+astropix_ids: esahubble|heic1907a
 
 credits> NASA, ESA, and STScI; The Southern Crab Nebula — Hubble’s 29th
 anniversary image....
@@ -14394,6 +14987,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1910aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1910a.jpg
+astropix_ids: esahubble|heic1910a
 
 credits> ESA/Hubble, NASA Acknowledgement; NGC 4485 has been involved in a
 dramatic gravitational interplay with its larger galactic neighbour NGC 4490 —
@@ -14418,6 +15012,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1910bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1910b.jpg
+astropix_ids: esahubble|heic1910b
 
 credits> NASA, ESA, Digitized Sky Survey ; This ground-based image shows the
 large galaxy NGC 4490 and the irregular galaxy NGC 4485 — above the larger
@@ -14442,6 +15037,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1911aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1911a.jpg
+astropix_ids: esahubble|heic1911a
 
 credits> ESA/Hubble, NASA; Nestled within this field of bright foreground stars
 lies ESO 495-21, a tiny galaxy with a big heart. ESO 495-21 is just 3000 li...
@@ -14465,6 +15061,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1911bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-heic1911b.jpg
+astropix_ids: esahubble|heic1911b
 
 credits> ESA/Hubble, NASA, Digitized Sky ; This image shows the sky around the
 galaxy ESO 495-21. It was created from images forming part of the Digitized Sky
@@ -14489,6 +15086,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0003bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0003b.jpg
+astropix_ids: esahubble|opo0003b
 
 credits> NASA/ESA and Dave Bennett (Unive; The Hubble Space Telescope clearly
 resolves a lensed star and yields its brightness....
@@ -14512,6 +15110,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0003cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0003c.jpg
+astropix_ids: esahubble|opo0003c
 
 credits> NOAO, Cerro Tololo Inter-America; Two images of a crowded starfield as
 seen through a ground-based telescope show the subtle brightening of a star due
@@ -14536,6 +15135,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0003dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0003d.jpg
+astropix_ids: esahubble|opo0003d
 
 credits> NOAO, Cerro Tololo Inter-America; Two images of a crowded starfield as
 seen through a ground-based telescope show the subtle brightening of a star due
@@ -14560,6 +15160,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0033cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0033c.jpg
+astropix_ids: esahubble|opo0033c
 
 credits> David Malin (Anglo-Australian Ob; The picture at left, taken by a
 terrestrial telescope, shows most of the cluster, a tightly packed group of
@@ -14584,6 +15185,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0122cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0122c.jpg
+astropix_ids: esahubble|opo0122c
 
 credits> NASA & ESA; Image of the Coma Cluster of galaxies...
 
@@ -14606,6 +15208,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0122fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0122f.jpg
+astropix_ids: esahubble|opo0122f
 
 credits> NASA & ESA; Studying the star clusters and dwarf galaxies in Stephan's
 Quintet provides insights into how galactic encounters may have drive...
@@ -14629,6 +15232,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0210dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0210d.jpg
+astropix_ids: esahubble|opo0210d
 
 credits> NASA/ESA and H. Richer; Peering deep inside a cluster of several
 hundred thousand stars, the NASA/ESA Hubble Space Telescope uncovered the oldest
@@ -14653,6 +15257,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0212cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0212c.jpg
+astropix_ids: esahubble|opo0212c
 
 credits> R. Chris Smith (CTIO) and Y.-H. ; Composite image of ground-based [S
 II] image (white; taken at the Curtis Schmidt Telescope at the Cerro Tololo
@@ -14677,6 +15282,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0306eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0306e.jpg
+astropix_ids: esahubble|opo0306e
 
 credits> Digitized Sky Survey (DSS); Close up of M27, The Dumbbell Nebula, as
 taken by the Digitized Sky Survey....
@@ -14700,6 +15306,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0312cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0312c.jpg
+astropix_ids: esahubble|opo0312c
 
 credits> NASA/ESA and J. Blakeslee (JHU); The red spot is the glow of a very
 distant supernova captured exploding in the field. The supernova is estimated to
@@ -14724,6 +15331,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0324eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0324e.jpg
+astropix_ids: esahubble|opo0324e
 
 credits> NASA/ESA, The Hubble Heritage Te; The center of NGC 3370 shows well
 delineated dust lanes and an uncommonly ill-defined nucleus....
@@ -14747,6 +15355,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0324fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0324f.jpg
+astropix_ids: esahubble|opo0324f
 
 credits> NASA/ESA, The Hubble Heritage Te; A region on the edge of the galaxy
 shows bright blue clusters of young, massive stars as well as distant, red
@@ -14771,6 +15380,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0324gL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0324g.jpg
+astropix_ids: esahubble|opo0324g
 
 credits> NASA/ESA, The Hubble Heritage Te; A region on the edge of the galaxy
 shows bright blue clusters of young, massive stars as well as distant, red
@@ -14795,6 +15405,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0324hL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0324h.jpg
+astropix_ids: esahubble|opo0324h
 
 credits> NASA/ESA, The Hubble Heritage Te; An unusual concentration in the upper
 corner shows a complex region of tidal interaction between a bright galaxy and
@@ -14819,6 +15430,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0324iL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0324i.jpg
+astropix_ids: esahubble|opo0324i
 
 credits> NASA/ESA, The Hubble Heritage Te; A Sombrero-galaxy-look-alike is seen
 edge on with a small warp in the middle right....
@@ -14842,6 +15454,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0324jL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0324j.jpg
+astropix_ids: esahubble|opo0324j
 
 credits> NASA & ESA; In the lower middle right, a distant filament of merging
 blue galaxies can be seen....
@@ -14865,6 +15478,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0331cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0331c.jpg
+astropix_ids: esahubble|opo0331c
 
 credits> N. Smith, University of Minnesot; This image shows the Carina Nebula
 (NGC 3372), combining the light from 3 different filters tracing emission from
@@ -14889,6 +15503,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0409aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0409a.jpg
+astropix_ids: esahubble|opo0409a
 
 credits> NASA/ESA, P. Challis, R. Kirshne; Seventeen years ago, astronomers
 spotted the brightest stellar explosion ever seen since the one observed by
@@ -14913,6 +15528,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0413bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0413b.jpg
+astropix_ids: esahubble|opo0413b
 
 credits> NASA, ESA, and The Hubble Herita; A ground-based Digitized Sky Survey
 image NGC 300....
@@ -14936,6 +15552,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0520aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0520a.jpg
+astropix_ids: esahubble|opo0520a
 
 credits> NASA, ESA and The Hubble Heritag; Gazing deep into the universe,
 NASA/ESA Hubble Space Telescope has spied a menagerie of galaxies. Located
@@ -14960,6 +15577,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0525aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0525a.jpg
+astropix_ids: esahubble|opo0525a
 
 credits> NASA, ESA and The Hubble Heritag; The NASA/ESA Hubble Space Telescope
 caught the Boomerang Nebula in images taken with the Advanced Camera for Surveys
@@ -14984,6 +15602,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0530aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0530a.jpg
+astropix_ids: esahubble|opo0530a
 
 credits> NASA, ESA, and The Hubble Herita; Intricate wisps of glowing gas float
 amid a myriad of stars in this image created by combining data from the NASA/ESA
@@ -15008,6 +15627,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0532bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0532b.jpg
+astropix_ids: esahubble|opo0532b
 
 credits> NASA, ESA, A. Bolton (Harvard-Sm; The thin blue bull's-eye patterns in
 these eight Hubble Space Telescope images appear like neon signs floating over
@@ -15032,6 +15652,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0607aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0607a.jpg
+astropix_ids: esahubble|opo0607a
 
 credits> NASA, ESA, The Hubble Heritage T; This dramatic spiral galaxy is one of
 the latest viewed by NASA/ESA Hubble Space Telescope. Stunning details of the
@@ -15056,6 +15677,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0607cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0607c.jpg
+astropix_ids: esahubble|opo0607c
 
 credits> NASA, ESA, The Hubble Heritage T; This image of NGC 1309 extends out to
 the physical edge of the ACS field. The image was taken in 2005. NGC 1309 is 100
@@ -15080,6 +15702,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0613aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0613a.jpg
+astropix_ids: esahubble|opo0613a
 
 credits> NASA, ESA, and The Hubble Herita; The yearly ritual of spring cleaning
 clears a house of dust as well as dust "bunnies", those pesky dust balls that
@@ -15104,6 +15727,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0613bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0613b.jpg
+astropix_ids: esahubble|opo0613b
 
 credits> T.A. Rector/University of Alaska; This wide-field view of the
 star-forming region NGC 281 in the constellation Cassiopeia was taken with the
@@ -15128,6 +15752,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0624aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0624a.jpg
+astropix_ids: esahubble|opo0624a
 
 credits> NASA, ESA, and The Hubble Herita; This is a unique NASA/ESA Hubble
 Space Telescope view of the disk galaxy NGC 5866 tilted nearly edge-on to our
@@ -15152,6 +15777,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0624bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0624b.jpg
+astropix_ids: esahubble|opo0624b
 
 credits> NASA, ESA, and The Hubble Herita; NGC 5866 is an edge-on galaxy that is
 tilted to our line-of-sight. It is classified as an S0 lenticular, due to its
@@ -15176,6 +15802,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0626aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0626a.jpg
+astropix_ids: esahubble|opo0626a
 
 credits> NASA, ESA, and The Hubble Herita; The sharp eye of the Hubble Space
 Telescope's Advanced Camera for Surveys has uncovered more than 200 mammoth star
@@ -15200,6 +15827,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0635aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0635a.jpg
+astropix_ids: esahubble|opo0635a
 
 credits> NASA, ESA and the Hubble Heritag; In the wake of Independence Day
 festivities surrounding the U.S. July 4th holiday, astronomers and image
@@ -15224,6 +15852,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0651cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0651c.jpg
+astropix_ids: esahubble|opo0651c
 
 credits> NASA/CXC, B. McNamara (Universit; This image of galaxy cluster MS
 0735.6+7421 was taken by the Chandra X-ray Observatory in November 2003.
@@ -15248,6 +15877,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0651dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0651d.jpg
+astropix_ids: esahubble|opo0651d
 
 credits> NASA, ESA, and B. McNamara (Univ; This image of galaxy cluster MS
 0735.6+7421 was taken with NASA/ESA Hubble Space Telescope in February 2006. The
@@ -15272,6 +15902,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0703cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0703c.jpg
+astropix_ids: esahubble|opo0703c
 
 credits> NASA/ESA and R. Humphreys (Unive; VY Canis Majoris is one of the
 largest known stars in the Universe in respect of size. The diameter of this red
@@ -15296,6 +15927,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0705bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0705b.jpg
+astropix_ids: esahubble|opo0705b
 
 credits> H. Boffin (FORS/VLT/ESO); This is a view of the barred spiral galaxy
 NGC 1313 taken with the the European Southern Observatory's Very Large Telescope
@@ -15320,6 +15952,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0705cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0705c.jpg
+astropix_ids: esahubble|opo0705c
 
 credits> NASA, ESA and A. Pellerin (STScI; This is a NASA/ESA Hubble Space
 Telescope image of the central region of the barred spiral galaxy NGC 1313.
@@ -15344,6 +15977,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0706eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0706e.jpg
+astropix_ids: esahubble|opo0706e
 
 credits> NASA, ESA, M. Davis (University ; This image, taken by NASA/ESA Hubble
 Space Telescope, represents a small section of a larger panoramic view of the
@@ -15368,6 +16002,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0708aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0708a.jpg
+astropix_ids: esahubble|opo0708a
 
 credits> NASA, ESA, and The Hubble Herita; This image from the NASA/ESA Hubble
 Space Telescope shows the diverse collection of galaxies in the cluster Abell
@@ -15392,6 +16027,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0733bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0733b.jpg
+astropix_ids: esahubble|opo0733b
 
 credits> NASA, ESA, and The Hubble Herita; He 2-47...
 
@@ -15414,6 +16050,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0733cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0733c.jpg
+astropix_ids: esahubble|opo0733c
 
 credits> NASA, ESA, and The Hubble Herita; NGC 5315...
 
@@ -15436,6 +16073,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0733dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0733d.jpg
+astropix_ids: esahubble|opo0733d
 
 credits> NASA, ESA, and The Hubble Herita; IC 4593...
 
@@ -15458,6 +16096,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0733eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0733e.jpg
+astropix_ids: esahubble|opo0733e
 
 credits> NASA, ESA, and The Hubble Herita; NGC 5307...
 
@@ -15480,6 +16119,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0737aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0737a.jpg
+astropix_ids: esahubble|opo0737a
 
 credits> NASA, ESA, D. Evans (Harvard-Smi; A powerful jet from a supermassive
 black hole is blasting a nearby galaxy, according to new data from NASA/ESA
@@ -15504,6 +16144,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0739bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0739b.jpg
+astropix_ids: esahubble|opo0739b
 
 credits> NASA, ESA, and G. Canalizo (Univ; This image taken by Hubble shows the
 host galaxy of the quasar MC2 1635+119. The quasar sits in an indisturbed
@@ -15528,6 +16169,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0742bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0742b.jpg
+astropix_ids: esahubble|opo0742b
 
 credits> D. Verschatse (Antilhue Observat; Ground-based Image of Globular
 Cluster NGC 6397...
@@ -15551,6 +16193,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0742cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0742c.jpg
+astropix_ids: esahubble|opo0742c
 
 credits> NASA, ESA, and H. Richer (Univer; Hubble Space Telescope Image of
 Globular Cluster NGC 6397...
@@ -15574,6 +16217,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0813aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0813a.jpg
+astropix_ids: esahubble|opo0813a
 
 credits> NASA, ESA, and the Hubble Herita; Probing a glowing bubble of gas and
 dust encircling a dying star, the NASA/ESA Hubble Space Telescope reveals a
@@ -15598,6 +16242,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0822aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0822a.jpg
+astropix_ids: esahubble|opo0822a
 
 credits> NASA, ESA, and the Hubble Herita; A delicate ribbon of gas floats
 eerily in our galaxy. A contrail from an alien spaceship? A jet from a black
@@ -15622,6 +16267,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0825bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0825b.jpg
+astropix_ids: esahubble|opo0825b
 
 credits> NASA, ESA, DSS, and L. Bedin (ST; This is a ground-based telescopic
 view of NGC 6791, located 13,300 light-years away in the constellation Lyra....
@@ -15645,6 +16291,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0825cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0825c.jpg
+astropix_ids: esahubble|opo0825c
 
 credits> NASA, ESA, and L. Bedin (STScI); The full Hubble Advanced Camera for
 Surveys field is full of stars estimated to be 8 billion years old. Two
@@ -15669,6 +16316,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0825dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0825d.jpg
+astropix_ids: esahubble|opo0825d
 
 credits> NASA, ESA, and L. Bedin (STScI); A blow up of view of a small region of
 the Advanced Camera for Surveys field reveals very faint white dwarfs. The
@@ -15693,6 +16341,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0829bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0829b.jpg
+astropix_ids: esahubble|opo0829b
 
 credits> NASA, ESA, K. Sheth (Spitzer Sci; Barred spiral galaxy 3127341 is
 located 2.1 billion light-years away from Earth. The galaxy is part of a
@@ -15717,6 +16366,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0829dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0829d.jpg
+astropix_ids: esahubble|opo0829d
 
 credits> NASA, ESA, K. Sheth (Spitzer Sci; Barred spiral galaxy 1161898 is
 located 5.3 billion light-years away from Earth. The galaxy is part of a
@@ -15741,6 +16391,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0829eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0829e.jpg
+astropix_ids: esahubble|opo0829e
 
 credits> NASA, ESA, K. Sheth (Spitzer Sci; Barred spiral galaxy 2607238 is
 located 6.4 billion light-years away from Earth. The galaxy is part of a
@@ -15765,6 +16416,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0833aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0833a.jpg
+astropix_ids: esahubble|opo0833a
 
 credits> NASA, ESA, and the Hubble Herita; The NASA/ESA Hubble Space Telescope
 has captured a rare alignment between two spiral galaxies. The outer rim of a
@@ -15789,6 +16441,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0834aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0834a.jpg
+astropix_ids: esahubble|opo0834a
 
 credits> NASA, ESA, and The Hubble Herita; Located in the Southern Hemisphere,
 NGC 3324 is at the northwest corner of the Carina Nebula (NGC 3372), home of the
@@ -15813,6 +16466,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0838aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0838a.jpg
+astropix_ids: esahubble|opo0838a
 
 credits> Advanced Camera Data: NASA, ESA, A. Aloisi (STScI/ESA), J. Mack and A.
 Grocholski (STScI), M. Sirianni (STScI/ESA), R. van der Marel (STScI), L.
@@ -15841,6 +16495,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0840aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0840a.jpg
+astropix_ids: esahubble|opo0840a
 
 credits> NASA, ESA, and the Hubble Herita; Like a whirl of shiny flakes
 sparkling in a snow globe, the NASA/ESA Hubble Space Telescope catches an
@@ -15865,6 +16520,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0840dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0840d.jpg
+astropix_ids: esahubble|opo0840d
 
 credits> NASA, ESA, and the Hubble Herita; Hubble catches an instantaneous
 glimpse of many hundreds of thousands of stars moving about in the globular
@@ -15889,6 +16545,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0902aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0902a.jpg
+astropix_ids: esahubble|opo0902a
 
 credits> NASA, ESA and Q.D. Wang (Univers; This composite colour infrared image
 of the centre of our Milky Way galaxy reveals a new population of massive stars
@@ -15913,6 +16570,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0902bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0902b.jpg
+astropix_ids: esahubble|opo0902b
 
 credits> NASA, ESA and Q.D. Wang (Univers; This NASA/ESA Hubble Space Telescope
 infrared mosaic image represents the sharpest survey of the galactic centre to
@@ -15937,6 +16595,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0907cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0907c.jpg
+astropix_ids: esahubble|opo0907c
 
 credits> NASA, ESA, CXC, SSC and STScI; The red colour is Spitzer's view in
 infared light. Most of this light comes the galaxy's delicate dust lanes. Such
@@ -15961,6 +16620,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0907dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0907d.jpg
+astropix_ids: esahubble|opo0907d
 
 credits> NASA, ESA, K. Kuntz (JHU), F. Br; The yellow colour is Hubble's view in
 visible light. Most of this light comes from stars, and they trace the same
@@ -15985,6 +16645,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0907eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0907e.jpg
+astropix_ids: esahubble|opo0907e
 
 credits> NASA, CXC, and K. Kuntz (JHU); The blue colour shows Chandra's view in
 X-ray light. Sources of X-rays include million-degree gas, exploded stars, and
@@ -16009,6 +16670,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0907gL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0907g.jpg
+astropix_ids: esahubble|opo0907g
 
 credits> NASA, Jet Propulsion Laboratory/; The galaxy Messier 101 is a swirling
 spiral of stars, gas, and dust. Messier 101 is nearly twice as wide as our Milky
@@ -16033,6 +16695,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0907iL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0907i.jpg
+astropix_ids: esahubble|opo0907i
 
 credits> NASA, CXC and K. Kuntz (JHU); Chandra's image of Messier 101, taken in
 X-ray light, shows the high-energy features of this spiral galaxy. X-rays are
@@ -16057,6 +16720,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0908bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0908b.jpg
+astropix_ids: esahubble|opo0908b
 
 credits> NASA, ESA and A. Riess (STScI/JH; This is a NASA/ESA Hubble Space
 Telescope photo of the spiral galaxy NGC 3021. This was one of several hosts of
@@ -16081,6 +16745,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0908cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0908c.jpg
+astropix_ids: esahubble|opo0908c
 
 credits> NASA, ESA and A. Riess (STScI/JH; This image is part of a montage of
 images of the spiral galaxy NGC 3021 taken by the NASA/ESA Hubble Space
@@ -16105,6 +16770,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0908dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0908d.jpg
+astropix_ids: esahubble|opo0908d
 
 credits> NASA, ESA and A. Riess (STScI/JH; This image is part of a montage of
 images of the spiral galaxy NGC 3021 taken by the NASA/ESA Hubble Space
@@ -16129,6 +16795,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0908eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0908e.jpg
+astropix_ids: esahubble|opo0908e
 
 credits> NASA, ESA and A. Riess (STScI/JH; This image is part of a montage of
 images of the spiral galaxy NGC 3021 taken by the NASA/ESA Hubble Space
@@ -16153,6 +16820,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0908fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0908f.jpg
+astropix_ids: esahubble|opo0908f
 
 credits> NASA, ESA and A. Riess (STScI/JH; This image is part of a montage of
 images of the spiral galaxy NGC 3021 taken by the NASA/ESA Hubble Space
@@ -16177,6 +16845,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0916bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0916b.jpg
+astropix_ids: esahubble|opo0916b
 
 credits> NASA, ESA and J. Madrid (McMaste; Image taken on 17 May 1999....
 
@@ -16199,6 +16868,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0916cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0916c.jpg
+astropix_ids: esahubble|opo0916c
 
 credits> NASA, ESA and J. Madrid (McMaste; Image taken on 17 July 2002....
 
@@ -16221,6 +16891,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0916dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0916d.jpg
+astropix_ids: esahubble|opo0916d
 
 credits> NASA, ESA and J. Madrid (McMaste; Image taken on 27 February 2002....
 
@@ -16243,6 +16914,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0916eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0916e.jpg
+astropix_ids: esahubble|opo0916e
 
 credits> NASA, ESA and J. Madrid (McMaste; Image taken on 17 April 2003....
 
@@ -16265,6 +16937,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0916fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0916f.jpg
+astropix_ids: esahubble|opo0916f
 
 credits> NASA, ESA and J. Madrid (McMaste; Image taken on 9 May 2005....
 
@@ -16287,6 +16960,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0916gL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0916g.jpg
+astropix_ids: esahubble|opo0916g
 
 credits> NASA, ESA and J. Madrid (McMaste; Image taken on 28 November 2006....
 
@@ -16309,6 +16983,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0919bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0919b.jpg
+astropix_ids: esahubble|opo0919b
 
 credits> NASA, ESA and K. McQuinn (Univer; This image, taken by the NASA/ESA
 Hubble Space Telescope, shows myriad stars residing in the central region of the
@@ -16333,6 +17008,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0919cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0919c.jpg
+astropix_ids: esahubble|opo0919c
 
 credits> NASA, ESA and K. McQuinn (Univer; This image, taken by the NASA/ESA
 Hubble Space Telescope, shows myriad stars residing in the central regions of
@@ -16357,6 +17033,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0919dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0919d.jpg
+astropix_ids: esahubble|opo0919d
 
 credits> NASA, ESA and K. McQuinn (Univer; This image, taken by the NASA/ESA
 Hubble Space Telescope, shows myriad stars residing in the central regions of
@@ -16381,6 +17058,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0921aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0921a.jpg
+astropix_ids: esahubble|opo0921a
 
 credits> NASA, ESA and the Hubble Heritag; The Hubble community bids farewell to
 the soon-to-be decommissioned Wide Field Planetary Camera 2 (WFPC2) onboard the
@@ -16405,6 +17083,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0928bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0928b.jpg
+astropix_ids: esahubble|opo0928b
 
 credits> NASA, ESA, SSC, CXC and STScI; In celebration of the International Year
 of Astronomy 2009, the NASA/ESA Hubble Space Telescope and its companion Great
@@ -16429,6 +17108,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0928dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0928d.jpg
+astropix_ids: esahubble|opo0928d
 
 credits> NASA, JPL-Caltech, E. Churchwell; The Spitzer Space Telescope's
 infrared-light observations provide a detailed and spectacular view of the
@@ -16453,6 +17133,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0928eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0928e.jpg
+astropix_ids: esahubble|opo0928e
 
 credits> NASA, ESA, Q.D. Wang (Univ. of M; Although best known for its
 visible-light images, the Hubble Space Telescope also observes over a limited
@@ -16477,6 +17158,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0928fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0928f.jpg
+astropix_ids: esahubble|opo0928f
 
 credits> NASA, CXC, D. Wang (University o; X-rays detected by the Chandra X-ray
 Observatory expose a wealth of exotic objects and high-energy features. In this
@@ -16501,6 +17183,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0929bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0929b.jpg
+astropix_ids: esahubble|opo0929b
 
 credits> NASA, ESA and the Hubble Heritag; The spectacular new camera installed
 on the NASA/ESA Hubble Space Telescope during Servicing Mission 4 in May has
@@ -16525,6 +17208,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0929cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0929c.jpg
+astropix_ids: esahubble|opo0929c
 
 credits> ESO; This is an image of the galaxy M83, taken by the European Southern
 Observatory's Wide Field Imager on the ESO/MPG 2.2-metre tele...
@@ -16548,6 +17232,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0929eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0929e.jpg
+astropix_ids: esahubble|opo0929e
 
 credits> Digitized Sky Survey (DSS), STScI/AURA, Palomar/Caltech and UKSTU/AAO;
 This is a Digitized Sky Survey (DSS) image of the field around M83. This image
@@ -16572,6 +17257,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0932aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0932a.jpg
+astropix_ids: esahubble|opo0932a
 
 credits> NASA, ESA, and F. Paresce (INAF-; Just in time for the holidays: a
 Hubble Space Telescope picture postcard of hundreds of brilliant blue stars
@@ -16596,6 +17282,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0932fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo0932f.jpg
+astropix_ids: esahubble|opo0932f
 
 credits> NASA, ESA, and F. Paresce (INAF-; The massive, young stellar grouping,
 called R136, is only a few million years old and resides in the 30 Doradus
@@ -16620,6 +17307,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1000aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1000a.jpg
+astropix_ids: esahubble|opo1000a
 
 credits> NASA, ESA, and the Hubble Herita; A bluish-white spiral galaxy hangs
 delicately in the cold vacuum of space. Known as NGC 1376, this snowflake-shaped
@@ -16644,6 +17332,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1005aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1005a.jpg
+astropix_ids: esahubble|opo1005a
 
 credits> NASA, ESA, and J. Dalcanton and ; NGC 2976 does not look like a typical
 spiral galaxy, as this NASA/ESA Hubble Space Telescope image shows. In this view
@@ -16690,6 +17379,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1008aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1008a.jpg
+astropix_ids: esahubble|opo1008a
 
 credits> NASA, ESA, S. Gallagher (The Uni; These four dwarf galaxies waited
 billions of years to come together, setting off a fireworks show as thousands of
@@ -16714,6 +17404,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1008bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1008b.jpg
+astropix_ids: esahubble|opo1008b
 
 credits> NASA, ESA, J. English (Universit; These four dwarf galaxies waited
 billions of years to come together, setting off a fireworks show as thousands of
@@ -16738,6 +17429,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1019bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1019b.jpg
+astropix_ids: esahubble|opo1019b
 
 credits> NASA, ESA, O. Gnedin (University; This NASA/ESA Hubble Space Telescope
 image shows the hypervelocity star that was kicked out of the centre of our
@@ -16762,6 +17454,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1022aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1022a.jpg
+astropix_ids: esahubble|opo1022a
 
 credits> NASA, ESA, R. O'Connell (Univers; Like a 4th of July fireworks display,
 a young, glittering collection of stars looks like an aerial burst. The cluster
@@ -16786,6 +17479,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1024aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1024a.jpg
+astropix_ids: esahubble|opo1024a
 
 credits> NASA, ESA, and the Hubble Herita; A long-exposure Hubble Space
 Telescope image shows a majestic face-on spiral galaxy located deep within the
@@ -16810,6 +17504,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1029aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1029a.jpg
+astropix_ids: esahubble|opo1029a
 
 credits> NASA, ESA, and the Hubble Herita; Enjoying a frozen treat on a hot
 summer day can leave a sticky mess as it melts in the Sun and deforms. In the
@@ -16834,6 +17529,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1030aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1030a.jpg
+astropix_ids: esahubble|opo1030a
 
 credits> NASA, ESA, K. France (University; This image shows the entire region
 around supernova 1987A. The most prominent feature in the image is a ring with
@@ -16858,6 +17554,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1036aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1036a.jpg
+astropix_ids: esahubble|opo1036a
 
 credits> NASA, ESA, and the Hubble Herita; Though the universe is chock full of
 spiral-shaped galaxies, no two look exactly the same. This face-on spiral
@@ -16882,6 +17579,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1037aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1037a.jpg
+astropix_ids: esahubble|opo1037a
 
 credits> NASA, ESA, D. Coe (NASA Jet Prop; This NASA/ESA Hubble Space Telescope
 image shows the distribution of dark matter in the centre of the giant galaxy
@@ -16906,6 +17604,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1038bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1038b.jpg
+astropix_ids: esahubble|opo1038b
 
 credits> NASA, ESA, R.M. Crockett (Univer; Elliptical galaxy NGC 4150....
 
@@ -16928,6 +17627,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1038cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1038c.jpg
+astropix_ids: esahubble|opo1038c
 
 credits> NASA, ESA, R.M. Crockett (Univer; Core of elliptical galaxy NGC 4150
 (detailed view)....
@@ -16951,6 +17651,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1116bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1116b.jpg
+astropix_ids: esahubble|opo1116b
 
 credits> NASA, ESA, W. Clarkson (Indiana ; Hubble ACS SWEEPS field....
 
@@ -16973,6 +17674,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1130bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1130b.jpg
+astropix_ids: esahubble|opo1130b
 
 credits> NASA, ESA, and J. Lotz (STScI); Merging galaxies — 2.4 billion
 light-years from Earth....
@@ -16996,6 +17698,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1130cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1130c.jpg
+astropix_ids: esahubble|opo1130c
 
 credits> NASA, ESA, and J. Lotz (STScI); Merging galaxies — 3 billion
 light-years from Earth....
@@ -17019,6 +17722,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1130dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1130d.jpg
+astropix_ids: esahubble|opo1130d
 
 credits> NASA, ESA, and J. Lotz (STScI); Merging galaxies — 5.3 billion
 light-years from Earth....
@@ -17042,6 +17746,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1130eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1130e.jpg
+astropix_ids: esahubble|opo1130e
 
 credits> NASA, ESA, and J. Lotz (STScI); Merging galaxies — 6.2 billion
 light-years from Earth....
@@ -17065,6 +17770,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1212eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1212e.jpg
+astropix_ids: esahubble|opo1212e
 
 credits> NOAO, AURA, NSF, and N. Smith (U; This image shows a giant star-forming
 region in the southern sky known as the Carina Nebula and combines the light
@@ -17089,6 +17795,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1247aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1247a.jpg
+astropix_ids: esahubble|opo1247a
 
 credits> NASA, ESA, S. Baum and C. O'Dea ; Spectacular jets powered by the
 gravitational energy of a supermassive black hole in the core of the elliptical
@@ -17113,6 +17820,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1308aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1308a.jpg
+astropix_ids: esahubble|opo1308a
 
 credits> Digitized Sky Survey (DSS), STSc; This is a Digitized Sky Survey image
 of the oldest star with a well-determined age in our galaxy. The ageing star,
@@ -17137,6 +17845,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1432bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1432b.jpg
+astropix_ids: esahubble|opo1432b
 
 credits> NASA, ESA, The Hubble Heritage T; This image shows spiral galaxy NGC
 1309. Astronomers have observed a rare type Iax supernova in the outskirts of
@@ -17161,6 +17870,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1432cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1432c.jpg
+astropix_ids: esahubble|opo1432c
 
 credits> NASA, ESA, C. McCully and S. Jha; These Hubble data from 2005 and 2006
 show the progenitor system for Supernova 2012Z, a supernova in the outskirts of
@@ -17185,6 +17895,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1432dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1432d.jpg
+astropix_ids: esahubble|opo1432d
 
 credits> NASA, ESA, C. McCully and S. Jha; This image shows Supernova 2012Z,
 found in the outskirts of the spiral galaxy NGC 1309. The stellar blast is a
@@ -17209,6 +17920,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1443aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1443a.jpg
+astropix_ids: esahubble|opo1443a
 
 credits> NASA, ESA, M. Montes (IAC), and ; The massive galaxy cluster Abell
 2744, nicknamed Pandora's Cluster, takes on a ghostly look in this NASA/ESA
@@ -17233,6 +17945,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1448jL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1448j.jpg
+astropix_ids: esahubble|opo1448j
 
 credits> NASA, ESA, and P. Sell (Texas Te; This NASA/ESA Hubble Space Telescope
 image of the galaxy J1613+2834 shows it is undergoing a firestorm of star birth,
@@ -17257,6 +17970,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1448kL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1448k.jpg
+astropix_ids: esahubble|opo1448k
 
 credits> NASA, ESA, and P. Sell (Texas Te; This NASA/ESA Hubble Space Telescope
 image of the galaxy J1634+4619 shows it is undergoing a firestorm of star birth,
@@ -17281,6 +17995,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1448lL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1448l.jpg
+astropix_ids: esahubble|opo1448l
 
 credits> NASA, ESA, and P. Sell (Texas Te; This NASA/ESA Hubble Space Telescope
 image of the galaxy J1713+2817 shows it is undergoing a firestorm of star birth,
@@ -17305,6 +18020,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1521bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1521b.jpg
+astropix_ids: esahubble|opo1521b
 
 credits> NASA, ESA, and J. Mauerhan (Univ; This visible-light image taken by
 NASA's Hubble Space Telescope reveals a pancake-shaped disk of gas around an
@@ -17329,6 +18045,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1531bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1531b.jpg
+astropix_ids: esahubble|opo1531b
 
 credits> NASA, ESA, the Hubble Heritage T; This Hubble Space Telescope image
 reveals a bright starlike glow in the center of the interacting galaxy Markarian
@@ -17353,6 +18070,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1629bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1629b.jpg
+astropix_ids: esahubble|opo1629b
 
 credits> NASA, ESA, and E. Tollerud (STSc; This image shows the galaxy Pisces A.
 The bright object at the top of the image is a distant background galaxy. Other
@@ -17377,6 +18095,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1629cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1629c.jpg
+astropix_ids: esahubble|opo1629c
 
 credits> NASA, ESA, and E. Tollerud (STS; This image shows the galaxy Pisces B.
 The bright object with the diffraction spikes below left of centre is a
@@ -17401,6 +18120,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1727bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1727b.jpg
+astropix_ids: esahubble|opo1727b
 
 credits> NASA, ESA, and T. Johnson (Unive; The galaxy cluster shown here, SDSS
 J1110+6459, was discovered as part of the Sloan Giant Arcs Survey. It is located
@@ -17425,6 +18145,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1733aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1733a.jpg
+astropix_ids: esahubble|opo1733a
 
 credits> NASA, ESA, and B. Sunnquist and ; Some asteroids from within our Solar
 System have photobombed deep images of the Universe taken by the NASA/ESA Hubble
@@ -17449,6 +18170,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1733bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1733b.jpg
+astropix_ids: esahubble|opo1733b
 
 credits> NASA, ESA, and B. Sunnquist and ; As if this Hubble Space Telescope
 picture isn't cluttered enough with myriad galaxies, nearby asteroids photobomb
@@ -17473,6 +18195,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1801aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo1801a.jpg
+astropix_ids: esahubble|opo1801a
 
 credits> NASA, ESA, and T. Brown (STScI),; This image from the NASA/ESA Hubble
 Space Telescope shows a sparkling jewel box full of stars captured the heart of
@@ -17497,6 +18220,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9009cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9009c.jpg
+astropix_ids: esahubble|opo9009c
 
 credits> NASA/ESA; Computer processing of the HST image sharpens the appearance
 of the cluster by subtracting stellar halos introduced by spherical...
@@ -17520,6 +18244,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9009dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9009d.jpg
+astropix_ids: esahubble|opo9009d
 
 credits> George Meylan and ESO; This is a 2.7 X 2.7 arc minute view of star
 cluster R136 as seen from a ground-based telescope under exceptional observing
@@ -17544,6 +18269,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9009eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9009e.jpg
+astropix_ids: esahubble|opo9009e
 
 credits> NASA/ESA; This unprocessed image, taken with NASA/ESA Hubble Space
 Telescope, yields stellar diameters of 0.1 arc second, allowing many mo...
@@ -17567,6 +18293,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9212aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9212a.jpg
+astropix_ids: esahubble|opo9212a
 
 credits> S. Heap, NASA/ESA/Goddard Space ; This photograph from the NASA/ESA
 Hubble Space Telescope presents the first clear view of one of the hottest known
@@ -17591,6 +18318,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9216bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9216b.jpg
+astropix_ids: esahubble|opo9216b
 
 credits> E. Shaya, D. Dowling/U. of Maryl; An image of the central part of the
 ultra-luminuous infrared galaxy Arp 220 taken with the WFPC on the Hubble Space
@@ -17615,6 +18343,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9227aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9227a.jpg
+astropix_ids: esahubble|opo9227a
 
 credits> N/A; This is a Hubble Space Telescope (HST) image of the core of galaxy
 NGC 4261....
@@ -17638,6 +18367,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9229aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9229a.jpg
+astropix_ids: esahubble|opo9229a
 
 credits> C.R. O'Dell (Rice University), a; A NASA Hubble Space Telescope "true
 color" mosaic image of a small portion of the Orion Nebula, taken the Wide Field
@@ -17662,6 +18392,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9404bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9404b.jpg
+astropix_ids: esahubble|opo9404b
 
 credits> NASA/ESA, STScI; The image shows the Star Cluster R136 in 30
 Doradus....
@@ -17685,6 +18416,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9404cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9404c.jpg
+astropix_ids: esahubble|opo9404c
 
 credits> NASA, STScI, ESA/Hubble; The star cluster R136 is a cluster of young,
 bright stars in 30 Doradus. The image of the cluster was obtained using the
@@ -17709,6 +18441,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9425aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9425a.jpg
+astropix_ids: esahubble|opo9425a
 
 credits> Alan Dressier (Carnegie Institut; This NASA/ESA Hubble Space Telescope
 (HST) image of the central portion of a remote cluster of galaxies (CL
@@ -17733,6 +18466,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9451aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9451a.jpg
+astropix_ids: esahubble|opo9451a
 
 credits> Dwingeloo Obscured Galaxy Survey; This visual light image of a newly
 discovered galaxy called "Dwingeloo 1," was taken with the Isaac Newton
@@ -17757,6 +18491,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9544aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9544a.jpg
+astropix_ids: esahubble|opo9544a
 
 credits> Jeff Hester and Paul Scowen (Ari; Undersea coral? Enchanted castles?
 Space serpents? These eerie, dark pillar-like structures are actually columns of
@@ -17781,6 +18516,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9617bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9617b.jpg
+astropix_ids: esahubble|opo9617b
 
 credits> Nino Panagia ( Space Telescope S; The NASA/ESA Hubble Space Telescope
 has snapped a view of several star generations in the central region of the
@@ -17805,6 +18541,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9635b2L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9635b2.jpg
+astropix_ids: esahubble|opo9635b2
 
 credits> John Bahcall (Institute for Adva; In this image astronomers can
 thoroughly examine the quasar's nucleus....
@@ -17828,6 +18565,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9638aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9638a.jpg
+astropix_ids: esahubble|opo9638a
 
 credits> A. Caulet (ST-ECF, ESA) and NASA; This Hubble Space Telescope (HST)
 image reveals a pair of one-half light-year long interstellar 'twisters' --
@@ -17852,6 +18590,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9638bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9638b.jpg
+astropix_ids: esahubble|opo9638b
 
 credits> A. Caulet (ST-ECF, ESA) and NASA; This Hubble Space Telescope (HST)
 image reveals a pair of one-half light-year long interstellar 'twisters' - eerie
@@ -17876,6 +18615,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9711bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9711b.jpg
+astropix_ids: esahubble|opo9711b
 
 credits> Rodger Thompson, Marcia Rieke, G; The Egg Nebula, also known as CRL
 2688, is shown as it appears in visible light with the Hubble Space Telescope's
@@ -17900,6 +18640,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9711cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9711c.jpg
+astropix_ids: esahubble|opo9711c
 
 credits> Rodger Thompson, Marcia Rieke, G; The Egg Nebula, also known as CRL
 2688, is shown as it appears in infrared light with Hubble's Near Infrared
@@ -17924,6 +18665,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9734pL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9734p.jpg
+astropix_ids: esahubble|opo9734p
 
 credits> Francois Schweizer (CIW/DTM); The spiral galaxies NGC 4038 and NGC 4039
 form together the famous Antennae Galaxies, named after the long tails of gas,
@@ -17948,6 +18690,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9734qL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9734q.jpg
+astropix_ids: esahubble|opo9734q
 
 credits> Francois Schweizer (CIW/DTM); NGC 7252 is the resulting objects of two
 galaxies colliding with each others a billion years ago. Because of its
@@ -17972,6 +18715,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9734uL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9734u.jpg
+astropix_ids: esahubble|opo9734u
 
 credits> B. Whitmore (STScI); In NGC 7252, where we had discovered ~40 globular
 clusters with the Hubble before its refurbishment, we have recently
@@ -17996,6 +18740,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9734vL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9734v.jpg
+astropix_ids: esahubble|opo9734v
 
 credits> B. Whitmore (STScI); In NGC 3921, we have discovered over 100 new young
 clusters. There are two reasons to believe that all these young clusters form...
@@ -18019,6 +18764,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9734wL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9734w.jpg
+astropix_ids: esahubble|opo9734w
 
 credits> Brad Whitmore (STScI); Includes an image made in red light from
 hydrogen gas....
@@ -18042,6 +18788,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c10L{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9738c10.jpg
+astropix_ids: esahubble|opo9738c10
 
 credits> Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble
 Gallery of Planetary Nebulae....
@@ -18065,6 +18812,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c11L{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9738c11.jpg
+astropix_ids: esahubble|opo9738c11
 
 credits> Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble
 Gallery of Planetary Nebulae....
@@ -18088,6 +18836,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c12L{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9738c12.jpg
+astropix_ids: esahubble|opo9738c12
 
 credits> Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble
 Gallery of Planetary Nebulae....
@@ -18111,6 +18860,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c13L{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9738c13.jpg
+astropix_ids: esahubble|opo9738c13
 
 credits> Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble
 Gallery of Planetary Nebulae....
@@ -18134,6 +18884,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c14L{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9738c14.jpg
+astropix_ids: esahubble|opo9738c14
 
 credits> Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble
 Gallery of Planetary Nebulae....
@@ -18157,6 +18908,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c15L{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9738c15.jpg
+astropix_ids: esahubble|opo9738c15
 
 credits> Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble
 Gallery of Planetary Nebulae....
@@ -18180,6 +18932,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c17L{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9738c17.jpg
+astropix_ids: esahubble|opo9738c17
 
 credits> Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble
 Gallery of Planetary Nebulae....
@@ -18203,6 +18956,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c19L{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9738c19.jpg
+astropix_ids: esahubble|opo9738c19
 
 credits> Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble
 Gallery of Planetary Nebulae....
@@ -18226,6 +18980,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c1L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9738c1.jpg
+astropix_ids: esahubble|opo9738c1
 
 credits> Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble
 Gallery of Planetary Nebulae....
@@ -18249,6 +19004,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c21L{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9738c21.jpg
+astropix_ids: esahubble|opo9738c21
 
 credits> Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble
 Gallery of Planetary Nebulae....
@@ -18272,6 +19028,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c22L{1}X{2}Y{3}.pn
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9738c22.jpg
+astropix_ids: esahubble|opo9738c22
 
 credits> Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble
 Gallery of Planetary Nebulae....
@@ -18295,6 +19052,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c3L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9738c3.jpg
+astropix_ids: esahubble|opo9738c3
 
 credits> Bruce Balick and Jason Alexander; This image is a part of the Hubble
 Gallery of Planetary Nebulae....
@@ -18318,6 +19076,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c4L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9738c4.jpg
+astropix_ids: esahubble|opo9738c4
 
 credits> Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble
 Gallery of Planetary Nebulae....
@@ -18341,6 +19100,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c5L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9738c5.jpg
+astropix_ids: esahubble|opo9738c5
 
 credits> Bruce Balick (University of Wash; This image is a part of the Hubble
 Gallery of Planetary Nebulae....
@@ -18364,6 +19124,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c6L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9738c6.jpg
+astropix_ids: esahubble|opo9738c6
 
 credits> Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble
 Gallery of Planetary Nebulae....
@@ -18387,6 +19148,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c7L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9738c7.jpg
+astropix_ids: esahubble|opo9738c7
 
 credits> Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble
 Gallery of Planetary Nebulae....
@@ -18410,6 +19172,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c9L{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9738c9.jpg
+astropix_ids: esahubble|opo9738c9
 
 credits> Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble
 Gallery of Planetary Nebulae....
@@ -18433,6 +19196,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9808fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9808f.jpg
+astropix_ids: esahubble|opo9808f
 
 credits> Peter Garnavich (Harvard-Smithso; Latest Hubble image shows knot in
 ring significantly brighter....
@@ -18456,6 +19220,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9815bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9815b.jpg
+astropix_ids: esahubble|opo9815b
 
 credits> Matt Bobrowsky (Orbital Sciences; This Wide Field and Planetary Camera
 2image captures the infancy of the Stingray nebula (Hen-1357), the youngest
@@ -18480,6 +19245,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9816aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9816a.jpg
+astropix_ids: esahubble|opo9816a
 
 credits> Rebecca Elson and Richard Sword,; A dazzling 'jewel-box' collection of
 over 20, 000 stars can be seen in crystal clarity in this NASA/ESA Hubble Space
@@ -18504,6 +19270,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9821fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9821f.jpg
+astropix_ids: esahubble|opo9821f
 
 credits> G. Fritz Benedict, Andrew Howell; The two spiral arms outside the ring
 are probably unrelated to the dust lanes, and seem to contain very little dust
@@ -18528,6 +19295,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9836fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9836f.jpg
+astropix_ids: esahubble|opo9836f
 
 credits> Robert Rubin and Christopher Ort; A combination of two composite images
 of NGC 6210. The outer, mostly green portion represents the light of doubly
@@ -18552,6 +19320,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9838eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9838e.jpg
+astropix_ids: esahubble|opo9838e
 
 credits> Yves Grosdidier (University of M; The massive, hot central star is
 known as a Wolf-Rayet star. This extremely rare and short-lived class of
@@ -18576,6 +19345,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9841kL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9841k.jpg
+astropix_ids: esahubble|opo9841k
 
 credits> STScI and the Anglo-Australian T; Location of the HDF South Sky Survey
 Image with overlay...
@@ -18599,6 +19369,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9841nL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9841n.jpg
+astropix_ids: esahubble|opo9841n
 
 credits> J. Gardner (NOAO/GSFC), Cerro To; After the great success of the
 origninal Hubble Deep Field, later called Hubble Deep Field North (HDF-N), an
@@ -18623,6 +19394,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9905iL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9905i.jpg
+astropix_ids: esahubble|opo9905i
 
 credits> John Krist (STScI) and the WFPC2; This wide-angle image (17,000 AU from
 top to bottom) shows the region around Haro 6-5b, which is located at the center
@@ -18647,6 +19419,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9910bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9910b.jpg
+astropix_ids: esahubble|opo9910b
 
 credits> Torsten Boeker, Space Telescope; Astronomers have used the NASA/ESA
 Hubble Space Telescope to produce an infrared 'photo essay' of spiral galaxies.
@@ -18671,6 +19444,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9910cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9910c.jpg
+astropix_ids: esahubble|opo9910c
 
 credits> Torsten Boeker, Space Telescope; Astronomers have used the NASA/ESA
 Hubble Space Telescope to produce an infrared 'photo essay' of spiral galaxies.
@@ -18695,6 +19469,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9923bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-opo9923b.jpg
+astropix_ids: esahubble|opo9923b
 
 credits> M. Heydari-Malayeri (Paris Obser; A NASA/ESA Hubble Space Telescope
 view of a turbulent cauldron of starbirth, called N159, taking place 170,000
@@ -18719,6 +19494,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1001aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1001a.jpg
+astropix_ids: esahubble|potw1001a
 
 credits> ESA/Hubble & NASA; As the first in the new weekly series of spectacular
 images from the NASA/ESA Hubble Space Telescope, the Hubble Picture of the ...
@@ -18742,6 +19518,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1002aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1002a.jpg
+astropix_ids: esahubble|potw1002a
 
 credits> ESA/Hubble and NASA; The richly textured spiral galaxy NGC 2082 is
 found about 60 million light-years away in the constellation of Dorado (the
@@ -18766,6 +19543,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1003aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1003a.jpg
+astropix_ids: esahubble|potw1003a
 
 credits> ESA/Hubble and NASA.; This striking Hubble image of the planetary
 nebula IC 4634 reveals two shining, S-shaped ejections from a dying star. This
@@ -18790,6 +19568,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1004aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1004a.jpg
+astropix_ids: esahubble|potw1004a
 
 credits> ESA/Hubble and NASA; That galaxies come in very different shapes and
 sizes is dramatically demonstrated by this striking Hubble image of the Hickson
@@ -18814,6 +19593,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1006aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1006a.jpg
+astropix_ids: esahubble|potw1006a
 
 credits> ESA/Hubble and NASA; The bright galaxy NGC 3810 demonstrates classical
 spiral structure in this very detailed image from Hubble. The bright central
@@ -18838,6 +19618,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1007aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1007a.jpg
+astropix_ids: esahubble|potw1007a
 
 credits> ESA/Hubble and NASA; The star HD 44179 is surrounded by an
 extraordinary structure known as the Red Rectangle. It acquired its moniker
@@ -18862,6 +19643,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1008aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1008a.jpg
+astropix_ids: esahubble|potw1008a
 
 credits> ESA/Hubble, R. Sahai and NASA; The little-known nebula IRAS 05437+2502
 billows out among the bright stars and dark dust clouds that surround it in this
@@ -18886,6 +19668,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1009aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1009a.jpg
+astropix_ids: esahubble|potw1009a
 
 credits> ESA/Hubble and NASA; The small spiral galaxy NGC 2758 is captured in
 great detail in this image from the Advanced Camera for Surveys (ACS) on the
@@ -18910,6 +19693,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1010aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1010a.jpg
+astropix_ids: esahubble|potw1010a
 
 credits> ESA/Hubble and NASA; The Hubble Space Telescope captured this beautiful
 image of NGC 6326, a planetary nebula with glowing wisps of outpouring gas th...
@@ -18933,6 +19717,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1011aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1011a.jpg
+astropix_ids: esahubble|potw1011a
 
 credits> ESA/Hubble and NASA; This image, taken by the Advanced Camera for
 Surveys on the Hubble Space Telescope, shows the core of the great globular
@@ -18957,6 +19742,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1012aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1012a.jpg
+astropix_ids: esahubble|potw1012a
 
 credits> ESA/Hubble and NASA.; This Hubble Space Telescope picture captures a
 brief but beautiful phase late in the life of a star. The curious cloud around
@@ -18981,6 +19767,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1013aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1013a.jpg
+astropix_ids: esahubble|potw1013a
 
 credits> ESA/Hubble and NASA; This spectacular NASA/ESA Hubble Space Telescope
 picture shows NGC 1872, a rich cluster of thousands of stars lying in our
@@ -19005,6 +19792,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1014aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1014a.jpg
+astropix_ids: esahubble|potw1014a
 
 credits> ESA/Hubble and NASA; This NASA/ESA Hubble Space Telescope picture
 depicts the galaxy NGC 1533 in the southern constellation of Dorado (the
@@ -19029,6 +19817,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1015aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1015a.jpg
+astropix_ids: esahubble|potw1015a
 
 credits> ESA/Hubble and NASA; This dramatic image from the NASA/ESA Hubble Space
 Telescope shows the planetary nebula NGC 3918, a brilliant cloud of colourful...
@@ -19052,6 +19841,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1016aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1016a.jpg
+astropix_ids: esahubble|potw1016a
 
 credits> ESA/Hubble/ESO and NASA; Haro 11 appears to shine gently amid clouds of
 gas and dust, but this placid facade belies the monumental rate of star
@@ -19076,6 +19866,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1017aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1017a.jpg
+astropix_ids: esahubble|potw1017a
 
 credits> ESA/Hubble, NASA and H. Ebeling.; At first glance, the scatter of pale
 dots on this NASA/ESA Hubble Space Telescope image looks like a snowstorm in the
@@ -19100,6 +19891,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1018aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1018a.jpg
+astropix_ids: esahubble|potw1018a
 
 credits> ESA/Hubble and NASA; This spectacular NASA/ESA Hubble Space Telescope
 image shows a bright scattering of stars in the small constellation of Sagitta
@@ -19124,6 +19916,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1019aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1019a.jpg
+astropix_ids: esahubble|potw1019a
 
 credits> ESA/Hubble and NASA ; A billowing cloud of hydrogen in the Triangulum
 galaxy (Messier 33), about 2.7 million light-years away from Earth, glows with
@@ -19148,6 +19941,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1020aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1020a.jpg
+astropix_ids: esahubble|potw1020a
 
 credits> ESA/NASA & R. Sahai; This remarkable picture from the Advanced Camera
 for Surveys on the NASA/ESA Hubble Space Telescope shows one of the most
@@ -19172,6 +19966,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1021aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1021a.jpg
+astropix_ids: esahubble|potw1021a
 
 credits> ESA/Hubble & NASA; Astronomers are used to encountering challenges in
 their work, but studying the prosaically-named galaxy PGC 39058 proves more d...
@@ -19195,6 +19990,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1022aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1022a.jpg
+astropix_ids: esahubble|potw1022a
 
 credits> ESA/Hubble and NASA﻿; The NASA/ESA Hubble Space Telescope snapped this
 striking image of an aging star whose outer layers of gas have blown off into
@@ -19219,6 +20015,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1023aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1023a.jpg
+astropix_ids: esahubble|potw1023a
 
 credits> ESA/Hubble & NASA; This bright spray of stars in the small but
 evocative constellation of Delphinus (the Dolphin) is the globular cluster NGC
@@ -19243,6 +20040,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1024aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1024a.jpg
+astropix_ids: esahubble|potw1024a
 
 credits> ESA/Hubble & NASA; The keen eye of the NASA/ESA Hubble Space Telescope
 has often peered deeply into the Orion Nebula to see the processes occurring...
@@ -19266,6 +20064,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1025aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1025a.jpg
+astropix_ids: esahubble|potw1025a
 
 credits> ESA/Hubble and NASA; The beautiful spiral galaxy NGC 406 was discovered
 in 1834 by John Herschel and is here imaged in great detail by the NASA/ESA H...
@@ -19289,6 +20088,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1026aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1026a.jpg
+astropix_ids: esahubble|potw1026a
 
 credits> ESA/Hubble and NASA; The NASA/ESA Hubble Space Telescope has taken a
 striking high resolution image of the curious planetary nebula NGC 6210.
@@ -19313,6 +20113,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1027aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1027a.jpg
+astropix_ids: esahubble|potw1027a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope has turned its
 sharp eye towards a tight collection of stars, first seen 174 years ago. The ...
@@ -19336,6 +20137,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1028aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1028a.jpg
+astropix_ids: esahubble|potw1028a
 
 credits> ESA/Hubble & NASA; At first glance NGC 3077 looks like a typical,
 relatively peaceful elliptical galaxy. However, as this NASA/ESA Hubble Space
@@ -19360,6 +20162,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1029aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1029a.jpg
+astropix_ids: esahubble|potw1029a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope has imaged a
 striking galaxy called NGC 4452, which appears to lie exactly edge-on as seen
@@ -19384,6 +20187,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1030aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1030a.jpg
+astropix_ids: esahubble|potw1030a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope has used its
 Advanced Camera for Surveys to peer closely at the strange cloud of gas and
@@ -19408,6 +20212,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1031aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1031a.jpg
+astropix_ids: esahubble|potw1031a
 
 credits> ESA/Hubble and NASA; Smaller, dimmer galaxies appear to flit like moths
 around a radiant street light in this image captured by the NASA/ESA Hubble S...
@@ -19431,6 +20236,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1032aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1032a.jpg
+astropix_ids: esahubble|potw1032a
 
 credits> ESA/Hubble and NASA; Fresh starbirth infuses the galaxy NGC 6503 with a
 vital pink glow in this image from the NASA/ESA Hubble Space Telescope. This ...
@@ -19454,6 +20260,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1033aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1033a.jpg
+astropix_ids: esahubble|potw1033a
 
 credits> ESA/Hubble & NASA; The star cluster is very bright and was discovered
 in the mid-eighteenth century. The nebula, however, is much more elusive and ...
@@ -19477,6 +20284,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1034aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1034a.jpg
+astropix_ids: esahubble|potw1034a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope has turned its
 eagle eye to the planetary nebula NGC 6572, a very bright example of these st...
@@ -19500,6 +20308,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1035aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1035a.jpg
+astropix_ids: esahubble|potw1035a
 
 credits> ESA/Hubble & NASA; The galaxy captured in this image, called UGC 12158,
 certainly isn’t camera-shy: this spiral stunner is posing face-on to the NA...
@@ -19523,6 +20332,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1036aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1036a.jpg
+astropix_ids: esahubble|potw1036a
 
 credits> ESA/Hubble & NASA; An image of the Cartwheel Galaxy taken with the
 NASA/ESA Hubble Space Telescope has been reprocessed using the latest
@@ -19547,6 +20357,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1101aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1101a.jpg
+astropix_ids: esahubble|potw1101a
 
 credits> ESA/Hubble & NASA; A spectacular section of the well-known Eagle Nebula
 has been targeted by the NASA/ESA Hubble Space Telescope. This collection o...
@@ -19570,6 +20381,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1102aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1102a.jpg
+astropix_ids: esahubble|potw1102a
 
 credits> ESA/Hubble & NASA; Astronomers have used the NASA/ESA Hubble Space
 Telescope to image the tiny planetary nebula NGC 6886. These celestial objects
@@ -19594,6 +20406,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1103aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1103a.jpg
+astropix_ids: esahubble|potw1103a
 
 credits> ESA/Hubble & NASA; The spiral galaxy NGC 1345 and its loose and ragged
 arms dominate this rich image from the NASA/ESA Hubble Space Telescope. It i...
@@ -19617,6 +20430,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1104aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1104a.jpg
+astropix_ids: esahubble|potw1104a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope has captured a
 clear view of the unusual globular cluster Palomar 1, whose youthful beauty i...
@@ -19640,6 +20454,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1105aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1105a.jpg
+astropix_ids: esahubble|potw1105a
 
 credits> ESA/Hubble & NASA; Hubble's Advanced Camera for Surveys has captured
 this moment in the ever-changing life of a spiral galaxy called IC 391.
@@ -19664,6 +20479,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1107aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1107a.jpg
+astropix_ids: esahubble|potw1107a
 
 credits> ESA/Hubble & NASA; The dazzling stars in Messier 15 look fresh and new
 in this image from the NASA/Hubble Space Telescope, but they are actually al...
@@ -19687,6 +20503,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1108aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1108a.jpg
+astropix_ids: esahubble|potw1108a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope has produced
 this finely detailed image of the beautiful spiral galaxy NGC 6384. This
@@ -19711,6 +20528,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1109aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1109a.jpg
+astropix_ids: esahubble|potw1109a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope has taken a
 close-up view of an outer part of the Orion Nebula’s little brother, Messier
@@ -19735,6 +20553,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1110aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1110a.jpg
+astropix_ids: esahubble|potw1110a
 
 credits> ESA/Hubble & NASA; The strange and irregular bundle of jets and clouds
 in this curious image from the NASA/ESA Hubble Space Telescope is the result...
@@ -19758,6 +20577,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1111aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1111a.jpg
+astropix_ids: esahubble|potw1111a
 
 credits> ESA/Hubble & NASA ; Most of the rich globular star clusters that orbit
 the Milky Way have cores that are tightly packed with stars, but NGC 288 is o...
@@ -19781,6 +20601,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1112aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1112a.jpg
+astropix_ids: esahubble|potw1112a
 
 credits> NASA, ESA, A. Riess (STScI/JHU),; This view from the NASA/ESA Hubble
 Space Telescope shows the beautiful spiral galaxy NGC 5584. This galaxy has
@@ -19805,6 +20626,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1113aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1113a.jpg
+astropix_ids: esahubble|potw1113a
 
 credits> ESA/Hubble & NASA ; The high concentration of stars within globular
 clusters, like Messier 12, shown here in an image from the NASA/ESA Hubble
@@ -19829,6 +20651,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1114aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1114a.jpg
+astropix_ids: esahubble|potw1114a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope has captured a
 planetary nebula with unconventional good looks. Planetary nebulae signal the...
@@ -19852,6 +20675,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1115aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1115a.jpg
+astropix_ids: esahubble|potw1115a
 
 credits> ESA/Hubble & NASA; Astronomers have used the NASA/ESA Hubble Space
 Telescope to study the young open star cluster IC 1590, which is found within
@@ -19876,6 +20700,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1116aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1116a.jpg
+astropix_ids: esahubble|potw1116a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope usually works as
 a solo artist to capture awe-inspiring images of the distant Universe. For ...
@@ -19899,6 +20724,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1117aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1117a.jpg
+astropix_ids: esahubble|potw1117a
 
 credits> ESA/Hubble & NASA ; Galaxies come in all sorts of shapes and sizes,
 with most being classed as either elliptical or spiral. However, some fall into
@@ -19923,6 +20749,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1118aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1118a.jpg
+astropix_ids: esahubble|potw1118a
 
 credits> ESA/Hubble & NASA ; The globular cluster Messier 5, shown here in this
 NASA/ESA Hubble Space Telescope image, is one of the oldest belonging to the ...
@@ -19946,6 +20773,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1119aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1119a.jpg
+astropix_ids: esahubble|potw1119a
 
 credits> ESA/Hubble & NASA; This NASA/ESA Hubble Space Telescope image shows the
 edge-on profile of the slender spiral galaxy NGC 5775. Although the spiral ...
@@ -19969,6 +20797,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1120aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1120a.jpg
+astropix_ids: esahubble|potw1120a
 
 credits> ESA/Hubble & NASA ; Like a Dali masterpiece, this image of Messier 8
 from the NASA/ESA Hubble Space Telescope is both intensely colourful and
@@ -19993,6 +20822,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1121aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1121a.jpg
+astropix_ids: esahubble|potw1121a
 
 credits> ESA/Hubble & NASA ; Deep within the Milky Way lies the ancient globular
 cluster Terzan 5. This NASA/ESA Hubble Space Telescope image shows the clust...
@@ -20016,6 +20846,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1122aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1122a.jpg
+astropix_ids: esahubble|potw1122a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope is renowned for
 its breathtaking images and this snapshot of NGC 634 is definitely that — th...
@@ -20039,6 +20870,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1123aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1123a.jpg
+astropix_ids: esahubble|potw1123a
 
 credits> ESA/Hubble & NASA; The two billowing structures in this NASA/ESA Hubble
 Space Telescope image of IRAS 13208-6020 are formed from material that is s...
@@ -20062,6 +20894,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1124aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1124a.jpg
+astropix_ids: esahubble|potw1124a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope has made a rare
 celestial catch. Close to a bright, nearby star in this image, the bizarre, ...
@@ -20085,6 +20918,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1125aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1125a.jpg
+astropix_ids: esahubble|potw1125a
 
 credits> ESA/Hubble & NASA; In this NASA/ESA Hubble Space Telescope image of NGC
 7479 — created from observations at visible and near-infrared wavelengths —...
@@ -20108,6 +20942,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1126aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1126a.jpg
+astropix_ids: esahubble|potw1126a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope has imaged an
 area so jam-packed with stars that they almost overwhelm the inky blackness
@@ -20132,6 +20967,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1127aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1127a.jpg
+astropix_ids: esahubble|potw1127a
 
 credits> ESA/Hubble & NASA ; Looking like an elegant abstract art piece painted
 by talented hands, this picture is actually a NASA/ESA Hubble Space Telescope...
@@ -20155,6 +20991,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1129aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1129a.jpg
+astropix_ids: esahubble|potw1129a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope has imaged an
 elongated stream of stars, gas and dust called IC 755, which is actually a
@@ -20179,6 +21016,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1130aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1130a.jpg
+astropix_ids: esahubble|potw1130a
 
 credits> ESA/Hubble & NASA ; NGC 2023 surrounds a massive young B-type star.
 These stars are large, bright and blue-white in colour, and have a high surface
@@ -20203,6 +21041,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1133aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1133a.jpg
+astropix_ids: esahubble|potw1133a
 
 credits> NASA, ESA and the Hubble Heritag; A giant cosmic necklace glows
 brightly in this NASA/ESA Hubble Space Telescope image.The object, aptly named
@@ -20227,6 +21066,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1134aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1134a.jpg
+astropix_ids: esahubble|potw1134a
 
 credits> ESA/Hubble & NASA ; NGC 2146 is classified as a barred spiral due to
 its shape, but the most distinctive feature is the dusty spiral arm that has
@@ -20251,6 +21091,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1135aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1135a.jpg
+astropix_ids: esahubble|potw1135a
 
 credits> ESA/Hubble & NASA; Peering into the depths of space, the sharp-eyed
 NASA/ESA Hubble Space Telescope has imaged the nearby but faint dwarf galaxy
@@ -20275,6 +21116,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1136aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1136a.jpg
+astropix_ids: esahubble|potw1136a
 
 credits> ESA/Hubble, NASA and R. Sahai ; Protoplanetary nebulae offer glimpses
 of how stars similar to the Sun end their lives and how they make the transition
@@ -20299,6 +21141,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1138aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1138a.jpg
+astropix_ids: esahubble|potw1138a
 
 credits> ESA/Hubble & NASA ; In this NASA/ESA Hubble Space Telescope image, NGC
 4874 is the brightest object, located to the right of the frame and seen as...
@@ -20322,6 +21165,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1139aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1139a.jpg
+astropix_ids: esahubble|potw1139a
 
 credits> ESA/Hubble & NASA; This NASA/ESA Hubble Space Telescope image shows
 remarkable structures in a galaxy cluster around an object called LRG-4-606.
@@ -20346,6 +21190,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1140aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1140a.jpg
+astropix_ids: esahubble|potw1140a
 
 credits> ESA/Hubble & NASA; Thousands and thousands of brilliant stars make up
 this globular cluster, Messier 53, captured with crystal clarity in this im...
@@ -20369,6 +21214,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1141aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1141a.jpg
+astropix_ids: esahubble|potw1141a
 
 credits> ESA/Hubble & NASA; Galaxies come in a variety of shapes and sizes, and
 these features change as they evolve. Some, like the galaxy in the centre ...
@@ -20392,6 +21238,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1142aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1142a.jpg
+astropix_ids: esahubble|potw1142a
 
 credits> ESA/Hubble & NASA; Supernova SN 1987A, one of the brightest stellar
 explosions since the invention of the telescope more than 400 years ago, is no
@@ -20416,6 +21263,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1143aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1143a.jpg
+astropix_ids: esahubble|potw1143a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope has taken this
 image of the Phoenix Dwarf Galaxy, which is located 1.4 million light-years a...
@@ -20439,6 +21287,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1144aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1144a.jpg
+astropix_ids: esahubble|potw1144a
 
 credits> ESA/Hubble & NASA ; The pearly wisps surrounding the central star IRAS
 10082-5647 in this Hubble image certainly draw the eye towards the heavens....
@@ -20462,6 +21311,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1145aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1145a.jpg
+astropix_ids: esahubble|potw1145a
 
 credits> ESA/Hubble & NASA; The object shown in this beautiful Hubble image,
 dubbed Messier 54, could be just another globular cluster, but this dense and
@@ -20486,6 +21336,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1146aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1146a.jpg
+astropix_ids: esahubble|potw1146a
 
 credits> NASA & ESA; The NASA/ESA Hubble Space Telescope has peered deep into
 NGC 4631, better known as the Whale Galaxy. Here, a profusion of starbi...
@@ -20509,6 +21360,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1147aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1147a.jpg
+astropix_ids: esahubble|potw1147a
 
 credits> ESA/Hubble, NASA and D. A. Gouli; In one of the largest known star
 formation regions in the Large Magellanic Cloud (LMC), a small satellite galaxy
@@ -20533,6 +21385,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1148aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1148a.jpg
+astropix_ids: esahubble|potw1148a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope has caught sight
 of a soft, diffuse-looking galaxy that is probably the aftermath of a long-...
@@ -20556,6 +21409,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1149aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1149a.jpg
+astropix_ids: esahubble|potw1149a
 
 credits> ESA/Hubble & NASA; Three thousand light-years from Earth lies the
 strange protoplanetary nebula IRAS 09371+1212, nicknamed the Frosty Leo Nebula.
@@ -20580,6 +21434,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1202aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1202a.jpg
+astropix_ids: esahubble|potw1202a
 
 credits> ESA/Hubble & NASA; This classic shot of a galaxy in the constellation
 of Ursa Major was taken by the NASA/ESA Hubble Space Telescope. NGC 3259 is...
@@ -20603,6 +21458,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1206aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1206a.jpg
+astropix_ids: esahubble|potw1206a
 
 credits> ESA/Hubble & NASA ; Many of the Universe’s galaxies are like our own,
 displaying beautiful spiral arms wrapping around a bright nucleus. Examples ...
@@ -20626,6 +21482,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1207aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1207a.jpg
+astropix_ids: esahubble|potw1207a
 
 credits> ESA/Hubble & NASA ; It’s well known that the Universe is changeable:
 even the stars that appear static and predictable every night are subject to ...
@@ -20649,6 +21506,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1209aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1209a.jpg
+astropix_ids: esahubble|potw1209a
 
 credits> ESA/Hubble & NASA; The myriad faint stars that comprise the Antlia
 Dwarf galaxy are more than four million light-years from Earth, but this
@@ -20673,6 +21531,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1210aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1210a.jpg
+astropix_ids: esahubble|potw1210a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope has produced
 this beautiful image of the galaxy NGC 1483. NGC 1483 is a barred spiral
@@ -20697,6 +21556,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1213aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1213a.jpg
+astropix_ids: esahubble|potw1213a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope has spotted a
 UFO — well, the UFO Galaxy, to be precise. NGC 2683 is a spiral galaxy seen
@@ -20721,6 +21581,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1214aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1214a.jpg
+astropix_ids: esahubble|potw1214a
 
 credits> ESA/Hubble & NASA; This image from the NASA/ESA Hubble Space Telescope
 shows NGC 4980, a spiral galaxy in the southern constellation of Hydra. The ...
@@ -20744,6 +21605,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1215aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1215a.jpg
+astropix_ids: esahubble|potw1215a
 
 credits> ESA/Hubble & NASA; In this image, the NASA/ESA Hubble Space Telescope
 has captured the brilliance of the compact centre of Messier 70, a globular c...
@@ -20767,6 +21629,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1217aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1217a.jpg
+astropix_ids: esahubble|potw1217a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope has been at the
 cutting edge of research into what happens to stars like our Sun at the ends...
@@ -20790,6 +21653,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1218aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1218a.jpg
+astropix_ids: esahubble|potw1218a
 
 credits> ESA/Hubble & NASA; This image from the NASA/ESA Hubble Space Telescope
 could seem like a quiet patch of sky at first glance. But zooming into the c...
@@ -20813,6 +21677,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1224aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1224a.jpg
+astropix_ids: esahubble|potw1224a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope has captured
 this view of the dwarf galaxy UGC 5497, which looks a bit like salt dashed on
@@ -20837,6 +21702,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1226aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1226a.jpg
+astropix_ids: esahubble|potw1226a
 
 credits> ESA/Hubble & NASA; Relatively few galaxies possess the sweeping,
 luminous spiral arms or brightly glowing centre of our home galaxy the Milky
@@ -20861,6 +21727,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1230aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1230a.jpg
+astropix_ids: esahubble|potw1230a
 
 credits> ESA/Hubble & NASA ; The galaxy NGC 4700 bears the signs of the vigorous
 birth of many new stars in this image captured by the NASA/ESA Hubble Spac...
@@ -20884,6 +21751,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1231aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1231a.jpg
+astropix_ids: esahubble|potw1231a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope offers this
 delightful view of the crowded stellar encampment called Messier 68, a
@@ -20908,6 +21776,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1234aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1234a.jpg
+astropix_ids: esahubble|potw1234a
 
 credits> NASA & ESA Acknowledgement: Gill; The NASA/ESA Hubble Space Telescope
 has produced this beautiful image of the globular cluster Messier 56 (also known
@@ -20932,6 +21801,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1235aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1235a.jpg
+astropix_ids: esahubble|potw1235a
 
 credits> ESA/Hubble & NASA; A new image from the NASA/ESA Hubble Space Telescope
 shows NGC 5806, a spiral galaxy in the constellation Virgo (the Virgin). ...
@@ -20955,6 +21825,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1238aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1238a.jpg
+astropix_ids: esahubble|potw1238a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope has produced a
 sharp image of NGC 4634, a spiral galaxy seen exactly side-on. Its disc is sl...
@@ -20978,6 +21849,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1238bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1238b.jpg
+astropix_ids: esahubble|potw1238b
 
 credits> NASA, ESA, Digitzed Sky Survey 2; This wide-field view from the
 Digitized Sky Survey shows NGC 4634 and NGC 4633, a pair of interacting galaxies
@@ -21002,6 +21874,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1240aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1240a.jpg
+astropix_ids: esahubble|potw1240a
 
 credits> ESA/Hubble & NASA; This dazzling image shows the globular cluster
 Messier 69, or M 69 for short, as viewed through the NASA/ESA Hubble Space
@@ -21026,6 +21899,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1242aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1242a.jpg
+astropix_ids: esahubble|potw1242a
 
 credits> ESA/Hubble & NASA; NGC 3344 is a glorious spiral galaxy around half the
 size of the Milky Way, which lies 25 million light-years distant. We are fo...
@@ -21049,6 +21923,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1243aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1243a.jpg
+astropix_ids: esahubble|potw1243a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope has imaged the
 faint irregular galaxy NGC 3738, a starburst galaxy. The galaxy is in the mid...
@@ -21072,6 +21947,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1244aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1244a.jpg
+astropix_ids: esahubble|potw1244a
 
 credits> ESA/Hubble & NASA ; The NASA/ESA Hubble Space Telescope offers an
 impressive view of the centre of globular cluster NGC 6362. The image of this
@@ -21096,6 +21972,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1245aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1245a.jpg
+astropix_ids: esahubble|potw1245a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope has captured a
 beautiful galaxy that, with its reddish and yellow central area, looks rather...
@@ -21119,6 +21996,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1249aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1249a.jpg
+astropix_ids: esahubble|potw1249a
 
 credits> ESA/Hubble & NASA ; The brilliant cascade of stars through the middle
 of this image is the galaxy ESO 318-13 as seen by the NASA/ESA Hubble Space ...
@@ -21142,6 +22020,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1252aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1252a.jpg
+astropix_ids: esahubble|potw1252a
 
 credits> ESA/Hubble & NASAAcknowledgement; The NASA/ESA Hubble Space Telescope
 provides us this week with a spectacular image of the bright star-forming ring
@@ -21166,6 +22045,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1253aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1253a.jpg
+astropix_ids: esahubble|potw1253a
 
 credits> ESA/Hubble & NASA; The Universe loves to fool our eyes, giving the
 impression that celestial objects are located at the same distance from Earth.
@@ -21190,6 +22070,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1301aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1301a.jpg
+astropix_ids: esahubble|potw1301a
 
 credits> ESA/Hubble & NASA; The constellation of Ursa Major (The Great Bear) is
 home to Messier 101, the Pinwheel Galaxy. One of the biggest and brightest...
@@ -21213,6 +22094,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1302aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1302a.jpg
+astropix_ids: esahubble|potw1302a
 
 credits> ESA/Hubble & NASA ; A busy patch of space has been captured in this
 image from the NASA/ESA Hubble Space Telescope. Scattered with many nearby
@@ -21237,6 +22119,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1303aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1303a.jpg
+astropix_ids: esahubble|potw1303a
 
 credits> ESA/Hubble & NASA ; Globular clusters are roughly spherical collections
 of extremely old stars, and around 150 of them are scattered around our ga...
@@ -21260,6 +22143,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1305aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1305a.jpg
+astropix_ids: esahubble|potw1305a
 
 credits> ESA/Hubble & NASA ; This thin, glittering streak of stars is the spiral
 galaxy ESO 121-6, which lies in the southern constellation of Pictor (The ...
@@ -21283,6 +22167,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1313aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1313a.jpg
+astropix_ids: esahubble|potw1313a
 
 credits> ESA/Hubble & NASA, M. Hayes; Visible as a small, sparkling hook in the
 dark sky, this beautiful object is known as J082354.96+280621.6, or J082354.96
@@ -21307,6 +22192,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1323aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1323a.jpg
+astropix_ids: esahubble|potw1323a
 
 credits> ESA/Hubble & NASA ; The contorted object captured by Hubble in this
 picture is IRAS 22491-1808, also known as the South America Galaxy. It is an
@@ -21331,6 +22217,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1330aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1330a.jpg
+astropix_ids: esahubble|potw1330a
 
 credits> ESA/Hubble & NASAAcknowledgement; Another treasure unearthed from the
 Hubble archives, this beautiful image shows a spiral galaxy named NGC 4517.
@@ -21355,6 +22242,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1351aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1351a.jpg
+astropix_ids: esahubble|potw1351a
 
 credits> ESA/Hubble & NASA; Located some 25 million light-years away, this new
 Hubble image shows spiral galaxy ESO 373-8. Together with at least seven of i...
@@ -21378,6 +22266,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1403aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1403a.jpg
+astropix_ids: esahubble|potw1403a
 
 credits> ESA/Hubble & NASA; In this new Hubble image two objects are clearly
 visible, shining brightly. When they were first discovered in 1979, they were
@@ -21402,6 +22291,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1421aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1421a.jpg
+astropix_ids: esahubble|potw1421a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This new Hubble image shows IRAS
 14568-6304, a young star that is cloaked in a haze of golden gas and dust. It
@@ -21426,6 +22316,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1434aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1434a.jpg
+astropix_ids: esahubble|potw1434a
 
 credits> ESA/Hubble & NASA; This new NASA/ESA Hubble Space Telescope image shows
 a variety of intriguing cosmic phenomena. Surrounded by bright stars, towar...
@@ -21449,6 +22340,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1435aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1435a.jpg
+astropix_ids: esahubble|potw1435a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This new NASA/ESA Hubble Space
 Telescope image shows a beautiful spiral galaxy known as PGC 54493, located in
@@ -21473,6 +22365,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1436aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1436a.jpg
+astropix_ids: esahubble|potw1436a
 
 credits> ESA/Hubble, NASA, D. Calzetti ; Far beyond the stars in the
 constellation of Leo (The Lion) is irregular galaxy IC 559. IC 559 is not your
@@ -21497,6 +22390,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1438aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1438a.jpg
+astropix_ids: esahubble|potw1438a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This new image from the NASA/ESA
 Hubble Space Telescope shows NGC 7793, a spiral galaxy in the constellation of
@@ -21521,6 +22415,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1439aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1439a.jpg
+astropix_ids: esahubble|potw1439a
 
 credits> ESA/Hubble & NASA; In this new Hubble image, the strikingly luminous
 star AG Carinae — otherwise known as HD 94910 — takes centre stage. Found
@@ -21545,6 +22440,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1440aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1440a.jpg
+astropix_ids: esahubble|potw1440a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This magnificent new image taken with
 the NASA/ESA Hubble Space Telescope shows the edge-on spiral galaxy NGC 4206,
@@ -21569,6 +22465,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1441aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1441a.jpg
+astropix_ids: esahubble|potw1441a
 
 credits> ESA/Hubble & NASA Acknowledgemen; The brightly glowing plumes seen in
 this image are reminiscent of an underwater scene, with turquoise-tinted
@@ -21593,6 +22490,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1442aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1442a.jpg
+astropix_ids: esahubble|potw1442a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This neat little galaxy is known as
 NGC 4526. Its dark lanes of dust and bright diffuse glow make the galaxy appear
@@ -21617,6 +22515,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1443aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1443a.jpg
+astropix_ids: esahubble|potw1443a
 
 credits> ESA/Hubble & NASA; This spectacular image was captured by the NASA/ESA
 Hubble Space Telescope's Advanced Camera for Surveys (ACS). The bright strea...
@@ -21640,6 +22539,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1445aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1445a.jpg
+astropix_ids: esahubble|potw1445a
 
 credits> ESA/Hubble & NASAAcknowledgement; This new image from the NASA/ESA
 Hubble Space Telescope shows the super-rich galaxy cluster Abell 1413. Located
@@ -21664,6 +22564,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1447aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1447a.jpg
+astropix_ids: esahubble|potw1447a
 
 credits> ESA/Hubble & NASA Acknowledgemen; The galaxy cutting dramatically
 across the frame of this NASA/ESA Hubble Space Telescope image is a slightly
@@ -21688,6 +22589,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1448aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1448a.jpg
+astropix_ids: esahubble|potw1448a
 
 credits> ESA/Hubble, NASA and S. Smartt; The NASA/ESA Hubble Space Telescope
 observes some of the most beautiful galaxies in our skies — spirals sparkling
@@ -21712,6 +22614,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1449aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1449a.jpg
+astropix_ids: esahubble|potw1449a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This striking new NASA/ESA Hubble
 Space Telescope image shows a glittering bauble named Messier 92. Located in the
@@ -21736,6 +22639,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1450aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1450a.jpg
+astropix_ids: esahubble|potw1450a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This sprinkle of cosmic glitter is a
 blue compact dwarf galaxy known as Markarian 209. Galaxies of this type are
@@ -21760,6 +22664,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1451aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1451a.jpg
+astropix_ids: esahubble|potw1451a
 
 credits> ESA/Hubble & NASA; This new NASA/ESA Hubble Space Telescope image shows
 the galaxy IC 335 in front of a backdrop of distant galaxies. IC 335 is par...
@@ -21783,6 +22688,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1452aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1452a.jpg
+astropix_ids: esahubble|potw1452a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This image captures the stunning NGC
 6535, a globular cluster 22 000 light-years away in the constellation of Serpens
@@ -21807,6 +22713,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1501aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1501a.jpg
+astropix_ids: esahubble|potw1501a
 
 credits> ESA/Hubble & NASA; This new NASA/ESA Hubble Space Telescope image shows
 a star known as R Sculptoris, a red giant located 1500 light-years from Ear...
@@ -21830,6 +22737,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1502aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1502a.jpg
+astropix_ids: esahubble|potw1502a
 
 credits> ESA/Hubble & NASA Acknowledgemen; The subject of this image is NGC
 6861, a galaxy discovered in 1826 by the Scottish astronomer James Dunlop.
@@ -21854,6 +22762,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1503aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1503a.jpg
+astropix_ids: esahubble|potw1503a
 
 credits> ESA/Hubble & NASAAcknowl; In this image the NASA/ESA Hubble Space
 Telescope takes a close look at the spiral galaxy NGC 4217, 60 million
@@ -21878,6 +22787,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1504aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1504a.jpg
+astropix_ids: esahubble|potw1504a
 
 credits> ESA/Hubble & NASAAcknowl; This Picture of the Week shows Arp 230, also
 known as IC 51, observed by the NASA/ESA Hubble Space Telescope. Arp 230 is a
@@ -21902,6 +22812,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1505aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1505a.jpg
+astropix_ids: esahubble|potw1505a
 
 credits> ESA/Hubble & NASAAcknowl; Galaxies can take many shapes and be oriented
 any way relative to us in the sky. This can make it hard to figure out their
@@ -21926,6 +22837,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1506aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1506a.jpg
+astropix_ids: esahubble|potw1506a
 
 credits> NASA & ESA Acknowledgement: Judy; In the centre of this image, taken
 with the NASA/ESA Hubble Space Telescope, are two faint galaxies that seem to be
@@ -21950,6 +22862,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1507aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1507a.jpg
+astropix_ids: esahubble|potw1507a
 
 credits> ESA/Hubble & NASA; Panta rhei is a simplified version of the famous
 greek philosopher Heraclitus' teachings. It basically means, everything flows.
@@ -21974,6 +22887,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1508aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1508a.jpg
+astropix_ids: esahubble|potw1508a
 
 credits> ESA/Hubble & NASAAcknowledgement; The galaxy pictured here is NGC 4424,
 located in the constellation of Virgo. It is not visible with the naked eye but
@@ -21998,6 +22912,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1509aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1509a.jpg
+astropix_ids: esahubble|potw1509a
 
 credits> ESA/Hubble, NASA, Karl Stapelfe; With its helical appearance resembling
 a snail’s shell, this reflection nebula seems to spiral out from a luminous
@@ -22022,6 +22937,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1510aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1510a.jpg
+astropix_ids: esahubble|potw1510a
 
 credits> ESA/Hubble & NASA; The galaxy UGC 8201, captured here by the NASA/ESA
 Hubble Space Telescope, is a dwarf irregular galaxy, so called because of its...
@@ -22045,6 +22961,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1511aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1511a.jpg
+astropix_ids: esahubble|potw1511a
 
 credits> ESA/Hubble & NASA Acknowledgemen; The bright streak of glowing gas and
 stars in this NASA/ESA Hubble Space Telescope image is known as PGC 51017, or
@@ -22069,6 +22986,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1512aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1512a.jpg
+astropix_ids: esahubble|potw1512a
 
 credits> ESA/Hubble & NASA; This NASA/ESA Hubble Space Telescope image shows an
 edge-on view of the spiral galaxy NGC 5023. Due to its orientation we cannot...
@@ -22092,6 +23010,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1513aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1513a.jpg
+astropix_ids: esahubble|potw1513a
 
 credits> NASA & ESA Acknowledgement: A. R; This NASA/ESA Hubble Space Telescope
 image shows the spiral galaxy NGC 3021 which lies about 100 million light-years
@@ -22116,6 +23035,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1514aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1514a.jpg
+astropix_ids: esahubble|potw1514a
 
 credits> ESA/Hubble & NASA; This image shows the centre of the globular cluster
 Messier 22, also known as M22, as observed by the NASA/ESA Hubble Space Tele...
@@ -22139,6 +23059,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1515aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1515a.jpg
+astropix_ids: esahubble|potw1515a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This NASA/ESA Hubble Space Telescope
 image shows an elliptical galaxy called NGC 2865. It lies just over 100 million
@@ -22163,6 +23084,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1516aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1516a.jpg
+astropix_ids: esahubble|potw1516a
 
 credits> ESA/Hubble & NASA; This galaxy goes by the name of ESO 162-17 and is
 located about 40 million light-years away in the constellation of Carina. At
@@ -22187,6 +23109,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1517aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1517a.jpg
+astropix_ids: esahubble|potw1517a
 
 credits> ESA/Hubble & NASA Acknowledgemen; The smudge of stars at the centre of
 this NASA/ESA Hubble Space Telescope image is a galaxy known as UGC 5797. UGC
@@ -22211,6 +23134,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1518aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1518a.jpg
+astropix_ids: esahubble|potw1518a
 
 credits> ESA/Hubble & NASA; This image provides the clearest ever view of galaxy
 NGC 949, which lies over 30 million light-years away in the constellation o...
@@ -22234,6 +23158,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1519aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1519a.jpg
+astropix_ids: esahubble|potw1519a
 
 credits> ESA/Hubble & NASA Acknowledgemen; The glowing object in this image is
 an elliptical galaxy called NGC 3923. It is located over 90 million light-years
@@ -22258,6 +23183,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1520aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1520a.jpg
+astropix_ids: esahubble|potw1520a
 
 credits> NASA, ESA, the Hubble Heritage (; Not all galaxies are neatly shaped,
 as this new NASA/ESA Hubble Space Telescope image of NGC 6240 clearly
@@ -22282,6 +23208,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1521aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1521a.jpg
+astropix_ids: esahubble|potw1521a
 
 credits> NASA & ESA; This new NASA/ESA Hubble Space Telescope image presents the
 Arches Cluster, the densest known star cluster in the Milky Way. It ...
@@ -22305,6 +23232,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1522aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1522a.jpg
+astropix_ids: esahubble|potw1522a
 
 credits> ESA/Hubble & NASA; This NASA/ESA Hubble Space Telescope image captures
 the galaxy Messier 84 — also known as NGC 4374 — an object from the Messier ...
@@ -22328,6 +23256,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1523aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1523a.jpg
+astropix_ids: esahubble|potw1523a
 
 credits> ESA/Hubble & NASA; There are many galaxies in the Universe and although
 there is plenty of room, they tend to stick together. The Milky Way, for ex...
@@ -22351,6 +23280,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1524aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1524a.jpg
+astropix_ids: esahubble|potw1524a
 
 credits> ESA/Hubble & NASA; This NASA/ESA Hubble Space Telescope image shows a
 galaxy known as UGC 11411. It is a galaxy type known as an irregular blue com...
@@ -22374,6 +23304,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1525aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1525a.jpg
+astropix_ids: esahubble|potw1525a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This NASA/ESA Hubble Space Telescope
 image shows a planetary nebula named NGC 6153, located about 4000 light-years
@@ -22398,6 +23329,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1526aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1526a.jpg
+astropix_ids: esahubble|potw1526a
 
 credits> ESA/Hubble & NASA; This NASA/ESA Hubble Space Telescope picture shows a
 galaxy named SBS 1415+437 or SDSS CGB 12067.1, located about 45 million lig...
@@ -22421,6 +23353,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1527aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1527a.jpg
+astropix_ids: esahubble|potw1527a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This little-known galaxy, officially
 named J04542829-6625280, but most often referred to as LEDA 89996, is a classic
@@ -22445,6 +23378,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1528aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1528a.jpg
+astropix_ids: esahubble|potw1528a
 
 credits> ESA/Hubble & NASA; Although this cluster of stars gained its name due
 to its five brightest stars, it is home to hundreds more. The huge number of ...
@@ -22468,6 +23402,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1529aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1529a.jpg
+astropix_ids: esahubble|potw1529a
 
 credits> ESA/Hubble & NASA; This dramatic image shows the NASA/ESA Hubble Space
 Telescope’s view of dwarf galaxy known as NGC 1140, which lies 60 million li...
@@ -22491,6 +23426,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1530aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1530a.jpg
+astropix_ids: esahubble|potw1530a
 
 credits> ESA/Hubble & NASA Acknowledgemen; A dying star’s final moments are
 captured in this image from the NASA/ESA Hubble Space Telescope. The death
@@ -22515,6 +23451,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1531aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1531a.jpg
+astropix_ids: esahubble|potw1531a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This colourful bubble is a planetary
 nebula called NGC 6818, also known as the Little Gem Nebula. It is located in
@@ -22539,6 +23476,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1532aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1532a.jpg
+astropix_ids: esahubble|potw1532a
 
 credits> ESA/Hubble and NASA and S. Smart; Bursts of pink and red, dark lanes of
 mottled cosmic dust, and a bright scattering of stars — this NASA/ESA Hubble
@@ -22563,6 +23501,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1533aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1533a.jpg
+astropix_ids: esahubble|potw1533a
 
 credits> ESA/Hubble & NASA Acknowledgeme; Here we see the spectacular cosmic
 pairing of the star Hen 2-427 — more commonly known as WR 124 — and the nebula
@@ -22587,6 +23526,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1534aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1534a.jpg
+astropix_ids: esahubble|potw1534a
 
 credits> ESA/Hubble & NASA Acknowledgemen; Shown here in a new image taken with
 the Advanced Camera for Surveys (ACS) on board the NASA/ESA Hubble Space
@@ -22611,6 +23551,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1535aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1535a.jpg
+astropix_ids: esahubble|potw1535a
 
 credits> ESA/Hubble & NASA and the LEGUS ; This new NASA/ESA Hubble Space
 Telescope shows Messier 96, a spiral galaxy just over 35 million light-years
@@ -22635,6 +23576,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1536aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1536a.jpg
+astropix_ids: esahubble|potw1536a
 
 credits> ESA/Hubble & NASA; The arrangement of the spiral arms in the galaxy
 Messier 63, seen here in a new image from the NASA/ESA Hubble Space Telescope,
@@ -22659,6 +23601,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1537aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1537a.jpg
+astropix_ids: esahubble|potw1537a
 
 credits> ESA/Hubble & NASA Acknowledgemen; It is known today that merging
 galaxies play a large role in the evolution of galaxies and the formation of
@@ -22683,6 +23626,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1538aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1538a.jpg
+astropix_ids: esahubble|potw1538a
 
 credits> ESA/Hubble & NASA and S. Smartt ; This new image of the spiral galaxy
 NGC 3521 from the NASA/ESA Hubble Space Telescope is not out of focus. Instead,
@@ -22707,6 +23651,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1539aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1539a.jpg
+astropix_ids: esahubble|potw1539a
 
 credits> ESA/Hubble & NASA and S. Smartt ; Ribbons of dust festoon the galaxy
 NGC 613 in this new image from the NASA/ESA Hubble Space Telescope. NGC 613 is
@@ -22731,6 +23676,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1540aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1540a.jpg
+astropix_ids: esahubble|potw1540a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This planetary nebula is called PK
 329-02.2 and is located in the constellation of Norma in the southern sky. It is
@@ -22755,6 +23701,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1541aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1541a.jpg
+astropix_ids: esahubble|potw1541a
 
 credits> ESA/Hubble & NASA; NGC 4639 is a beautiful example of a type of galaxy
 known as a barred spiral. It lies over 70 million light-years away in the co...
@@ -22778,6 +23725,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1542aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1542a.jpg
+astropix_ids: esahubble|potw1542a
 
 credits> ESA/Hubble & NASA; This image shows the galaxy Messier 94, which lies
 in the small northern constellation of the Hunting Dogs, about 16 million lig...
@@ -22801,6 +23749,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1543aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1543a.jpg
+astropix_ids: esahubble|potw1543a
 
 credits> ESA/Hubble & NASA Acknowledgemen; Two stars shine through the centre of
 a ring of cascading dust in this image taken by the NASA/ESA Hubble Space
@@ -22825,6 +23774,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1544aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1544a.jpg
+astropix_ids: esahubble|potw1544a
 
 credits> ESA/Hubble & NASA and N. Grogin ; This galaxy is known as Mrk 820 and
 is classified as a lenticular galaxy — type S0 on the Hubble Tuning Fork. The
@@ -22849,6 +23799,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1545aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1545a.jpg
+astropix_ids: esahubble|potw1545a
 
 credits> ESA/Hubble & NASA and N. Gorin (; Only three local stars appear in this
 image, quartered by right-angled diffraction spikes. Everything besides them is
@@ -22873,6 +23824,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1546aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1546a.jpg
+astropix_ids: esahubble|potw1546a
 
 credits> ESA/Hubble & NASA, Acknowledge; At the centre of this amazing image is
 the elliptical galaxy NGC 3610. Surrounding the galaxy are a wealth of other
@@ -22897,6 +23849,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1547aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1547a.jpg
+astropix_ids: esahubble|potw1547a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This curious galaxy — only known by
 the seemingly random jumble of letters and numbers 2MASX J16270254+4328340 — has
@@ -22921,6 +23874,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1548aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1548a.jpg
+astropix_ids: esahubble|potw1548a
 
 credits> ESA/Hubble, NASA and S. Smar; Like a lighthouse in the fog the luminous
 core of NGC 2768 slowly fades outwards to a dull white haze in this image taken
@@ -22945,6 +23899,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1549aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1549a.jpg
+astropix_ids: esahubble|potw1549a
 
 credits> NASA & ESA, Acknowledgements: J; Only rarely does an astronomical
 object have a political association. However, the spiral galaxy NGC 7252
@@ -22969,6 +23924,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1550aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1550a.jpg
+astropix_ids: esahubble|potw1550a
 
 credits> NASA & ESA, Acknowledgement: Ju; This image, taken with the Wide Field
 Planetary Camera 2 on board the NASA/ESA Hubble Space Telescope, shows the
@@ -22993,6 +23949,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1551aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1551a.jpg
+astropix_ids: esahubble|potw1551a
 
 credits> ESA/Hubble & NASA; The artistic outburst of an extremely young star, in
 the earliest phase of formation, is captured in this spectacular image from...
@@ -23016,6 +23973,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1552aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1552a.jpg
+astropix_ids: esahubble|potw1552a
 
 credits> ESA/Hubble & NASA, Acknowledgeme; This image, taken with the Wide Field
 Planetary Camera 2 on board the NASA/ESA Hubble Space Telescope, shows the
@@ -23040,6 +23998,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1601aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1601a.jpg
+astropix_ids: esahubble|potw1601a
 
 credits> ESA/Hubble & NASA and S. Smartt ; This NASA/ESA Hubble Space Telescope
 image shows the spiral galaxy NGC 4845, located over 65 million light-years away
@@ -23064,6 +24023,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1602aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1602a.jpg
+astropix_ids: esahubble|potw1602a
 
 credits> ESA/Hubble & NASA Acknowledgemen; The subject of this NASA/ESA Hubble
 Space Telescope image is known as NGC 3597. It is the product of a collision
@@ -23088,6 +24048,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1603aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1603a.jpg
+astropix_ids: esahubble|potw1603a
 
 credits> ESA/Hubble & NASA Acknowledgemen; Most galaxies possess a majestic
 spiral or elliptical structure. About a quarter of galaxies, though, defy such
@@ -23112,6 +24073,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1604aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1604a.jpg
+astropix_ids: esahubble|potw1604a
 
 credits> ESA/Hubble & NASA Acknowledgemen; Despite its unassuming appearance,
 the edge-on spiral galaxy captured in the left half of this NASA/ESA Hubble
@@ -23136,6 +24098,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1605aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1605a.jpg
+astropix_ids: esahubble|potw1605a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This image, taken by the NASA/ESA
 Hubble Space Telescope, shows a peculiar galaxy known as NGC 1487, lying about
@@ -23160,6 +24123,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1606aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1606a.jpg
+astropix_ids: esahubble|potw1606a
 
 credits> ESA/Hubble & NASA Acknowledgemen; In this cosmic snapshot, the
 spectacularly symmetrical wings of Hen 2-437 show up in a magnificent icy blue
@@ -23184,6 +24148,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1607aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1607a.jpg
+astropix_ids: esahubble|potw1607a
 
 credits> ESA/Hubble & NASA Acknowledgemen; Surrounded by an envelope of dust,
 the subject of this NASA/ESA Hubble Space Telescope image is a young
@@ -23208,6 +24173,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1608aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1608a.jpg
+astropix_ids: esahubble|potw1608a
 
 credits> ESA/Hubble & NASA Acknowledgemen; Sparkling at the centre of this
 beautiful NASA/ESA Hubble Space Telescope image is a Wolf–Rayet star known as WR
@@ -23232,6 +24198,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1609aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1609a.jpg
+astropix_ids: esahubble|potw1609a
 
 credits> ESA/Hubble & NASA Acknowledgemen; Showcased at the centre of this
 NASA/ESA Hubble Space Telescope image is an emission-line star known as IRAS
@@ -23256,6 +24223,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1610aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1610a.jpg
+astropix_ids: esahubble|potw1610a
 
 credits> NASA, ESA and the HST Frontier F; Peering deep into the early Universe,
 this picturesque parallel field observation from the NASA/ESA Hubble Space
@@ -23280,6 +24248,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1611aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1611a.jpg
+astropix_ids: esahubble|potw1611a
 
 credits> NASA, ESA, CXC, NRAO/AUI/NSF, ST; In October of 2013 Hubble kicked off
 the Frontier Fields programme, a three-year series of observations aiming to
@@ -23304,6 +24273,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1612aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1612a.jpg
+astropix_ids: esahubble|potw1612a
 
 credits> NASA, ESA, CXC, NRAO/AUI/NSF, ; At first glance, this cosmic
 kaleidoscope of purple, blue and pink offers a strikingly beautiful — and serene
@@ -23328,6 +24298,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1613aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1613a.jpg
+astropix_ids: esahubble|potw1613a
 
 credits> ESA/Hubble & NASA Acknowledgemen; Despite being less famous than their
 elliptical and spiral galactic cousins, irregular dwarf galaxies, such as the
@@ -23352,6 +24323,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1614aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1614a.jpg
+astropix_ids: esahubble|potw1614a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This striking NASA/ESA Hubble Space
 Telescope image captures the galaxy UGC 477, located just over 110 million
@@ -23376,6 +24348,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1615aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1615a.jpg
+astropix_ids: esahubble|potw1615a
 
 credits> ESA/Hubble & NASA Acknowledgeme; At first glance this NASA/ESA Hubble
 Space Telescope image seems to show an array of different cosmic objects, but
@@ -23400,6 +24373,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1616aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1616a.jpg
+astropix_ids: esahubble|potw1616a
 
 credits> ESA/Hubble & NASA Acknowledgemen; The elegant simplicity of NGC 4111,
 seen here in this image from the NASA/ESA Hubble Space Telescope, hides a more
@@ -23424,6 +24398,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1617aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1617a.jpg
+astropix_ids: esahubble|potw1617a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This NASA/ESA Hubble Space Telescope
 image reveals the simple beauty of NGC 339, a massive intermediate age star
@@ -23448,6 +24423,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1618aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1618a.jpg
+astropix_ids: esahubble|potw1618a
 
 credits> ESA/Hubble & NASA Acknowledgemen; Discovered in 1784 by the
 German–British astronomer William Herschel, NGC 4394 is a barred spiral galaxy
@@ -23472,6 +24448,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1619aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1619a.jpg
+astropix_ids: esahubble|potw1619a
 
 credits> ESA/Hubble & NASA Acknowledgeme; Spiral galaxies together with
 irregular galaxies make up approximately 60% of the galaxies in the local
@@ -23520,6 +24497,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1621aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1621a.jpg
+astropix_ids: esahubble|potw1621a
 
 credits> ESA/Hubble & NASA Acknowledgeme; Nearly as deep as the Hubble Ultra
 Deep Field, which contains approximately 10 000 galaxies, this incredible image
@@ -23544,6 +24522,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1622aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1622a.jpg
+astropix_ids: esahubble|potw1622a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This 10.5-billion-year-old globular
 cluster, NGC 6496, is home to heavy-metal stars of a celestial kind! The stars
@@ -23568,6 +24547,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1623aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1623a.jpg
+astropix_ids: esahubble|potw1623a
 
 credits> NASA & ESA; The drizzle of stars scattered across this image forms a
 galaxy known as UGC 4879. UGC 4879 is an irregular dwarf galaxy — as th...
@@ -23591,6 +24571,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1624aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1624a.jpg
+astropix_ids: esahubble|potw1624a
 
 credits> ESA/Hubble & NASA; This colourful and star-studded view of the Milky
 Way galaxy was captured when the NASA/ESA Hubble Space Telescope pointed its
@@ -23615,6 +24596,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1625aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1625a.jpg
+astropix_ids: esahubble|potw1625a
 
 credits> ESA/Hubble & NASA; This NASA/ESA Hubble Space Telescope image shows the
 globular cluster NGC 1854, a gathering of white and blue stars in the south...
@@ -23638,6 +24620,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1626aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1626a.jpg
+astropix_ids: esahubble|potw1626a
 
 credits> ESA/Hubble & NASA, Aloisi, Ford ; This NASA/ESA Hubble Space Telescope
 image reveals the iridescent interior of one of the most active galaxies in our
@@ -23662,6 +24645,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1627aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1627a.jpg
+astropix_ids: esahubble|potw1627a
 
 credits> ESA/Hubble & NASA; The fuzzy collection of stars seen in this NASA/ESA
 Hubble Space Telescope image forms an intriguing dwarf galaxy named LEDA 677...
@@ -23685,6 +24669,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1628aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1628a.jpg
+astropix_ids: esahubble|potw1628a
 
 credits> ESA/Hubble & NASA and N. Grogin ; This image was taken by the NASA/ESA
 Hubble Space Telescope’s Advanced Camera for Surveys (ACS), and shows a
@@ -23709,6 +24694,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1629aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1629a.jpg
+astropix_ids: esahubble|potw1629a
 
 credits> ESA/Hubble & NASAAcknowledgement; This NASA/ESA Hubble Space Telescope
 image reveals the vibrant core of the galaxy NGC 3125. Discovered by John
@@ -23733,6 +24719,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1630aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1630a.jpg
+astropix_ids: esahubble|potw1630a
 
 credits> ESA/Hubble & NASA, Y. Chu; This NASA/ESA Hubble Space Telescope image
 captures the remnants of a long-dead star. These rippling wisps of ionised gas,
@@ -23757,6 +24744,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1631aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1631a.jpg
+astropix_ids: esahubble|potw1631a
 
 credits> ESA/Hubble and NASA; Located approximately 22 000 light-years away in
 the constellation of Musca (The Fly), this tightly packed collection of stars...
@@ -23780,6 +24768,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1632aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1632a.jpg
+astropix_ids: esahubble|potw1632a
 
 credits> ESA/Hubble & NASA; This galaxy, known as NGC 2337, resides 25 million
 light-years away in the constellation of Lynx. NGC 2337 is an irregular galax...
@@ -23803,6 +24792,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1633aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1633a.jpg
+astropix_ids: esahubble|potw1633a
 
 credits> ESA/Hubble & NASA, Y. Chu; Several thousand years ago, a star some 160
 000 light-years away from us exploded, scattering stellar shrapnel across the
@@ -23827,6 +24817,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1634aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1634a.jpg
+astropix_ids: esahubble|potw1634a
 
 credits> ESA/Hubble & NASA; This image, courtesy of the NASA/ESA Hubble Space
 Telescope’s Advanced Camera for Surveys (ACS), captures the glow of distant ...
@@ -23850,6 +24841,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1635aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1635a.jpg
+astropix_ids: esahubble|potw1635a
 
 credits> ESA/Hubble & NASA; The closest star system to the Earth is the famous
 Alpha Centauri group. Located in the constellation of Centaurus (The Centaur)...
@@ -23873,6 +24865,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1636aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1636a.jpg
+astropix_ids: esahubble|potw1636a
 
 credits> ESA/Hubble & NASA; This shot from the NASA/ESA Hubble Space Telescope
 shows a maelstrom of glowing gas and dark dust within one of the Milky Way’s ...
@@ -23896,6 +24889,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1637aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1637a.jpg
+astropix_ids: esahubble|potw1637a
 
 credits> ESA/Hubble & NASA Acknowledgemen; A lone source shines out brightly
 from the dark expanse of deep space, glowing softly against a picturesque
@@ -23920,6 +24914,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1639aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1639a.jpg
+astropix_ids: esahubble|potw1639a
 
 credits> ESA/Hubble & NASA; This shining disc of a spiral galaxy sits
 approximately 25 million light-years away from Earth in the constellation of
@@ -23944,6 +24939,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1640aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1640a.jpg
+astropix_ids: esahubble|potw1640a
 
 credits> ESA/Hubble & NASA; This Hubble image shows the central region of a
 spiral galaxy known as NGC 247. NGC 247 is a relatively small spiral galaxy
@@ -23968,6 +24964,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1641aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1641a.jpg
+astropix_ids: esahubble|potw1641a
 
 credits> ESA/Hubble & NASA and S. Smartt; This image, taken by the NASA/ESA
 Hubble Space Telescope’s Wide Field Planetary Camera 2, shows a spiral galaxy
@@ -23992,6 +24989,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1642aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1642a.jpg
+astropix_ids: esahubble|potw1642a
 
 credits> ESA/Hubble & NASA; It may be famous for hosting spectacular sights such
 as the Tucana Dwarf Galaxy and 47 Tucanae (heic1510), the second brightest ...
@@ -24015,6 +25013,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1643aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1643a.jpg
+astropix_ids: esahubble|potw1643a
 
 credits> ESA/Hubble & NASA; Globular clusters offer some of the most spectacular
 sights in the night sky. These ornate spheres contain hundreds of thousands...
@@ -24038,6 +25037,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1644aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1644a.jpg
+astropix_ids: esahubble|potw1644a
 
 credits> ESA/Hubble & NASA. Acknowledg; In 1054 AD, during the Song dynasty,
 Chinese astronomers spotted a bright new star in the night sky. This newcomer
@@ -24062,6 +25062,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1645aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1645a.jpg
+astropix_ids: esahubble|potw1645a
 
 credits> ESA/Hubble & NASA; NGC 1222, seen in this image taken with the Wide
 Field Camera 3 on board the NASA/ESA Hubble Space Telescope (HST), is a
@@ -24086,6 +25087,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1646aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1646a.jpg
+astropix_ids: esahubble|potw1646a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This Hubble image shows NGC 4789A, a
 dwarf irregular galaxy in the constellation of Coma Berenices. It certainly
@@ -24110,6 +25112,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1647aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1647a.jpg
+astropix_ids: esahubble|potw1647a
 
 credits> ESA/Hubble & NASA, D. Calzetti; This image of the spiral galaxy NGC
 3274 comes courtesy of the NASA/ESA Hubble Space Telescope’s Wide Field Camera 3
@@ -24134,6 +25137,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1648aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1648a.jpg
+astropix_ids: esahubble|potw1648a
 
 credits> ESA/Hubble & NASA; This delicate blue group of stars — actually an
 irregular galaxy named IC 3583 — sits some 30 million light-years away in the
@@ -24158,6 +25162,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1649aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1649a.jpg
+astropix_ids: esahubble|potw1649a
 
 credits> ESA/Hubble & NASA; The constellation of Virgo (The Virgin) is
 especially rich in galaxies, due in part to the presence of a massive and
@@ -24182,6 +25187,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1650aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1650a.jpg
+astropix_ids: esahubble|potw1650a
 
 credits> ESA/Hubble & NASA; In 1900, astronomer Joseph Lunt made a discovery:
 Peering through a telescope at Cape Town Observatory, the British–South
@@ -24206,6 +25212,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1651aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1651a.jpg
+astropix_ids: esahubble|potw1651a
 
 credits> ESA/Hubble & NASA; On a clear evening in April of 1789, the renowned
 astronomer William Herschel continued his unrelenting survey of the night
@@ -24230,6 +25237,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1652aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1652a.jpg
+astropix_ids: esahubble|potw1652a
 
 credits> ESA/Hubble & NASAAcknowledgeme; This galaxy has a far more exciting and
 futuristic classification than most — it is a megamaser. Megamasers are
@@ -24254,6 +25262,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1701aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1701a.jpg
+astropix_ids: esahubble|potw1701a
 
 credits> ESA/Hubble & NASA; This delicate smudge in deep space is far more
 turbulent than it first appears. Known as IRAS 14348-1447 — a name derived in
@@ -24278,6 +25287,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1702aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1702a.jpg
+astropix_ids: esahubble|potw1702a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This image taken with the Advanced
 Camera for Surveys (ACS) onboard the NASA/ESA Hubble Space Telescope captures a
@@ -24302,6 +25312,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1703aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1703a.jpg
+astropix_ids: esahubble|potw1703a
 
 credits> ESA/Hubble & NASA; This stunning image, captured by the NASA/ESA Hubble
 Space Telescope’s Advanced Camera for Surveys (ACS), shows part of the sky...
@@ -24325,6 +25336,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1704aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1704a.jpg
+astropix_ids: esahubble|potw1704a
 
 credits> ESA/Hubble & NASA; The lesser-known constellation of Canes Venatici
 (The Hunting Dogs), is home to a variety of deep-sky objects — including this...
@@ -24348,6 +25360,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1705aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1705a.jpg
+astropix_ids: esahubble|potw1705a
 
 credits> ESA/Hubble & NASA Acknowledgem; The Calabash Nebula, pictured here —
 which has the technical name OH 231.8+04.2 — is a spectacular example of the
@@ -24372,6 +25385,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1706aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1706a.jpg
+astropix_ids: esahubble|potw1706a
 
 credits> ESA/Hubble & NASA; Not to be confused with our neighbouring Andromeda
 Galaxy, the Andromeda constellation is one of the 88 modern constellations. ...
@@ -24395,6 +25409,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1707aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1707a.jpg
+astropix_ids: esahubble|potw1707a
 
 credits> ESA/Hubble & NASA; This image was captured by the NASA/ESA Hubble Space
 Telescope’s Advanced Camera for Surveys (ACS), a highly efficient wide-fi...
@@ -24418,6 +25433,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1708aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1708a.jpg
+astropix_ids: esahubble|potw1708a
 
 credits> ESA/Hubble & NASA, T. Kitayama (; The events surrounding the Big Bang
 were so cataclysmic that they left an indelible imprint on the fabric of the
@@ -24442,6 +25458,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1708bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1708b.jpg
+astropix_ids: esahubble|potw1708b
 
 credits> ESA/Hubble, NASA; This cluster of galaxies, RX J1347.5–1145, was
 observed by the NASA/ESA Hubble Space Telescope as part of the Cluster Lensing
@@ -24466,6 +25483,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1709aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1709a.jpg
+astropix_ids: esahubble|potw1709a
 
 credits> ESA/Hubble & NASA; This NASA/ESA Hubble Space Telescope image showcases
 the remarkable galaxy UGC 12591. Classified as an S0/Sa galaxy, UGC 12591 s...
@@ -24489,6 +25507,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1710aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1710a.jpg
+astropix_ids: esahubble|potw1710a
 
 credits> ESA/Hubble & NASA; Light travels through space at just under 300 000
 kilometres per second! This staggering speed is used to calculate astronomic...
@@ -24512,6 +25531,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1711aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1711a.jpg
+astropix_ids: esahubble|potw1711a
 
 credits> ESA/Hubble & NASA; This image from Hubble’s Wide Field Camera 3 (WFC3)
 shows NGC 1448, a spiral galaxy located about 50 million light-years from E...
@@ -24535,6 +25555,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1712aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1712a.jpg
+astropix_ids: esahubble|potw1712a
 
 credits> ESA/Hubble & NASA; Some galaxies are harder to classify than others.
 Here, Hubble’s trusty Wide Field Camera 3 (WFC3) has captured a striking vie...
@@ -24558,6 +25579,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1713aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1713a.jpg
+astropix_ids: esahubble|potw1713a
 
 credits> ESA/Hubble & NASA; Some astronomical objects have endearing or quirky
 nicknames, inspired by mythology or their own appearance. Take, for example,...
@@ -24581,6 +25603,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1715aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1715a.jpg
+astropix_ids: esahubble|potw1715a
 
 credits> ESA/Hubble & NASA; Despite all efforts galaxy formation and evolution
 are still far from being fully understood. Fortunately, the conditions we se...
@@ -24604,6 +25627,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1716aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1716a.jpg
+astropix_ids: esahubble|potw1716a
 
 credits> ESA/Hubble & NASA; This entrancing image shows a few of the tenuous
 threads that comprise Sh2-308, a faint and wispy shell of gas located 5200 li...
@@ -24627,6 +25651,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1717aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1717a.jpg
+astropix_ids: esahubble|potw1717a
 
 credits> ESA/Hubble & NASA; In space, being outshone is an occupational hazard.
 This NASA/ESA Hubble Space Telescope image captures a galaxy named NGC 7250...
@@ -24650,6 +25675,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1718aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1718a.jpg
+astropix_ids: esahubble|potw1718a
 
 credits> ESA/Hubble & NASA; This image from Hubble’s Wide Field Camera 3 (WFC3)
 shows a spiral galaxy NGC 5917, perhaps best known for its intriguing intera...
@@ -24673,6 +25699,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1719aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1719a.jpg
+astropix_ids: esahubble|potw1719a
 
 credits> ESA/Hubble & NASA; This image from the NASA/ESA Hubble Space Telescope
 shows the unusual galaxy IRAS 06076-2139, found in the constellation Lepus ...
@@ -24696,6 +25723,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1720aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1720a.jpg
+astropix_ids: esahubble|potw1720a
 
 credits> NASA, ESA, G. Dubner (IAFE, CONI; This captivating new image shows the
 Crab Nebula in bright neon colours. The unusual image was produced by combining
@@ -24720,6 +25748,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1720bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1720b.jpg
+astropix_ids: esahubble|potw1720b
 
 credits> NRAO/AUI/NSF; The Karl G. Jansky Very Large Array (VLA) observed the
 Crab Nebula, a supernova remnant located 6500 light-years from Earth, at ...
@@ -24743,6 +25772,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1720cL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1720c.jpg
+astropix_ids: esahubble|potw1720c
 
 credits> JPL/Caltech; NASA’s Spitzer Space Telescope observed the Crab Nebula, a
 supernova remnant located 6500 light-years from Earth, in the infrare...
@@ -24766,6 +25796,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1720dL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1720d.jpg
+astropix_ids: esahubble|potw1720d
 
 credits> NASA, ESA/Hubble; The NASA/ESA Hubble Space Telescope observed the Crab
 Nebula, a supernova remnant located 6500 light-years from Earth, in optica...
@@ -24789,6 +25820,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1720eL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1720e.jpg
+astropix_ids: esahubble|potw1720e
 
 credits> ESA; ESA’s XMM-Newton telescope observed the Crab Nebula, a supernova
 remnant located 6500 light-years from Earth, in the ultraviolet...
@@ -24812,6 +25844,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1720fL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1720f.jpg
+astropix_ids: esahubble|potw1720f
 
 credits> CXC; NASA’s Chandra X-ray Observatory observed X-ray emissions from the
 Crab Nebula, a supernova remnant located 6500 light-years fro...
@@ -24835,6 +25868,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1721aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1721a.jpg
+astropix_ids: esahubble|potw1721a
 
 credits> ESA/Hubble & NASA; The NASA/ESA Hubble Space Telescope still has a few
 tricks up its sleeve in its task of exploring the Universe. For one, it is...
@@ -24858,6 +25892,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1724aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1724a.jpg
+astropix_ids: esahubble|potw1724a
 
 credits> NASA, ESA, and K. Sahu (STScI); A century ago, Albert Einstein
 published his famous theory of relativity. He proposed that all objects
@@ -24882,6 +25917,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1725aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1725a.jpg
+astropix_ids: esahubble|potw1725a
 
 credits> ESA/Hubble & NASA; The object in the middle of this image, sitting
 alone within a star-studded cosmos, is a galaxy known as ESO 486-21. ESO 486-21
@@ -24906,6 +25942,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1726aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1726a.jpg
+astropix_ids: esahubble|potw1726a
 
 credits> ESA/Hubble & NASA; Not all galaxies have the luxury of possessing a
 simple moniker or quirky nickname. The subject of this NASA/ESA Hubble Space ...
@@ -24929,6 +25966,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1727aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1727a.jpg
+astropix_ids: esahubble|potw1727a
 
 credits> ESA/Hubble & NASA; IC 342 is a challenging cosmic target. Although it
 is bright, the galaxy sits near the equator of the Milky Way’s galactic dis...
@@ -24952,6 +25990,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1728aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1728a.jpg
+astropix_ids: esahubble|potw1728a
 
 credits> ESA/Hubble & NASA; Discovered by British astronomer William Herschel
 over 200 years ago, NGC 2500 lies about 30 million light-years away in the ...
@@ -24975,6 +26014,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1729aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1729a.jpg
+astropix_ids: esahubble|potw1729a
 
 credits> ESA/Hubble & NASA; Tucked away in the small northern constellation of
 Canes Venatici (The Hunting Dogs) is the galaxy NGC 4242, shown here as see...
@@ -24998,6 +26038,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1730aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1730a.jpg
+astropix_ids: esahubble|potw1730a
 
 credits> ESA/Hubble & NASA; This beautiful clump of glowing gas, dark dust, and
 glittering stars is the spiral galaxy NGC 4248, located about 24 million l...
@@ -25021,6 +26062,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1731aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1731a.jpg
+astropix_ids: esahubble|potw1731a
 
 credits> ESA/Hubble & NASA; The star of this Hubble Picture of the Week is a
 galaxy known as NGC 4656, located in the constellation of Canes Venatici (The...
@@ -25044,6 +26086,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1732aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1732a.jpg
+astropix_ids: esahubble|potw1732a
 
 credits> ESA/Hubble & NASA; The subject of this NASA/ESA Hubble Space Telescope
 image is a dwarf galaxy named NGC 5949. Thanks to its proximity to Earth —...
@@ -25067,6 +26110,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1733aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1733a.jpg
+astropix_ids: esahubble|potw1733a
 
 credits> ESA/Hubble & NASA; Gravity governs the movements of the cosmos. It
 draws flocks of galaxies together to form small groups and more massive
@@ -25091,6 +26135,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1734aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1734a.jpg
+astropix_ids: esahubble|potw1734a
 
 credits> ESA/Hubble & NASA; NGC 178 may be small, but it packs quite a punch.
 Measuring around 40 000 light-years across, its diameter is less than half t...
@@ -25114,6 +26159,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1735aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1735a.jpg
+astropix_ids: esahubble|potw1735a
 
 credits> ESA/Hubble & NASA; Phenomena across the Universe emit radiation
 spanning the entire electromagnetic spectrum — from high-energy gamma rays,
@@ -25138,6 +26184,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1736aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1736a.jpg
+astropix_ids: esahubble|potw1736a
 
 credits> ESA/Hubble & NASA; Like firecrackers lighting up the sky on New Year’s
 Eve, the majestic spiral arms of NGC 5559 are alight with new stars being ...
@@ -25161,6 +26208,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1737aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1737a.jpg
+astropix_ids: esahubble|potw1737a
 
 credits> ESA/Hubble & NASA; This NASA/ESA Hubble Space Telescope picture shows
 NGC 5398, a barred spiral galaxy located about 55 million light-years away....
@@ -25184,6 +26232,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1738aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1738a.jpg
+astropix_ids: esahubble|potw1738a
 
 credits> ESA/Hubble & NASAAcknowledgeme; Despite the advances made in past
 decades, the process of galaxy formation remains an open question in astronomy.
@@ -25208,6 +26257,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1739aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1739a.jpg
+astropix_ids: esahubble|potw1739a
 
 credits> ESA/Hubble & NASA; The distances to objects in the Universe can differ
 enormously. The nearest star to us — Proxima Centauri — lies some 4.2 ligh...
@@ -25231,6 +26281,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1740aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1740a.jpg
+astropix_ids: esahubble|potw1740a
 
 credits> ESA/Hubble & NASAAcknowledgemen; At a distance of just 160 000
 light-years, the Large Magellanic Cloud (LMC) is one of the Milky Way’s closest
@@ -25255,6 +26306,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1741aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1741a.jpg
+astropix_ids: esahubble|potw1741a
 
 credits> ESA/Hubble & NASA; As far as galaxies are concerned, size can be
 deceiving. Some of the largest galaxies in the Universe are dormant, while some
@@ -25279,6 +26331,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1742aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1742a.jpg
+astropix_ids: esahubble|potw1742a
 
 credits> ESA/Hubble & NASA; This image, captured by the NASA/ESA Hubble Space
 Telescope, shows what happens when two galaxies become one. The twisted cosm...
@@ -25302,6 +26355,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1743aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1743a.jpg
+astropix_ids: esahubble|potw1743a
 
 credits> ESA/Hubble & NASA; This NASA/ESA Hubble Space Telescope image is
 chock-full of galaxies — each glowing speck is a different galaxy, bar the
@@ -25326,6 +26380,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1744aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1744a.jpg
+astropix_ids: esahubble|potw1744a
 
 credits> ESA/Hubble & NASA; The Universe contains some truly massive objects.
 Although we are still unsure how such gigantic things come to be, the current...
@@ -25349,6 +26404,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1745aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1745a.jpg
+astropix_ids: esahubble|potw1745a
 
 credits> ESA/Hubble & NASA; This NASA/ESA Hubble Space Telescope image seems to
 sink into the screen, plunging the viewer into the dark depths of the earl...
@@ -25372,6 +26428,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1746aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1746a.jpg
+astropix_ids: esahubble|potw1746a
 
 credits> ESA/Hubble & NASA; This new Picture of the Week, taken by the NASA/ESA
 Hubble Space Telescope, shows the dwarf galaxy NGC 4625, located about 30 m...
@@ -25395,6 +26452,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1747aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1747a.jpg
+astropix_ids: esahubble|potw1747a
 
 credits> ESA/Hubble, NASA; This NASA/ESA Hubble Space Telescope image reveals
 the Cosmic Snake, a distant galaxy peppered with clumpy regions of intense st...
@@ -25418,6 +26476,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1747bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1747b.jpg
+astropix_ids: esahubble|potw1747b
 
 credits> ESA/Hubble & NASA; This image shows the galaxy cluster
 MACSJ1206.2-0847. The cluster is so far away, it took the light from the cluster
@@ -25442,6 +26501,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1748aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1748a.jpg
+astropix_ids: esahubble|potw1748a
 
 credits> ESA/Hubble & NASA; This picturesque view from the NASA/ESA Hubble Space
 Telescope peers into the distant Universe to reveal a galaxy cluster call...
@@ -25465,6 +26525,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1749aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1749a.jpg
+astropix_ids: esahubble|potw1749a
 
 credits> ESA/Hubble & NASA; Don’t be fooled! The subject of this Picture of the
 Week, ESO 580-49, may seem tranquil and unassuming, but this spiral galaxy a...
@@ -25488,6 +26549,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1750aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1750a.jpg
+astropix_ids: esahubble|potw1750a
 
 credits> ESA/Hubble & NASA; Galaxies glow like fireflies in this spectacular
 NASA/ESA Hubble Space Telescope image! This flickering swarm of cosmic firefl...
@@ -25511,6 +26573,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1751aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1751a.jpg
+astropix_ids: esahubble|potw1751a
 
 credits> NASA and ESA Acknowledgement: S.; It’s beginning to look a lot like
 Christmas in this NASA/ESA Hubble Space Telescope image of a blizzard of stars,
@@ -25535,6 +26598,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1752aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1752a.jpg
+astropix_ids: esahubble|potw1752a
 
 credits> ESO, ESA/Hubble & NASA; This image shows something spectacular: a
 massive galaxy cluster that it is warping the space around it! The cluster,
@@ -25559,6 +26623,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1752bL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1752b.jpg
+astropix_ids: esahubble|potw1752b
 
 credits> ESO & ESA/Hubble & NASA; This image shows the galaxy cluster RCS2
 J2327. The mass of the cluster causes both strong and weak gravitational
@@ -25583,6 +26648,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1801aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1801a.jpg
+astropix_ids: esahubble|potw1801a
 
 credits> ESA/Hubble & NASA; This image, captured by the NASA/ESA Hubble Space
 Telescope’s Wide Field Camera 3 (WFC3), shows a galaxy named UGC 6093. As can
@@ -25607,6 +26673,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1802aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1802a.jpg
+astropix_ids: esahubble|potw1802a
 
 credits> ESA/Hubble & NASA, RELICS; In 2014, astronomers using the NASA/ESA
 Hubble Space Telescope found that this enormous galaxy cluster contains the mass
@@ -25631,6 +26698,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1803aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1803a.jpg
+astropix_ids: esahubble|potw1803a
 
 credits> NASA, ESA, and J. Comerford (Uni; Researchers using a suite of
 telescopes including the NASA/ESA Hubble Space Telescope have spotted a
@@ -25655,6 +26723,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1804aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1804a.jpg
+astropix_ids: esahubble|potw1804a
 
 credits> ESA/Hubble & NASA; This image from the NASA/ESA Hubble Space Telescope
 reveals a glistening and ancient globular cluster named NGC 3201 — a gatheri...
@@ -25678,6 +26747,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1805aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1805a.jpg
+astropix_ids: esahubble|potw1805a
 
 credits> ESA/Hubble & NASA/D. Milisavljev; This NASA/ESA Hubble Space Telescope
 image shows a spiral galaxy known as NGC 7331. First spotted by the prolific
@@ -25702,6 +26772,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1806aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1806a.jpg
+astropix_ids: esahubble|potw1806a
 
 credits> ESA/Hubble & NASA; Roughly 50 million light-years away lies a somewhat
 overlooked little galaxy named NGC 1559. Pictured here by Hubble’s Wide Fiel...
@@ -25725,6 +26796,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1807aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1807a.jpg
+astropix_ids: esahubble|potw1807a
 
 credits> ESA/Hubble & NASA, RELICS; This image from the NASA/ESA Hubble Space
 Telescope shows the galaxy cluster PLCK G004.5-19.5. It was discovered by the
@@ -25749,6 +26821,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1809aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1809a.jpg
+astropix_ids: esahubble|potw1809a
 
 credits> ESA/Hubble & NASA Acknowledgemen; Discovered in 1900 by astronomer
 DeLisle Stewart and here imaged by the NASA/ESA Hubble Space Telescope, IC 4710
@@ -25773,6 +26846,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1811aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1811a.jpg
+astropix_ids: esahubble|potw1811a
 
 credits> ESA/Hubble & NASA, A. Riess (STS; This stunning image from Hubble shows
 the majestic galaxy NGC 1015, found nestled within the constellation of Cetus
@@ -25797,6 +26871,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1812aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1812a.jpg
+astropix_ids: esahubble|potw1812a
 
 credits> NASA, ESA, and M. Beasley (Insti; This idyllic scene, packed with
 glowing galaxies, has something truly remarkable at its core: an untouched relic
@@ -25821,6 +26896,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1813aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1813a.jpg
+astropix_ids: esahubble|potw1813a
 
 credits> ESA/Hubble & NASA; This image, captured by the Advanced Camera for
 Surveys (ACS) on the NASA/ESA Hubble Space Telescope, shows the spiral galaxy
@@ -25845,6 +26921,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1816aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1816a.jpg
+astropix_ids: esahubble|potw1816a
 
 credits> ESA/Hubble & NASA, RELICS; This intriguing image from the NASA/ESA
 Hubble Space Telescope shows a massive galaxy cluster called PSZ2 G138.61-10.84,
@@ -25869,6 +26946,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1817aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1817a.jpg
+astropix_ids: esahubble|potw1817a
 
 credits> ESA/Hubble & NASA, A. Fillipenko; This pretty, cloud-like object may
 not look much like a galaxy — it lacks the well-defined arms of a spiral galaxy,
@@ -25893,6 +26971,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1819aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1819a.jpg
+astropix_ids: esahubble|potw1819a
 
 credits> ESA/Hubble & NASA, RELICS; In the darkness of the distant Universe,
 galaxies resemble glowing fireflies, flickering candles, charred embers floating
@@ -25917,6 +26996,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1820aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1820a.jpg
+astropix_ids: esahubble|potw1820a
 
 credits> ESA/Hubble & NASA; Resembling a wizard’s staff set aglow, NGC 1032
 cleaves the quiet darkness of space in two in this image from the NASA/ESA
@@ -25941,6 +27021,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1822aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1822a.jpg
+astropix_ids: esahubble|potw1822a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This NASA/ESA Hubble Space Telescope
 image shows a cluster of hundreds of galaxies located about 7.5 billion
@@ -25965,6 +27046,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1823aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1823a.jpg
+astropix_ids: esahubble|potw1823a
 
 credits> ESA/Hubble & NASA; A ripple of bright blue threads through this galaxy
 like a misshapen lake system. The foreground of this image is littered with ...
@@ -25988,6 +27070,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1824aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1824a.jpg
+astropix_ids: esahubble|potw1824a
 
 credits> ESA/Hubble & NASA, RELICS; This sparkling Picture of the Week features
 a massive galaxy cluster named RXC J0232.2-4420. This image was taken by
@@ -26012,6 +27095,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1825aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1825a.jpg
+astropix_ids: esahubble|potw1825a
 
 credits> ESA/Hubble & NASA, RELICS; In astronomy, the devil is in the details —
 as this image, taken by the NASA/ESA Hubble Space Telescope’s Advanced Camera
@@ -26036,6 +27120,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1826aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1826a.jpg
+astropix_ids: esahubble|potw1826a
 
 credits> ESA/Hubble & NASA; This rich and dense smattering of stars is a massive
 globular cluster, a gravitationally-bound collection of stars that orbits t...
@@ -26059,6 +27144,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1827aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1827a.jpg
+astropix_ids: esahubble|potw1827a
 
 credits> ESA/Hubble & NASA, RELICS; This busy image is a treasure trove of
 wonders. Bright stars from the Milky Way sparkle in the foreground, the
@@ -26083,6 +27169,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1829aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1829a.jpg
+astropix_ids: esahubble|potw1829a
 
 credits> ESA/Hubble & NASA; At first glance, it may seem as though this image
 was taken through a faulty lens, but the mind-bending distortions visible in
@@ -26107,6 +27194,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1830aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1830a.jpg
+astropix_ids: esahubble|potw1830a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This image taken by the NASA/ESA
 Hubble Space Telescope’s Wide Field Camera 3 (WFC3) shows a beautiful spiral
@@ -26131,6 +27219,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1831aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1831a.jpg
+astropix_ids: esahubble|potw1831a
 
 credits> ESA/Hubble & NASA Acknowledgemen; Obtained for a research programme on
 star formation in old and distant galaxies, this NASA/ESA Hubble Space Telescope
@@ -26155,6 +27244,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1832aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1832a.jpg
+astropix_ids: esahubble|potw1832a
 
 credits> ESA/Hubble & NASA; This Picture of the Week shows the colourful
 globular cluster NGC 2108. The cluster is nestled within the Large Magellanic
@@ -26202,6 +27292,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1835aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1835a.jpg
+astropix_ids: esahubble|potw1835a
 
 credits> ESA/Hubble & NASA; Following on from last week’s Picture of the Week,
 this week we showcase the second part of the Hubble Deep UV (HDUV) Legacy Fie...
@@ -26225,6 +27316,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1836aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1836a.jpg
+astropix_ids: esahubble|potw1836a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This week’s NASA/ESA Hubble Space
 Telescope image showcases the galaxy NGC 4036: a lenticular galaxy some 70
@@ -26249,6 +27341,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1837aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1837a.jpg
+astropix_ids: esahubble|potw1837a
 
 credits> ESA/Hubble & NASA Acknowledgemen; Gravity is so much a part of our
 daily lives that it is all too easy to forget its awesome power — but on a
@@ -26273,6 +27366,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1838aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1838a.jpg
+astropix_ids: esahubble|potw1838a
 
 credits> ESA/Hubble & NASA; In the northern constellation of Coma Berenices
 (Berenice's Hair) lies the impressive Coma Cluster — a structure of over a
@@ -26297,6 +27391,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1839aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1839a.jpg
+astropix_ids: esahubble|potw1839a
 
 credits> ESA/Hubble & NASAAcknowledgement; This NASA/ESA Hubble Space Telescope
 image contains a veritable mix of different galaxies, some of which belong to
@@ -26345,6 +27440,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1841aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1841a.jpg
+astropix_ids: esahubble|potw1841a
 
 credits> ESA/Hubble & NASA; This image from the NASA/ESA Hubble Space Telescope
 reveals a spiral galaxy named Messier 95 (also known as M95 or NGC 3351). Lo...
@@ -26368,6 +27464,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1842aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1842a.jpg
+astropix_ids: esahubble|potw1842a
 
 credits> ESA/Hubble & NASA Acknowledgemen; This image, taken with the NASA/ESA
 Hubble Space Telescope's Wide Field Camera 3 (WFC3), shows a patch of space
@@ -26392,6 +27489,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1843aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1843a.jpg
+astropix_ids: esahubble|potw1843a
 
 credits> ESA/Hubble & NASAAcknowledgement; This Picture of the Week shows the
 unbarred spiral galaxy NGC 5033, located about 40 million light-years away in
@@ -26416,6 +27514,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1845aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1845a.jpg
+astropix_ids: esahubble|potw1845a
 
 credits> ESA/Hubble & NASA; This captivating image from the NASA/ESA Hubble
 Space Telescope’s Wide Field Camera 3 shows a lonely dwarf galaxy, a staggering
@@ -26440,6 +27539,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1846aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1846a.jpg
+astropix_ids: esahubble|potw1846a
 
 credits> ESA/Hubble & NASAAcknowledgement; At first glance, a bright blue
 crescent immediately jumps out of this NASA/ESA Hubble Space Telescope image: is
@@ -26464,6 +27564,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1847aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1847a.jpg
+astropix_ids: esahubble|potw1847a
 
 credits> ESA/Hubble & NASA; Star clusters are common structures throughout the
 Universe, each made up of hundreds of thousands of stars all bound together b...
@@ -26487,6 +27588,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1848aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1848a.jpg
+astropix_ids: esahubble|potw1848a
 
 credits> ESA/Hubble, NASA; This dark, tangled web is an object named SNR
 0454-67.2. It formed in a very violent fashion — it is a supernova remnant,
@@ -26511,6 +27613,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1849aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1849a.jpg
+astropix_ids: esahubble|potw1849a
 
 credits> NASA, ESA, J. Mack, and J. Madri; This image, from the NASA/ESA Hubble
 Space Telescope’s Advanced Camera for Surveys (ACS), reveals thousands of
@@ -26535,6 +27638,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1851aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1851a.jpg
+astropix_ids: esahubble|potw1851a
 
 credits> NASA, ESA, and A. Shapley (UCLA); For three weeks in October, Hubble’s
 eyes on the Universe closed. On the evening of Friday 5 October, the orbiting
@@ -26559,6 +27663,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1852aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1852a.jpg
+astropix_ids: esahubble|potw1852a
 
 credits> ESA/Hubble & NASA; This image from the NASA/ESA Hubble Space Telescope
 reveals an ancient, glimmering ball of stars called NGC 1466. It is a globul...
@@ -26582,6 +27687,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1853aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1853a.jpg
+astropix_ids: esahubble|potw1853a
 
 credits> ESA/Hubble & NASA, K. Stapelfeld; In this image the NASA/ESA Hubble
 Space Telescope has captured the smoking gun of a newborn star, the Herbig–Haro
@@ -26606,6 +27712,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1901aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1901a.jpg
+astropix_ids: esahubble|potw1901a
 
 credits> ESA/Hubble & NASA, C. Sarazin et; It might appear featureless and
 unexciting at first glance, but NASA/ESA Hubble Space Telescope observations of
@@ -26630,6 +27737,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1902aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1902a.jpg
+astropix_ids: esahubble|potw1902a
 
 credits> ESA/Hubble & NASA, S. Faber et a; This huge ball of stars — around 100
 billion in total — is an elliptical galaxy located some 55 million light-years
@@ -26654,6 +27762,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1903aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1903a.jpg
+astropix_ids: esahubble|potw1903a
 
 credits> ESA/Hubble & NASA, M. Gladders e; This picture showcases a
 gravitational lensing system called SDSS J0928+2031. Quite a few images of this
@@ -26678,6 +27787,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1904aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1904a.jpg
+astropix_ids: esahubble|potw1904a
 
 credits> ESA/Hubble & NASA, Cramer et al.; This striking image combines data
 gathered with the Advanced Camera for Surveys, installed on the NASA/ESA Hubble
@@ -26702,6 +27812,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1905aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1905a.jpg
+astropix_ids: esahubble|potw1905a
 
 credits> ESA/Hubble & NASA, R. O'Connell; This atmospheric image shows a galaxy
 named Messier 85, captured in all its delicate, hazy glory by the NASA/ESA
@@ -26726,6 +27837,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1908aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1908a.jpg
+astropix_ids: esahubble|potw1908a
 
 credits> ESA/Hubble & NASA, S. Larsen et ; Globular clusters like NGC 2419,
 visible in this image taken with the NASA/ESA Hubble Space Telescope, are not
@@ -26750,6 +27862,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1909aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1909a.jpg
+astropix_ids: esahubble|potw1909a
 
 credits> ESA/Hubble & NASA, A. Adamo et a; Located in the constellation of
 Hercules, about 230 million light-years away, NGC 6052 is a pair of colliding
@@ -26774,6 +27887,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1910aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1910a.jpg
+astropix_ids: esahubble|potw1910a
 
 credits> ESA/Hubble & NASA, J. E. Grindla; This Hubble Picture of the Week shows
 Messier 28, a globular cluster in the constellation of Sagittarius (The Archer),
@@ -26798,6 +27912,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1911aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1911a.jpg
+astropix_ids: esahubble|potw1911a
 
 credits> ESA/Hubble & NASA, J. Blakenslee; This fuzzy orb of light is a giant
 elliptical galaxy filled with an incredible 200 billion stars. Unlike spiral
@@ -26822,6 +27937,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1912aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1912a.jpg
+astropix_ids: esahubble|potw1912a
 
 credits> ESA/Hubble & NASA, P. Dobbie et ; This star-studded image shows us a
 portion of Messier 11, an open star cluster in the southern constellation of
@@ -26846,6 +27962,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1913aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1913a.jpg
+astropix_ids: esahubble|potw1913a
 
 credits> ESA/Hubble & NASA, G. Piotto et ; Star clusters are commonly featured
 in cosmic photoshoots, and are also well-loved by the keen eye of the NASA/ESA
@@ -26870,6 +27987,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1914aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1914a.jpg
+astropix_ids: esahubble|potw1914a
 
 credits> ESA/Hubble & NASA, G. Piotto et ; Globular clusters are inherently
 beautiful objects, but the subject of this NASA/ESA Hubble Space Telescope
@@ -26894,6 +28012,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1915aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1915a.jpg
+astropix_ids: esahubble|potw1915a
 
 credits> ESA/Hubble & NASA, S. Anderson e; Most globular clusters are almost
 perfectly spherical collections of stars — but Messier 62 breaks the mould. The
@@ -26918,6 +28037,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1916aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1916a.jpg
+astropix_ids: esahubble|potw1916a
 
 credits> ESA/Hubble & NASA, F. Ferraro et; This sparkling burst of stars is
 Messier 75. It is a globular cluster: a spherical collection of stars bound
@@ -26942,6 +28062,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1917aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1917a.jpg
+astropix_ids: esahubble|potw1917a
 
 credits> ESA/Hubble & NASA, L. Ho et al.; Few of the Universe’s residents are as
 iconic as the spiral galaxy. These limelight-hogging celestial objects combine
@@ -26966,6 +28087,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1918aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1918a.jpg
+astropix_ids: esahubble|potw1918a
 
 credits> ESA/Hubble & NASA, I. Karachents; Dotted across the sky in the
 constellation of Pictor (The Painter’s Easel) is the galaxy cluster highlighted
@@ -26990,6 +28112,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1919aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1919a.jpg
+astropix_ids: esahubble|potw1919a
 
 credits> ESA/Hubble & NASA, B. Lehmer et ; NGC 3384, visible in this image, has
 many of the features characteristic of so-called elliptical galaxies. Such
@@ -27014,6 +28137,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1920aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1920a.jpg
+astropix_ids: esahubble|potw1920a
 
 credits> ESA/Hubble & NASA, W. Sargent et; This Picture of the Week stars
 Messier 90, a beautiful spiral galaxy located roughly 60 million light-years
@@ -27038,6 +28162,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1921aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1921a.jpg
+astropix_ids: esahubble|potw1921a
 
 credits> ESA/Hubble & NASA, P. Cote; This luminous orb is the galaxy NGC 4621,
 better known as Messier 59. As this latter moniker indicates, the galaxy was
@@ -27062,6 +28187,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1922aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1922a.jpg
+astropix_ids: esahubble|potw1922a
 
 credits> ESA/Hubble & NASA, J. Walsh; This striking image was taken by the
 NASA/ESA Hubble Space Telescope’s Wide Field Camera 3, a powerful instrument
@@ -27086,6 +28212,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1923aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1923a.jpg
+astropix_ids: esahubble|potw1923a
 
 credits> ESA/Hubble & NASA, D. Crenshaw a; When massive stars die at the end of
 their short lives, they light up the cosmos with bright, explosive bursts of
@@ -27110,6 +28237,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1924aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1924a.jpg
+astropix_ids: esahubble|potw1924a
 
 credits> NASA, ESA and F. Bauer; This image shows an irregular galaxy named IC
 10, a member of the Local Group — a collectiongrouping of over 50 galaxies
@@ -27134,6 +28262,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1925aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1925a.jpg
+astropix_ids: esahubble|potw1925a
 
 credits> ESA/Hubble & NASA, V. Rubin et a; This Hubble Picture of the Week shows
 the spiral galaxy Messier 98, which is located about 45 million light-years away
@@ -27158,6 +28287,7 @@ url: http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1926aL{1}X{2}Y{3}.png
 copyright: Public domain
 license_id: CC-PDDC
 thumbnail: http://wwtfiles.blob.core.windows.net/vamp/thumb-Hubble-potw1926a.jpg
+astropix_ids: esahubble|potw1926a
 
 credits> ESA/Hubble, NASA, L. Ho; This NASA/ESA Hubble Space Telescope Picture
 of the Week shows bright, colourful pockets of star formation blooming like

--- a/cxprep/hubble.txt
+++ b/cxprep/hubble.txt
@@ -1041,7 +1041,7 @@ place_uuid: 3179be1f-96ad-4567-8567-d547c0cdb2ee
 image_url: http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000000232{Q}?g=138
 outgoing_url: http://hubblesite.org/contents/news-releases/1993/news-1993-11.html
 
-text> NGC 7257: Spiral Disk and Globular Star Clusters at the Core of a
+text> NGC 7252: Spiral Disk and Globular Star Clusters at the Core of a
 Colliding Galaxy
 
 wip: yes

--- a/cxprep/hubble.txt
+++ b/cxprep/hubble.txt
@@ -1,15 +1,4 @@
 
-@image
-url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001321{Q}?g=138
-copyright: Public domain
-license_id: CC-PDDC
-thumbnail: http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=314237335
-astropix_ids: stsci|2005-37a
-
-credits> NASA, ESA, J. Hester and A. Loll (Arizona State University)
-
----
-
 @scene
 place_uuid: 6492b213-8592-443a-9fcf-f57bb06925e3
 image_url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001321{Q}?g=138

--- a/cxprep/hubble.txt
+++ b/cxprep/hubble.txt
@@ -1,18 +1,4 @@
 
-@scene
-place_uuid: 6492b213-8592-443a-9fcf-f57bb06925e3
-image_url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001321{Q}?g=138
-outgoing_url: http://hubblesite.org/contents/news-releases/2005/news-2005-37.html
-
-text> The Crab Nebula is a six-light-year-wide expanding remnant of a star's
-supernova explosion. Japanese and Chinese astronomers recorded this violent
-event nearly 1,000 years ago in 1054, as did, almost certainly, Native
-Americans. This composite image was assembled from 24 individual exposures taken
-with the NASA Hubble Space Telescope's Wide Field and Planetary Camera 2 in
-October 1999, January 2000, and December 2000.
-
----
-
 @image
 url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001331{Q}?g=138
 copyright: Public domain

--- a/cxprep/hubble.txt
+++ b/cxprep/hubble.txt
@@ -8,7 +8,6 @@ astropix_ids: stsci|2005-37a
 
 credits> NASA, ESA, J. Hester and A. Loll (Arizona State University)
 
-wip: yes
 ---
 
 @scene
@@ -16,19 +15,13 @@ place_uuid: 6492b213-8592-443a-9fcf-f57bb06925e3
 image_url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001321{Q}?g=138
 outgoing_url: http://hubblesite.org/contents/news-releases/2005/news-2005-37.html
 
-text> Giant Hubble Mosaic of the Crab Nebula
+text> The Crab Nebula is a six-light-year-wide expanding remnant of a star's
+supernova explosion. Japanese and Chinese astronomers recorded this violent
+event nearly 1,000 years ago in 1054, as did, almost certainly, Native
+Americans. This composite image was assembled from 24 individual exposures taken
+with the NASA Hubble Space Telescope's Wide Field and Planetary Camera 2 in
+October 1999, January 2000, and December 2000.
 
-wip: yes
----
-
-@scene
-place_uuid: 6a0c9089-27d4-4949-83f9-abb1badee694
-image_url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001321{Q}?g=138
-outgoing_url: http://hubblesite.org/contents/news-releases/2005/news-2005-37.html
-
-text> Giant Hubble Mosaic of the Crab Nebula
-
-wip: yes
 ---
 
 @image

--- a/cxprep/wwtcore.txt
+++ b/cxprep/wwtcore.txt
@@ -598,6 +598,7 @@ url: http://wwtfiles.blob.core.windows.net/plnk/planckmassmapL{1}X{2}Y{3}.png
 copyright: ~~COPYRIGHT~~
 license_id: ~~LICENSE~~
 thumbnail: http://wwtfiles.blob.core.windows.net/plnk/planckmassmap_thumb.jpg
+astropix_ids: planck|planck13-002c
 
 credits>
 

--- a/imagesets/sky__ir.xml
+++ b/imagesets/sky__ir.xml
@@ -846,6 +846,7 @@
     TileLevels="3"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001013{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2005-15c"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA/JPL-Caltech/CXC/NOAO/AURA/NSF</Credits>

--- a/imagesets/sky__ir.xml
+++ b/imagesets/sky__ir.xml
@@ -245,6 +245,7 @@
     TileLevels="5"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000011210{Q}?g=131"
     WidthFactor="2"
+    Xastropix_ids="spitzer|sig05-019a"
     Xcxstatus="in:64b744cfa15b29de42b30645"
   >
     <Credits>Courtesy NASA/JPL-Caltech</Credits>
@@ -493,6 +494,7 @@
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000011031{Q}?g=131"
     WidthFactor="2"
+    Xastropix_ids="spitzer|sig05-004a"
     Xcxstatus="in:64b741f8a15b29de42b304b1"
   >
     <Credits>NASA/JPL-Caltech/R. Gehrz (University of Minnesota)</Credits>
@@ -683,6 +685,7 @@
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000010322{Q}?g=131"
     WidthFactor="2"
+    Xastropix_ids="spitzer|sig05-003a"
     Xcxstatus="in:64b741f9a15b29de42b304b3"
   >
     <Credits>NASA/JPL-Caltech/R. Gehrz (University of Minnesota)</Credits>

--- a/imagesets/sky__ir.xml
+++ b/imagesets/sky__ir.xml
@@ -53,6 +53,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/packages/2022/08_jwst/cartwheel/{1}/{3}/{3}_{2}.png"
     WidthFactor="2"
+    Xastropix_ids="stsci|2022-039a"
     Xcxstatus="in:642761e6975014bc743f159f"
   >
     <Credits>NASA, ESA, CSA, STScI, Webb ERO Production Team</Credits>

--- a/imagesets/sky__microwave.xml
+++ b/imagesets/sky__microwave.xml
@@ -306,6 +306,7 @@
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/plnk/planckmassmapL{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="planck|planck13-002c"
     Xcxstatus="queue:wwtcore"
   >
     <ThumbnailUrl>http://wwtfiles.blob.core.windows.net/plnk/planckmassmap_thumb.jpg</ThumbnailUrl>
@@ -378,6 +379,7 @@
     TileLevels="6"
     Url="http://www.worldwidetelescope.org/wwtweb/tiles.aspx?q={1},{2},{3},planck"
     WidthFactor="2"
+    Xastropix_ids="planck|planck13-002a"
     Xcxstatus="in:64820bca67b5156060bfa2b0"
   >
     <Credits>Planck is a European Space Agency mission, with significant participation from NASA. NASAs Planck Project Office is based at JPL. JPL contributed mission-enabling technology for both of Plancks science instruments. European, Canadian and U.S. Planck scientists work together to analyze the Planck data.</Credits>

--- a/imagesets/sky__visible.xml
+++ b/imagesets/sky__visible.xml
@@ -99807,6 +99807,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-001L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-001"
     Xcxstatus="in:649e45cb1e6961df10c19558"
   >
     <Credits>NASA/JPL-Caltech/WISE Team; This infrared snapshot of a region in the constellation Carina near the Milky Way was taken shortly after NASA's Wide-field Infr...</Credits>
@@ -99833,6 +99834,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-002L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-002"
     Xcxstatus="in:649e45e01e6961df10c1958b"
   >
     <Credits>NASA/JPL-Caltech/UCLA; The red dot at the center of this image is the first near-Earth asteroid discovered by NASA's Wide-Field Infrared Survey Explore...</Credits>
@@ -99859,6 +99861,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-004bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-004b"
     Xcxstatus="in:649e45d81e6961df10c19578"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This dramatic image of a nebula containing young, massive stars was captured by NASA's Wide-Field Infrared Survey Explorer, or W...</Credits>
@@ -99885,6 +99888,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-004c1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-004c,wise|WISE2010-004c1"
     Xcxstatus="in:649e45db1e6961df10c1957d"
   >
     <Credits>NASA/JPL-Caltech/WISE Team; This image from NASA's Wide-field Infrared Survey Explorer, or WISE, highlights the Andromeda galaxy's older stellar population ...</Credits>
@@ -99911,6 +99915,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-004c2L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-004c2"
     Xcxstatus="in:649e45d51e6961df10c19571"
   >
     <Credits>NASA/JPL-Caltech/WISE Team; This image from NASA's Wide-field Infrared Survey Explorer, or WISE, highlights the dust that speckles the Andromeda galaxy's sp...</Credits>
@@ -99962,6 +99967,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-004dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-004d"
     Xcxstatus="in:649e45d41e6961df10c1956d"
   >
     <Credits>NASA/JPL-Caltech/UCLA; WISE's large field of view and multi-wavelength infrared sight allowed it to form this complete view of the cluster, containing ...</Credits>
@@ -99988,6 +99994,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-005L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-005"
     Xcxstatus="in:649e45d61e6961df10c19573"
   >
     <Credits>NASA/JPL-Caltech/UCLA; A mosaic of images from WISE in the constellation of Cassiopeia. This region contains a large star forming nebula within the Mil...</Credits>
@@ -100014,6 +100021,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-006L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-006"
     Xcxstatus="in:649e45e31e6961df10c19590"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This picture of the open star cluster NGC 7380 is a mosaic of images from the WISE mission spanning an area on the sky of about ...</Credits>
@@ -100040,6 +100048,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-008L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-008"
     Xcxstatus="in:649e45cd1e6961df10c1955e"
   >
     <Credits>NASA/JPL-Caltech/UCLA; A new infrared image from NASA's Wide-field Infrared Survey Explorer, or WISE, shows a cosmic rosebud blossoming with new stars....</Credits>
@@ -100066,6 +100075,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-009L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-009"
     Xcxstatus="in:649e45ea1e6961df10c195a1"
   >
     <Credits>NASA/JPL-Caltech/WISE Team; This image from the WISE mission was taken on January 2nd, 2010, during the check-out phase, before the start of the WISE survey...</Credits>
@@ -100092,6 +100102,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-010L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-010"
     Xcxstatus="in:649e45e01e6961df10c19589"
   >
     <Credits>NASA/JPL-Caltech/WISE Team; This WISE mosaic is of the Soul Nebula (a.k.a. the Embryo Nebula, IC 1848, or W5). It is an open cluster of stars surrounded by ...</Credits>
@@ -100118,6 +100129,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-011L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-011"
     Xcxstatus="in:649e45d71e6961df10c19574"
   >
     <Credits>NASA/JPL-Caltech/UCLA; A leggy cosmic creature comes out of hiding in this new infrared view from NASA's Wide-field Infrared Survey Explorer, or WISE. ...</Credits>
@@ -100144,6 +100156,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-012L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-012"
     Xcxstatus="in:649e45e11e6961df10c1958c"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This image from WISE is a view within the constellation Cassiopeia of another portion of the vast star forming complex that make...</Credits>
@@ -100170,6 +100183,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-013L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-013"
     Xcxstatus="in:649e45e71e6961df10c1959b"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This colorful image from WISE (Wide-field Infrared Survey Explorer) is a view of an area of the sky over 12 times the size of th...</Credits>
@@ -100196,6 +100210,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-014L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-014"
     Xcxstatus="in:649e45c61e6961df10c1954c"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This heroic image from WISE is of a special cloud of dust and gas in the constellation Canis Major catalogued as NGC 2359. The n...</Credits>
@@ -100222,6 +100237,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-015L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-015"
     Xcxstatus="in:649e45e91e6961df10c1959e"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This infrared image from NASA’s WISE (Wide-field Infrared Survey Explorer) features one of the bright stars in the constellation...</Credits>
@@ -100248,6 +100264,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-016L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-016"
     Xcxstatus="in:649e45e61e6961df10c19599"
   >
     <Credits>NASA/JPL-Caltech/WISE Team; A new infrared image from NASA's Wide-field Infrared Survey Explorer, or WISE, showcases the Tadpole nebula, a star-forming hub ...</Credits>
@@ -100274,6 +100291,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-017L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-017"
     Xcxstatus="in:649e45cb1e6961df10c19559"
   >
     <Credits>NASA/JPL-Caltech/UCLA; The Seagull nebula, seen in this infrared mosaic from NASA’s Wide-field Infrared Survey Explorer, or WISE, draws its common name...</Credits>
@@ -100300,6 +100318,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-018L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-018"
     Xcxstatus="in:649e45e61e6961df10c19597"
   >
     <Credits>NASA/JPL-Caltech/UCLA; The Heart and Soul nebulae are seen in this infrared mosaic from NASA’s Wide-field Infrared Survey Explorer, or WISE.  The image...</Credits>
@@ -100326,6 +100345,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-019L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-019"
     Xcxstatus="in:649e45ca1e6961df10c19557"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This image of spiral galaxy NGC 6744 from NASA’s WISE (Wide-field Infrared Survey Explorer) is a mosaic of frames covering an ar...</Credits>
@@ -100352,6 +100372,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-020L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-020"
     Xcxstatus="in:649e45c21e6961df10c19543"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This image from NASA’s Wide-field Infrared Survey Explorer (WISE) features comet 65P/Gunn. Comets are balls of dust and ice left...</Credits>
@@ -100378,6 +100399,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-021L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-021"
     Xcxstatus="in:649e45c01e6961df10c1953f"
   >
     <Credits>NASA/JPL-Caltech/UCLA; Some might see a blood-red jellyfish in a forest of seaweed, while others might see a big, red eye or a pair of lips. In fact, t...</Credits>
@@ -100404,6 +100426,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-022L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-022"
     Xcxstatus="in:649e45ce1e6961df10c19560"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This image from the Wide-field Infrared Survey Explorer (WISE) is of the nearby galaxy Messier 83, or M83 for short. It is a spi...</Credits>
@@ -100430,6 +100453,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-023L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-023"
     Xcxstatus="in:649e45dc1e6961df10c19580"
   >
     <Credits>NASA/JPL-Caltech/UCLA; Sending chills down the spine of all arachnophobes is the Tarantula Nebula in this image from NASA's Wide-field Infrared Survey ...</Credits>
@@ -100456,6 +100480,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-024L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-024"
     Xcxstatus="in:649e45df1e6961df10c19588"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This image from NASA's Wide-field Infrared Survey Explorer (WISE) takes in several interesting objects in the constellation Cass...</Credits>
@@ -100482,6 +100507,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-025L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-025"
     Xcxstatus="in:649e45ea1e6961df10c195a2"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This image shows the famous Pleiades cluster of stars as seen through the eyes of WISE, or NASA's Wide-field Infrared Survey Exp...</Credits>
@@ -100508,6 +100534,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-026L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-026"
     Xcxstatus="in:649e45e91e6961df10c195a0"
   >
     <Credits>NASA/JPL-Caltech/UCLA; New stars are forming inside this giant cloud of dust and gas as seen in infrared light by NASA’s Wide-field Infrared Survey Exp...</Credits>
@@ -100534,6 +100561,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-027L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-027"
     Xcxstatus="in:649e45cf1e6961df10c19561"
   >
     <Credits>NASA/JPL-Caltech/UCLA; The Wide-field Infrared Survey Explorer, or WISE, has seen a cluster of newborn stars enclosed in a cocoon of dust and gas in th...</Credits>
@@ -100560,6 +100588,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-028L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-028"
     Xcxstatus="in:649e45e11e6961df10c1958d"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This image captured by NASA’s Wide-field Infrared Survey Explorer (WISE) highlights the Small Magellanic Cloud.  Also known as N...</Credits>
@@ -100586,6 +100615,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-029L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-029"
     Xcxstatus="in:649e45e21e6961df10c1958e"
   >
     <Credits>NASA/JPL-Caltech/UCLA; NASA’s Wide-field Infrared Survey Explorer, or WISE, has captured a favorite observing target of amateur astronomers -- Omega Ce...</Credits>
@@ -100612,6 +100642,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-030L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-030"
     Xcxstatus="in:649e45c31e6961df10c19545"
   >
     <Credits>NASA/JPL-Caltech/UCLA; Unicorns and roses are usually the stuff of fairy tales, but a new cosmic image taken by NASA’s Wide-field Infrared Explorer (WI...</Credits>
@@ -100638,6 +100669,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-032L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-032"
     Xcxstatus="in:649e45e31e6961df10c19592"
   >
     <Credits>NASA/JPL-Caltech/UCLA; Nebulae are enormous clouds of dust and gas occupying the space between the stars. Some have pretty names to match their good lo...</Credits>
@@ -100664,6 +100696,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-033L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-033"
     Xcxstatus="in:649e45d81e6961df10c19576"
   >
     <Credits>NASA/JPL-Caltech/UCLA; Gripped in the claw of the constellation Scorpius, sits the reflection nebula DG 129, a cloud of gas and dust that reflects ligh...</Credits>
@@ -100690,6 +100723,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-034L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-034"
     Xcxstatus="in:649e45d91e6961df10c19579"
   >
     <Credits>NASA/JPL-Caltech/UCLA; NASA’s Wide-field Infrared Survey Explorer, or WISE, captured this image of a hidden star-forming cloud complex of dust and gas ...</Credits>
@@ -100742,6 +100776,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-036BL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-036B"
     Xcxstatus="in:649e45e91e6961df10c1959f"
   >
     <Credits>NASA/JPL-Caltech/UCLA; The Sculptor galaxy is shown in different infrared hues, in this new mosaic from NASA's Wide-field Infrared Survey Explorer, or ...</Credits>
@@ -100768,6 +100803,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-036CL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-036C"
     Xcxstatus="in:649e45c81e6961df10c19551"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This image from NASA's Wide-field Infrared Survey Explorer, or WISE, was taken with the two shortest-wavelength detectors (3.4 a...</Credits>
@@ -100794,6 +100830,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-036DL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-036D"
     Xcxstatus="in:649e45d01e6961df10c19564"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This image of the Sculptor Galaxy from NASA's Wide-field Infrared Survey Explorer, or WISE, reveals the galaxy's emerging young ...</Credits>
@@ -100820,6 +100857,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-036EL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-036E"
     Xcxstatus="in:649e45d11e6961df10c19566"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This image of the Sculptor Galaxy from NASA's Wide-field Infrared Survey Explorer, or WISE, shows the galaxy's active side. Infa...</Credits>
@@ -100846,6 +100884,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-037L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-037"
     Xcxstatus="in:649e45cd1e6961df10c1955c"
   >
     <Credits>NASA/JPL-Caltech/UCLA; The aptly named Cocoon nebula is featured in this image from NASAs Wide-field Infrared Survey Explorer, or WISE. This cloud of d...</Credits>
@@ -100872,6 +100911,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-038L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-038"
     Xcxstatus="in:649e45d81e6961df10c19577"
   >
     <Credits>NASA/JPL-Caltech/UCLA; NASAs Wide-field Infrared Survey Explorer, or WISE, captured this colorful image of the reflection nebula IRAS 12116-6001. This ...</Credits>
@@ -100898,6 +100938,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-039L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-039"
     Xcxstatus="in:649e45c81e6961df10c19552"
   >
     <Credits>NASA/JPL-Caltech/UCLA; The Wide-Field Infrared Survey Explorer, or WISE, has uncovered a striking population of young stellar objects in a complex of d...</Credits>
@@ -100924,6 +100965,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-040L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-040"
     Xcxstatus="in:649e45d31e6961df10c1956b"
   >
     <Credits>NASA/JPL-Caltech/UCLA; That green dot in the middle of this image might look like an emerald amidst glittering diamonds, but it is actually a dim star ...</Credits>
@@ -100976,6 +101018,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-041bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-041,wise|WISE2010-041b"
     Xcxstatus="in:649e45de1e6961df10c19585"
   >
     <Credits>Caltech/Palomar; This visible-light image is from the Digitized Sky Survey, based at the Space Telescope Science Institute in Baltimore, Md. The ...</Credits>
@@ -101002,6 +101045,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-042L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-042"
     Xcxstatus="in:649e45c71e6961df10c1954f"
   >
     <Credits>NASA/JPL-Caltech/UCLA; At a time of year when many people travel long distances to be with their families for the holidays, NASAs Wide-field Infrared S...</Credits>
@@ -101028,6 +101072,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-044L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-044"
     Xcxstatus="in:649e45d31e6961df10c1956c"
   >
     <Credits>Spitzer Space Telescope; This oddly colorful nebula is the supernova remnant IC 443 as seen by NASAs Wide-field Infrared Survey Explorer, or WISE. Also k...</Credits>
@@ -101054,6 +101099,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-045DL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-045D"
     Xcxstatus="in:649e45e41e6961df10c19594"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This galaxy does not have a spiral disk, just a bulge, making it a massive elliptical galaxy. M60 is about 20 percent larger tha...</Credits>
@@ -101080,6 +101126,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-045EL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-045E"
     Xcxstatus="in:649e45d91e6961df10c1957a"
   >
     <Credits>NASA/JPL-Caltech/UCLA; Messier 51, or NGC 5194, is also frequently referred to as the Whirlpool galaxy. The Whirlpool is a "grand design" spiral galaxy...</Credits>
@@ -101106,6 +101153,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-046L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-046"
     Xcxstatus="in:649e45e61e6961df10c19598"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This image from the Wide-field Infrared Survey Explorer, or WISE, is an infrared view of a star forming cloud in our Galaxy call...</Credits>
@@ -101132,6 +101180,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-047L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-047"
     Xcxstatus="in:649e45e71e6961df10c1959a"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This image captured by NASA’s Wide-field Infrared Survey Explorer, or WISE, shows of one of our closest neighboring galaxies, Me...</Credits>
@@ -101158,6 +101207,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-001L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-001"
     Xcxstatus="in:649e45d21e6961df10c19569"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This colorful picture is a mosaic of the Lagoon nebula taken by NASAs Wide-field Infrared Survey Explorer, or WISE. Normally, yo...</Credits>
@@ -101184,6 +101234,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-002L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-002"
     Xcxstatus="in:649e45c51e6961df10c19549"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This image from NASAs Wide-Field Infrared Survey Explorer, or WISE, features two stunning galaxies engaged in an intergalactic d...</Credits>
@@ -101210,6 +101261,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-003L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-003"
     Xcxstatus="in:649e45ca1e6961df10c19555"
   >
     <Credits>NASA/JPL-Caltech/UCLA; The blue star near the center of this image is Zeta Ophiuchi. When seen in visible light it appears as a relatively dim red star...</Credits>
@@ -101236,6 +101288,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-005L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-005"
     Xcxstatus="in:649e45c91e6961df10c19553"
   >
     <Credits>NASA/JPL-Caltech/WISE Team; This image from NASA's Wide-field Infrared Survey Explorer, or WISE, shows four galaxies in the Virgo cluster: Messier 59, Messi...</Credits>
@@ -101262,6 +101315,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-006L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-006"
     Xcxstatus="in:649e45e81e6961df10c1959c"
   >
     <Credits>NASA/JPL-Caltech/UCLA; On the morning of February 1st, 2011, NASAs Wide-field Infrared Survey Explorer, or WISE, took its last snapshot of the sky. Thi...</Credits>
@@ -101288,6 +101342,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-007L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-007"
     Xcxstatus="in:649e45de1e6961df10c19586"
   >
     <Credits>NASA/JPL-Caltech/UCLA; NASA's Wide-field Infrared Survey Explorer, or WISE, captured this colorful image of the nebula BFS 29 surrounding the star CE-C...</Credits>
@@ -101314,6 +101369,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-008L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-008"
     Xcxstatus="in:649e45c21e6961df10c19542"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This large mosaic image from NASAs Wide-field Infrared Survey Explorer, or WISE, features the wreckage of an exploded star, as w...</Credits>
@@ -101340,6 +101396,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-009L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-009"
     Xcxstatus="in:649e45e21e6961df10c1958f"
   >
     <Credits>NASA/JPL-Caltech/UCLA; NASAs Wide-field Infrared Survey Explorer, or WISE, captured this image of a star-forming cloud of dust and gas located in the c...</Credits>
@@ -101366,6 +101423,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-010L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-010"
     Xcxstatus="in:649e45d01e6961df10c19563"
   >
     <Credits>NASA/JPL-Caltech/UCLA; Just as some drivers obey the speed limit while others treat every road as if it were the autobahn, some stars move through spac...</Credits>
@@ -101392,6 +101450,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-011L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-011"
     Xcxstatus="in:649e45d01e6961df10c19565"
   >
     <Credits>NASA/JPL-Caltech/UCLA; Many consider the shamrock to be a symbol of rebirth and life, making it a fitting symbol for St. Patricks Day, which happens to...</Credits>
@@ -101418,6 +101477,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-012L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-012"
     Xcxstatus="in:649e45c31e6961df10c19546"
   >
     <Credits>NASA/JPL-Caltech/UCLA; Theres something special going on in the nearby Circinus galaxy, as revealed by this image from NASA's Wide-field Infrared Surve...</Credits>
@@ -101444,6 +101504,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-013L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-013"
     Xcxstatus="in:649e45dd1e6961df10c19584"
   >
     <Credits>NASA/JPL-Caltech/UCLA; A rich collection of colorful astronomical objects is revealed in this picturesque image of the Rho Ophiuchi cloud complex from ...</Credits>
@@ -101470,6 +101531,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-014L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-014"
     Xcxstatus="in:649e45ce1e6961df10c1955f"
   >
     <Credits>Spitzer Science Center; In the Perseus spiral arm of the Milky Way Galaxy, opposite the galactic center, lies the nebula SH 2-235. As seen in visible li...</Credits>
@@ -101496,6 +101558,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-017L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-017"
     Xcxstatus="in:649e45e51e6961df10c19596"
   >
     <Credits>NASA/JPL-Caltech/UCLA; NASAs Wide-field Infrared Survey Explorer, or WISE, is a little like the Vincent van Gogh of the infrared sky. Just like the fam...</Credits>
@@ -101522,6 +101585,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-018L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-018"
     Xcxstatus="in:649e45cf1e6961df10c19562"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This latest image from NASAs Wide-field Infrared Survey Explorer, or WISE, shows three different nebulae located in the constell...</Credits>
@@ -101548,6 +101612,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-019L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-019"
     Xcxstatus="in:649e45c41e6961df10c19548"
   >
     <Credits>NASA/JPL-Caltech/UCLA; Star clusters such as the Pleiades are often considered some of the most beautiful objects in the sky. Yet in this image taken b...</Credits>
@@ -101574,6 +101639,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-020aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-020a"
     Xcxstatus="in:649e45c31e6961df10c19544"
   >
     <Credits>NASA/JPL-Caltech/UCLA; Known by astronomers as M51, this beauty is a grand design spiral, which are galaxies with well-defined spiral arms. Its smaller...</Credits>
@@ -101600,6 +101666,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-020bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-020b"
     Xcxstatus="in:649e45c91e6961df10c19554"
   >
     <Credits>NASA/JPL-Caltech/UCLA; Some astronomers call the grand design spiral Messier 74 the "perfect spiral," for its exceptional symmetry. It is suspected to ...</Credits>
@@ -101626,6 +101693,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-020cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-020c"
     Xcxstatus="in:649e45da1e6961df10c1957c"
   >
     <Credits>NASA/JPL-Caltech/UCLA; M81 is another grand design spiral galaxy, with pronounced arms spiraling into its core. WISE highlights areas where gas and dus...</Credits>
@@ -101652,6 +101720,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-020dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-020d"
     Xcxstatus="in:649e45eb1e6961df10c195a3"
   >
     <Credits>NASA/JPL-Caltech/UCLA; At about 55,500 light-years across, M83 is s a bit more than half the size of our Milky Way Galaxy, but it has a similar overall...</Credits>
@@ -101678,6 +101747,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-020eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-020e"
     Xcxstatus="in:649e45dc1e6961df10c19581"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This barred spiral has a dense inner ring that surrounds a bright, central core. The ring is actually two spiral arms that are c...</Credits>
@@ -101704,6 +101774,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-020fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-020f"
     Xcxstatus="in:649e45c11e6961df10c19540"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This fuzzy-looking galaxy is a flocculent, or patchy, spiral. It is largely veiled by gas and dust at visible-light wavelengths,...</Credits>
@@ -101730,6 +101801,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-020gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-020g"
     Xcxstatus="in:649e45d61e6961df10c19572"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This galaxy's face is angled about 90 degrees from our view, so it appears edge-on and thin as a splinter, or knife. It was disc...</Credits>
@@ -101756,6 +101828,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-020hL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-020h"
     Xcxstatus="in:649e45df1e6961df10c19587"
   >
     <Credits>NASA/JPL-Caltech/UCLA; Sometimes called the Hidden Galaxy, this spiral beauty is shrouded behind our own galaxy, the Milky Way. Stargazers and professi...</Credits>
@@ -101782,6 +101855,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-020iL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-020i"
     Xcxstatus="in:649e45dd1e6961df10c19583"
   >
     <Credits>NASA/JPL-Caltech/UCLA; Barnard's Galaxy is known as a dwarf for its small size -- it has only about one percent of the mass of the Milky Way. The galax...</Credits>
@@ -101808,6 +101882,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-021L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-021"
     Xcxstatus="in:649e45d51e6961df10c1956f"
   >
     <Credits>NASA/JPL-Caltech/UCLA; NASAs Wide-field Infrared Survey Explorer, or WISE, captured this image of a huge complex of star-forming clouds and stellar clu...</Credits>
@@ -101834,6 +101909,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-022L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-022"
     Xcxstatus="in:649e45e01e6961df10c1958a"
   >
     <Credits>NASA/JPL-Caltech/UCLA; In the same way that dust is blown around by the wind here on Earth, space dust can be blown around by the wind and radiation fr...</Credits>
@@ -101860,6 +101936,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-023L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-023"
     Xcxstatus="in:649e45d71e6961df10c19575"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This image from NASAs Wide-field Infrared Survey Explorer, or WISE, highlights several star-forming regions. There are five dist...</Credits>
@@ -101886,6 +101963,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-024L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-024"
     Xcxstatus="in:649e45db1e6961df10c1957f"
   >
     <Credits>NASA/JPL-Caltech/UCLA; Many people enjoy the summer pastime of imagining pictures in clouds in the sky. The same can be done with clouds in the Univers...</Credits>
@@ -101912,6 +101990,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-025L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-025"
     Xcxstatus="in:649e45eb1e6961df10c195a4"
   >
     <Credits>NASA/JPL-Caltech/UCLA; A large spiral galaxy dominates this view from NASA’s Wide-field Infrared Survey Explorer, or WISE. The galaxy, often called the...</Credits>
@@ -101938,6 +102017,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-026L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-026"
     Xcxstatus="in:649e45e31e6961df10c19591"
   >
     <Credits>NASA/JPL-Caltech/UCLA; Asteroid 2010 TK7 is circled in green, in this single frame taken by NASA's Wide-field Infrared Survey Explorer, or WISE. The ma...</Credits>
@@ -101964,6 +102044,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-027L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-027"
     Xcxstatus="in:649e45c11e6961df10c19541"
   >
     <Credits>NASA/JPL-Caltech/UCLA; Typically if an astronomer wants to look into or through a thick dark cloud in space, they will choose to look in infrared light...</Credits>
@@ -101990,6 +102071,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-028aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-028a"
     Xcxstatus="in:649e45dd1e6961df10c19582"
   >
     <Credits>NASA/JPL-Caltech/B. Williams (NCSU); This image combines data from four different space telescopes to create a multi-wavelength view of all that remains of the oldes...</Credits>
@@ -102016,6 +102098,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-028bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-028b"
     Xcxstatus="in:649e45c41e6961df10c19547"
   >
     <Credits>NASA/JPL-Caltech/B. Williams (NC; This image combines data from four different space telescopes to create a multi-wavelength view of all that remains of the oldes...</Credits>
@@ -102042,6 +102125,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-029L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-029"
     Xcxstatus="in:649e45d21e6961df10c1956a"
   >
     <Credits>NASA/JPL-Caltech/UCLA
@@ -102069,6 +102153,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-030L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-030"
     Xcxstatus="in:649e45cc1e6961df10c1955a"
   >
     <Credits>NASA/JPL-Caltech/UCLA; Between the claws of the dreaded scorpion imagined by the ancient Greeks lies this giant dust cloud, imaged by the Wide-field In...</Credits>
@@ -102095,6 +102180,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-031L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-031"
     Xcxstatus="in:649e45da1e6961df10c1957b"
   >
     <Credits>NASA/JPL-Caltech/UCLA; No, it’s not a gang of intergalactic mobsters from the famous Star Wars movies. Jabbah is the name of the bright star right of c...</Credits>
@@ -102121,6 +102207,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-032L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-032"
     Xcxstatus="in:649e45c51e6961df10c1954b"
   >
     <Credits>NASA/JPL-Caltech/UCLA; About 3,700 years ago, people on Earth would have seen a brand-new bright star in the sky. As it slowly dimmed out of sight, it ...</Credits>
@@ -102147,6 +102234,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-033L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-033"
     Xcxstatus="in:649e45ca1e6961df10c19556"
   >
     <Credits>NASA/JPL-Caltech/UCLA; In keeping with the spirit of the holidays, NASA’s Wide-field Infrared Survey Explorer (WISE) mission presents the “Wreath Nebul...</Credits>
@@ -102173,6 +102261,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-033bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-033b"
     Xcxstatus="in:649e45c71e6961df10c1954e"
   >
     <Credits>NASA/JPL-Caltech/UCLA; In keeping with the spirit of the holidays, NASA’s Wide-field Infrared Survey Explorer (WISE) mission presents the “Wreath Nebul...</Credits>
@@ -102199,6 +102288,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-ydwarf-b1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-ydwarf-b1"
     Xcxstatus="in:649e45cd1e6961df10c1955d"
   >
     <Credits>NASA/JPL-Caltech/UCLA; NASA's Wide-field Infrared Survey Explorer, or WISE, has uncovered the coldest brown dwarf known so far (green dot in very cente...</Credits>
@@ -102225,6 +102315,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2011-ydwarf-b2L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2011-ydwarf-b2"
     Xcxstatus="in:649e45db1e6961df10c1957e"
   >
     <Credits>NASA/JPL-Caltech/UCLA; NASA's Wide-field Infrared Survey Explorer, or WISE, has uncovered the coldest brown dwarf known so far (green dot in very cente...</Credits>
@@ -102251,6 +102342,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2012-001L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2012-001"
     Xcxstatus="in:649e45d41e6961df10c1956e"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This enormous section of the Milky Way Galaxy is a mosaic of images from NASA’s Wide-field Infrared Survey Explorer, or WISE. Th...</Credits>
@@ -102277,6 +102369,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2012-002L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2012-002"
     Xcxstatus="in:649e45e41e6961df10c19593"
   >
     <Credits>NASA/JPL-Caltech/UCLA; Over 11,000 years ago, a massive, supergiant star in our Galaxy came to the end of its life. The star’s core collapsed to form a...</Credits>
@@ -102303,6 +102396,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2012-003L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2012-003"
     Xcxstatus="in:649e45d11e6961df10c19567"
   >
     <Credits>NASA/JPL-Caltech/UCLA; It's a dust bunny of cosmic proportions. Astronomers used images from NASA's Wide-field Infrared Survey Explorer, or WISE, to lo...</Credits>
@@ -102329,6 +102423,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2012-004L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2012-004"
     Xcxstatus="in:649e45cc1e6961df10c1955b"
   >
     <Credits>NASA/JPL-Caltech/UCLA; The Flame Nebula sits on the eastern hip of Orion the Hunter, a constellation most easily visible in the northern hemisphere dur...</Credits>
@@ -102355,6 +102450,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2013-001L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2013-001"
     Xcxstatus="in:649e45e51e6961df10c19595"
   >
     <Credits>NASA/JPL-Caltech/UCLA; The Great Nebula in Orion is featured in this sweeping image from NASA’s Wide-field Infrared Survey Explorer, or WISE. The const...</Credits>
@@ -102381,6 +102477,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2013-002L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2013-002"
     Xcxstatus="in:649e45c51e6961df10c1954a"
   >
     <Credits>NASA/JPL-Caltech; This image shows the potentially hazardous near-Earth object 1998 KN3 as it zips past a cloud of dense gas and dust near the Ori...</Credits>
@@ -102407,6 +102504,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2013-003L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2013-003"
     Xcxstatus="in:649e45d51e6961df10c19570"
   >
     <Credits>NASA/JPL-Caltech/UCLA; A witch appears to be screaming out into space in this new image from NASA's Wide-Field Infrared Survey Explorer, or WISE. The i...</Credits>

--- a/imagesets/sky__visible.xml
+++ b/imagesets/sky__visible.xml
@@ -91605,6 +91605,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig05-001aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig05-001a"
     Xcxstatus="in:64b74498a15b29de42b305cd"
   >
     <Credits>NASA/JPL-Caltech/E. Churchwell (; RCW 79 is seen in the southern Milky Way, 17,200 light-years from Earth in the constellation Centaurus. The bubble is 70-light y...</Credits>
@@ -91631,6 +91632,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig05-002aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig05-002a"
     Xcxstatus="in:64bb0fd9d87c275bcc5875ad"
   >
     <Credits>NASA/JPL-Caltech/M.L.N. Ashby (H; The spiral galaxy NGC 5907, sometimes known as the "Splinter Galaxy" because of its unusual appearance, is located in the conste...</Credits>
@@ -91657,6 +91659,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig05-006aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig05-006a"
     Xcxstatus="in:64b7448ca15b29de42b305b3"
   >
     <Credits>NASA/JPL-Caltech/B. J. Smith (Ea; NASA's Spitzer Space Telescope's sensitive infrared detectors map out faint regions of new star formation in this pair of collid...</Credits>
@@ -91683,6 +91686,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig05-011L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig05-011"
     Xcxstatus="in:64b74784a15b29de42b30689"
   >
     <Credits> NASA/JPL-Caltech/R. Kennicutt (; On August 25, 2003, NASA's Spitzer Space Telescope blasted into the same dark skies it now better understands. In just two years...</Credits>
@@ -91709,6 +91713,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig05-013L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig05-013"
     Xcxstatus="in:64b741f3a15b29de42b304a5"
   >
     <Credits>NASA/JPL-Caltech/R. Kennicutt (U; This beautiful spiral galaxy NGC 1566, located approximately 60 million light-years away in the constellation Dorado was capture...</Credits>
@@ -91735,6 +91740,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig05-014L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig05-014"
     Xcxstatus="in:64b74308a15b29de42b3051f"
   >
     <Credits>NASA/JPL-Caltech/R. Kennicutt (U; The nearby galaxy NGC 2976, located approximately 10 million light-years away in the constellation Ursa Major near the Big Dippe...</Credits>
@@ -91761,6 +91767,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig05-015L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig05-015"
     Xcxstatus="in:64b7448da15b29de42b305b5"
   >
     <Credits> NASA/JPL-Caltech/R. Kennicutt (; This image of galaxy NGC 3351, located approximately 30 million light-years away in the constellation Leo was captured by the Sp...</Credits>
@@ -91787,6 +91794,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig05-016L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig05-016"
     Xcxstatus="in:64b744c7a15b29de42b30633"
   >
     <Credits>NASA/JPL-Caltech/R. Kennicutt (U; This image of spiral galaxy NGC 3627, also known as Messier 66, was captured by the Spitzer Infrared Nearby Galaxy Survey (SINGS...</Credits>
@@ -91813,6 +91821,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig05-017L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig05-017"
     Xcxstatus="in:6544ee2a5dff7c3291e399bd"
   >
     <Credits> NASA/JPL-Caltech/R. Kennicutt (; Galaxy NGC 7793, located approximately 10 million light-years away, is a member of the Sculptor group of galaxies. This galaxy c...</Credits>
@@ -91839,6 +91848,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig05-019bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig05-019b"
     Xcxstatus="in:64b744d0a15b29de42b30647"
   >
     <Credits>NASA/JPL-Caltech/C. Lonsdale (Ca; This spectacular infrared image of the "Tadpole" galaxy, taken by the Spitzer Wide-area Infrared Extragalactic (SWIRE) Legacy pr...</Credits>
@@ -91865,6 +91875,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig05-021L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig05-021"
     Xcxstatus="in:64b74499a15b29de42b305cf"
   >
     <Credits>NASA/JPL-Caltech/S. J. U. Higdon; This infrared image from NASA's Spitzer Space Telescope shows little "dwarf galaxies" forming in the "tails" of two larger galax...</Credits>
@@ -91891,6 +91902,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig05-028aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig05-028a"
     Xcxstatus="in:64b742f9a15b29de42b304fd"
   >
     <Credits>NASA/JPL-Caltech/P.S. Teixeira (; Newborn stars, hidden behind thick dust, are revealed in this image of a section of the Christmas Tree Cluster from NASA's Spitz...</Credits>
@@ -91917,6 +91929,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig05-028bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig05-028b"
     Xcxstatus="in:64b742faa15b29de42b304ff"
   >
     <Credits>NASA/JPL-Caltech/P.S. Teixeira (; Newborn stars, hidden behind thick dust, are revealed in this image of a section of the Christmas Tree Cluster from NASA's Spitz...</Credits>
@@ -91943,6 +91956,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig05-028cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig05-028c"
     Xcxstatus="in:64b742fba15b29de42b30501"
   >
     <Credits>NASA/JPL-Caltech/P.S. Teixeira (; Newborn stars, hidden behind thick dust, are revealed in this image of a section of the Christmas Tree Cluster from NASA's Spitz...</Credits>
@@ -91969,6 +91983,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig06-002aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig06-002a"
     Xcxstatus="in:64b744c8a15b29de42b30635"
   >
     <Credits> NASA/JPL-Caltech/J. Bally (Univ; This "tornado," designated Herbig-Haro 49/50, is shaped by a cosmic jet packing a powerful punch as it plows through clouds of i...</Credits>
@@ -91995,6 +92010,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig06-003L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig06-003"
     Xcxstatus="in:64b74785a15b29de42b3068b"
   >
     <Credits>NASA/JPL-Caltech/R. Kennicutt (U; Galaxy NGC 4579 was captured by the Spitzer Infrared Nearby Galaxy Survey (SINGS) Legacy Project using the Spitzer Space Telesco...</Credits>
@@ -92021,6 +92037,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig06-004L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig06-004"
     Xcxstatus="in:64bb0fddd87c275bcc5875b7"
   >
     <Credits>NASA/JPL-Caltech/M. Morris (UCLA; The double helix nebula. The spots are infrared-luminous stars, mostly red giants and red supergiants. Many other stars are pres...</Credits>
@@ -92047,6 +92064,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig06-005L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig06-005"
     Xcxstatus="in:64b744b9a15b29de42b30615"
   >
     <Credits>NASA/JPL-Caltech/P. N. Appleton ; This multi-wavelength composite image shows the Cartwheel galaxy as seen by the Galaxy Evolution Explorer's Far Ultraviolet dete...</Credits>
@@ -92073,6 +92091,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig06-010L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig06-010"
     Xcxstatus="in:64b74309a15b29de42b30521"
   >
     <Credits>NASA/JPL-Caltech/STScI/CXC/UofA/; NASA's Spitzer, Hubble, and Chandra space observatories teamed up to create this multi-wavelength view of the M82 galaxy. The li...</Credits>
@@ -92125,6 +92144,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig06-012cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig06-012c"
     Xcxstatus="in:6544ee2c5dff7c3291e399c1"
   >
     <Credits>NASA/JPL-Caltech/P. Morris (NHSC; For the universe's biggest stars, even death is a show. Massive stars typically end their lives in explosive cataclysms, or supe...</Credits>
@@ -92151,6 +92171,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig06-013L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig06-013"
     Xcxstatus="in:64b741faa15b29de42b304b5"
   >
     <Credits>NASA/JPL-Caltech/L. Rebull (SSC/; Eight hundred light-years away in the Orion constellation, a gigantic murky cloud called the "Witch Head Nebula" is teeming with...</Credits>
@@ -92203,6 +92224,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig06-016aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig06-016a"
     Xcxstatus="in:64b74480a15b29de42b30599"
   >
     <Credits>NASA/JPL-Caltech/S. Stanimirovic; The supernova remnant 1E0102.2-7219 sits next to the nebula N76 in a bright, star-forming region of the Small Magellanic Cloud, ...</Credits>
@@ -92255,6 +92277,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig06-018cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig06-018c"
     Xcxstatus="in:64b74482a15b29de42b3059d"
   >
     <Credits>NASA/JPL-Caltech/B.E.K. Sugerman; Astronomers using NASA's Spitzer Space Telescope have created this infrared image of the spiral galaxy  M74, as seen by Spitzer'...</Credits>
@@ -92281,6 +92304,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig06-020aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig06-020a"
     Xcxstatus="in:64b741fca15b29de42b304b9"
   >
     <Credits>NASA/JPL-Caltech/L.Rebull (SSC/C; Eight hundred light-years away in the Orion constellation, a gigantic murky cloud called the "Witch Head" nebula is brewing baby...</Credits>
@@ -92307,6 +92331,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig06-021aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig06-021a"
     Xcxstatus="in:6544ee2c5dff7c3291e399c3"
   >
     <Credits>NASA/JPL-Caltech/S. Carey and J.; This image from NASA's Spitzer Space Telescope reveals the complex life cycle of young stars, from their dust-shrouded beginning...</Credits>
@@ -92333,6 +92358,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig06-024L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig06-024"
     Xcxstatus="in:64b744baa15b29de42b30617"
   >
     <Credits>NASA/JPL-Caltech/K. Gordon (Univ; The many "personalities" of our great galactic neighbor, the Andromeda galaxy, are exposed in this new composite image from NASA...</Credits>
@@ -92385,6 +92411,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig06-025aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig06-025a"
     Xcxstatus="in:64b744bca15b29de42b3061b"
   >
     <Credits>NASA/JPL-Caltech/D. Block (Anglo; Astronomers have new evidence that the Andromeda spiral galaxy was involved in a violent head-on collision with the neighboring ...</Credits>
@@ -92411,6 +92438,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig06-026L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig06-026"
     Xcxstatus="in:64b74326a15b29de42b3055f"
   >
     <Credits>NASA/JPL-Caltech/L. Cieza (UT Au; Infant stars are glowing gloriously in this infrared image of the Serpens star-forming region, captured by NASA's Spitzer Space ...</Credits>
@@ -92437,6 +92465,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig06-027L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig06-027"
     Xcxstatus="in:64b744daa15b29de42b3065d"
   >
     <Credits>NASA/JPL-Caltech/L. Cieza (UT Au; Baby stars are forming near the eastern rim of the cosmic cloud Perseus, in this infrared image from NASA's Spitzer Space Telesc...</Credits>
@@ -92463,6 +92492,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig06-028L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig06-028"
     Xcxstatus="in:64b741fda15b29de42b304bb"
   >
     <Credits>X-Ray: NASA/CXC/J.Hester (ASU); ; According to the folklore of the Celts and other ancient cultures, Halloween marked the midpoint between the autumnal equinox an...</Credits>
@@ -92489,6 +92519,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig07-002L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig07-002"
     Xcxstatus="in:64b74303a15b29de42b30513"
   >
     <Credits>NASA/JPL-Caltech/M. Hancock (E. ; A pair of interacting galaxies might be experiencing the galactic equivalent of a mid-life crisis. For some reason, the pair, ca...</Credits>
@@ -92541,6 +92572,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig07-005bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig07-005b"
     Xcxstatus="in:64b749c1a15b29de42b30692"
   >
     <Credits>NASA/JPL-Caltech/T. Bourke (Harv; Two rambunctious young stars are destroying their natal dust cloud with powerful jets of radiation, as revealed in an infrared i...</Credits>
@@ -92567,6 +92599,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig07-006L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig07-006"
     Xcxstatus="in:64b741fea15b29de42b304bd"
   >
     <Credits>ASA/JPL-Caltech/D. Barrado y Nav; This image from NASA's Spitzer Space Telescope shows infant stars "hatching" in the head of the hunter constellation, Orion. Ast...</Credits>
@@ -92593,6 +92626,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig07-007L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig07-007"
     Xcxstatus="in:64b741ffa15b29de42b304bf"
   >
     <Credits>ASA/JPL-Caltech/D. Barrado y Nav; This image from NASA's Spitzer Space Telescope shows infant stars "hatching" in the head of the hunter constellation, Orion. Ast...</Credits>
@@ -92619,6 +92653,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig07-010L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig07-010"
     Xcxstatus="in:64b74200a15b29de42b304c1"
   >
     <Credits>NASA/JPL-Caltech/A. Tappe and J.; Supernovae are the explosive deaths of the universe's most massive stars. In death, these volatile creatures blast tons of energ...</Credits>
@@ -92645,6 +92680,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig07-016L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig07-016"
     Xcxstatus="in:6544ee2d5dff7c3291e399c5"
   >
     <Credits>NASA/JPL-Caltech/ J. Hora (Harva; A newly expanded image of the Helix nebula lends a festive touch to the fourth anniversary of the launch of NASA's Spitzer Space...</Credits>
@@ -92671,6 +92707,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig07-017L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig07-017"
     Xcxstatus="in:64bb0fe9d87c275bcc5875c7"
   >
     <Credits>NASA/CXC/J. Forbrich (CfA), NASA; While perhaps not quite as well known as its star-formation cousin Orion, the Corona Australis region (containing, at its heart,...</Credits>
@@ -92697,6 +92734,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig07-018L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig07-018"
     Xcxstatus="in:64bb0fead87c275bcc5875c9"
   >
     <Credits>NASA/JPL-Caltech/L. Allen (CfA) ; While perhaps not quite as well known as its star formation cousin of Orion, the Corona Australis region (containing, at its hea...</Credits>
@@ -92723,6 +92761,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig07-022L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig07-022"
     Xcxstatus="in:64b74304a15b29de42b30515"
   >
     <Credits>NASA/JPL-Caltech/T. Velusamy (Je; A new image from NASA's Spitzer Space Telescope shows a baby star 1,140 light-years away from Earth blowing two massive "bubbles...</Credits>
@@ -92749,6 +92788,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig08-008L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig08-008"
     Xcxstatus="in:64b744aaa15b29de42b305f3"
   >
     <Credits>NASA/JPL-Caltech/R. Kennicutt (U; NGC 6946, or "The Fireworks Galaxy", is one of about a dozen nearby neighbors to the Milky Way. It is located approximately 10 m...</Credits>
@@ -92801,6 +92841,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig08-018L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig08-018"
     Xcxstatus="in:64b7448ea15b29de42b305b7"
   >
     <Credits>NASA/JPL-Caltech/E. Churchwell (; This image of prolific star-forming region RCW 49 exposes breathtaking detail of this dark and dusty region, which is home to mo...</Credits>
@@ -92827,6 +92868,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig09-001L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig09-001"
     Xcxstatus="in:64bb0fded87c275bcc5875b9"
   >
     <Credits>NASA/JPL-Caltech/J. Hora (Harvar; The "Cat's Eye" nebula, or NGC 6543, is a well-studied example of a "planetary nebula." Such objects are the glowing remnants of...</Credits>
@@ -92853,6 +92895,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig09-003L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig09-003"
     Xcxstatus="in:64b74482a15b29de42b3059f"
   >
     <Credits>NASA/JPL-Caltech; This image is a blend of the Galaxy Evolution Explorer's M33 image and another taken by NASA's Spitzer Space Telescope. M33, one...</Credits>
@@ -92879,6 +92922,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig09-004L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig09-004"
     Xcxstatus="in:64b74483a15b29de42b305a1"
   >
     <Credits>NASA/JPL-Caltech; This image is a blend of the Galaxy Evolution Explorer's M33 image and another taken by NASA's Spitzer Space Telescope. M33, one...</Credits>
@@ -92905,6 +92949,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig09-006L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig09-006"
     Xcxstatus="in:64b7430aa15b29de42b30523"
   >
     <Credits>NASA/JPL-Caltech; This latest image from NASA's Spitzer Space Telescope is of the spiral galaxy, NGC 2841. Located about 46 million light-years fr...</Credits>
@@ -92931,6 +92976,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-003L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-003"
     Xcxstatus="in:64b74201a15b29de42b304c3"
   >
     <Credits>NASA/JPL-Caltech/J. Stauffer (SS; A colony of hot, young stars is stirring up the cosmic scene in this new picture from NASA's Spitzer Space Telescope. The image ...</Credits>
@@ -92957,6 +93003,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-004L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-004"
     Xcxstatus="in:64b74203a15b29de42b304c5"
   >
     <Credits>NASA/JPL-Caltech/J. Stauffer (SS; A colony of hot, young stars is stirring up the cosmic scene in this new picture from NASA's Spitzer Space Telescope. The image ...</Credits>
@@ -92983,6 +93030,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-005L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-005"
     Xcxstatus="in:64b733e7a15b29de42b3047c"
   >
     <Credits>NASA/JPL-Caltech/Subaru/C. Papov; A surprisingly large collections of galaxies (red dots) stands out at a remarkably large distance in this composite image combin...</Credits>
@@ -93009,6 +93057,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-006aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-006a"
     Xcxstatus="in:64b744dca15b29de42b30661"
   >
     <Credits>NASA/JPL-Caltech/J. Tobin (Unive; A young protostar and its signature outflow peeks out through a shroud of dust in this infrared image from NASA's Spitzer Space ...</Credits>
@@ -93035,6 +93084,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-006bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-006b"
     Xcxstatus="in:64bb0ff1d87c275bcc5875d9"
   >
     <Credits>NASA/JPL-Caltech/J. Tobin (Unive; A young protostar and its signature outflow peeks out through a shroud of dust in this infrared image from NASA's Spitzer Space ...</Credits>
@@ -93061,6 +93111,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-006cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-006c"
     Xcxstatus="in:64b744d1a15b29de42b30649"
   >
     <Credits>NASA/JPL-Caltech/J. Tobin (Unive; A young protostar and its signature outflow peeks out through a shroud of dust in this infrared image from NASA's Spitzer Space ...</Credits>
@@ -93087,6 +93138,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-006dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-006d"
     Xcxstatus="in:64b744aba15b29de42b305f5"
   >
     <Credits>NASA/JPL-Caltech/J. Tobin (Unive; A young protostar and its signature outflow peeks out through a shroud of dust in this infrared image from NASA's Spitzer Space ...</Credits>
@@ -93113,6 +93165,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-006eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-006e"
     Xcxstatus="in:64b74327a15b29de42b30561"
   >
     <Credits>NASA/JPL-Caltech/J. Tobin (Unive; A young protostar and its signature outflow peeks out through a shroud of dust in this infrared image from NASA's Spitzer Space ...</Credits>
@@ -93139,6 +93192,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-006fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-006f"
     Xcxstatus="in:64b74204a15b29de42b304c7"
   >
     <Credits>NASA/JPL-Caltech/J. Tobin (Unive; A young protostar and its signature outflow peeks out through a shroud of dust in this infrared image from NASA's Spitzer Space ...</Credits>
@@ -93165,6 +93219,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-007L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-007"
     Xcxstatus="in:64b74319a15b29de42b30543"
   >
     <Credits>NASA/JPL-Caltech/P. Eisenhardt (; This image shows what astronomers think is one of the coldest brown dwarfs discovered so far (red dot in middle of frame). The o...</Credits>
@@ -93191,6 +93246,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-009aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-009a"
     Xcxstatus="in:64b74329a15b29de42b30563"
   >
     <Credits>NASA/JPL-Caltech/M. Povich (Penn; A dragon-shaped cloud of dust seems to fly out from a bright explosion in this infrared light image from the Spitzer Space Teles...</Credits>
@@ -93217,6 +93273,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-010aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-010a"
     Xcxstatus="in:64b7432aa15b29de42b30565"
   >
     <Credits>NASA/JPL-Caltech/; This visible-light view of the sky highlights the bright M17 nebula, as well as the glowing hot gas filling the "bubble" to its ...</Credits>
@@ -93243,6 +93300,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-013L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-013"
     Xcxstatus="in:64b744dca15b29de42b30663"
   >
     <Credits>NASA/JPL-Caltech/2MASS/B. Whitne; Two extremely bright stars illuminate a greenish mist in this and other images from the new GLIMPSE360 survey. This fog is compr...</Credits>
@@ -93269,6 +93327,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-014L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-014"
     Xcxstatus="in:64bb0ff2d87c275bcc5875db"
   >
     <Credits>NASA/JPL-Caltech/2MASS/B. Whitne; This image shows an outflow of gas from a new star as it jets from a space object dubbed IRAS 21078+5211, among other designatio...</Credits>
@@ -93295,6 +93354,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-015L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-015"
     Xcxstatus="in:6544ef745dff7c3291e399cd"
   >
     <Credits>NASA/JPL-Caltech/2MASS/B. Whitne; A star forming region called BG2107+49 shines from the considerable distance of more than 30,000 light years away in the upper l...</Credits>
@@ -93321,6 +93381,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-016L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-016"
     Xcxstatus="in:6544ee2e5dff7c3291e399c7"
   >
     <Credits>NASA/JPL-Caltech/2MASS/B. Whitne; This wispy, vast structure in the constellation Cygnus has a small bubble right in its center puffed out by the spasms of fresh-...</Credits>
@@ -93347,6 +93408,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-017L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-017"
     Xcxstatus="in:64b749c2a15b29de42b30694"
   >
     <Credits>NASA/CXC/SAO/JPL-Caltech/STScI; A new image of two tangled galaxies has been released by NASA's Great Observatories. The Antennae galaxies, located about 62 mil...</Credits>
@@ -93373,6 +93435,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-018aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-018a"
     Xcxstatus="in:64b73c10a15b29de42b3047f"
   >
     <Credits>NASA/JPL-Caltech/K. Tran (Texas ; Astronomers have found that stars are forming more rapidly in the center of a distant galaxy cluster than at its edges, which is...</Credits>
@@ -93399,6 +93462,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-020aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-020a"
     Xcxstatus="in:64bb0fdad87c275bcc5875af"
   >
     <Credits>NASA/JPL-Caltech/L. Pagani (Obse; This series of images from NASA's Spitzer Space Telescope shows a dark mass of gas and dust, called a core, where new stars and ...</Credits>
@@ -93425,6 +93489,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-020bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-020b"
     Xcxstatus="in:64bb0fdbd87c275bcc5875b1"
   >
     <Credits>NASA/JPL-Caltech/L. Pagani (Obse; This series of images from NASA's Spitzer Space Telescope shows a dark mass of gas and dust, called a core, where new stars and ...</Credits>
@@ -93451,6 +93516,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-020cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-020c"
     Xcxstatus="in:64bb0fdcd87c275bcc5875b3"
   >
     <Credits>NASA/JPL-Caltech/L. Pagani (Obse; This series of images from NASA's Spitzer Space Telescope shows a dark mass of gas and dust, called a core, where new stars and ...</Credits>
@@ -93477,6 +93543,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-023aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-023a"
     Xcxstatus="in:64b744aba15b29de42b305f7"
   >
     <Credits>NASA/JPL-Caltech/H. Inami (SSC/C; AA brilliant burst of star formation is revealed in this image combining observations from NASA's Spitzer and Hubble Space Teles...</Credits>
@@ -93503,6 +93570,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-023bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-023b"
     Xcxstatus="in:64b744aca15b29de42b305f9"
   >
     <Credits>NASA/JPL-Caltech/H. Inami (SSC/C; The merging galaxies known collectively as II Zw 096 are shown in this image from NASA's Hubble Space Telescope. This rendering ...</Credits>
@@ -93529,6 +93597,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig10-025L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig10-025"
     Xcxstatus="in:64b74012a15b29de42b3048e"
   >
     <Credits>NASA/JPL-Caltech/J. Turner (UCLA; Maffei 2 is the poster child for an infrared galaxy that is almost invisible to optical telescopes. Foreground dust clouds in th...</Credits>
@@ -93555,6 +93624,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig11-001L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig11-001"
     Xcxstatus="in:64b7449aa15b29de42b305d1"
   >
     <Credits>NASA/JPL-Caltech/SINGS Team; The various spiral arm segments of the Sunflower galaxy, also known as Messier 63, show up vividly in this image taken in infrar...</Credits>
@@ -93581,6 +93651,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig11-002L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig11-002"
     Xcxstatus="in:64b7449ba15b29de42b305d3"
   >
     <Credits>NASA/JPL-Caltech/SINGS Team; The various spiral arm segments of the Sunflower galaxy, also known as Messier 63, show up vividly in this image taken in infrar...</Credits>
@@ -93607,6 +93678,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig11-003L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig11-003"
     Xcxstatus="in:64bb0fdfd87c275bcc5875bb"
   >
     <Credits>NASA/JPL-Caltech; The region around the center of our Milky Way galaxy glows colorfully in this new version of an image taken by NASA's Spitzer Sp...</Credits>
@@ -93633,6 +93705,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig11-005aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig11-005a"
     Xcxstatus="in:64b74484a15b29de42b305a3"
   >
     <Credits>NASA/JPL-Caltech/L. Lanz (Harvar; This image shows an example of colliding galaxies from a new photo atlas of galactic "train wrecks". The new image combine obser...</Credits>
@@ -93659,6 +93732,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig11-005bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig11-005b"
     Xcxstatus="in:64b7448fa15b29de42b305b9"
   >
     <Credits>NASA/JPL-Caltech/L. Lanz (Harvar; This image shows an example of colliding galaxies from a new photo atlas of galactic "train wrecks". The new image combine obser...</Credits>
@@ -93685,6 +93759,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig11-005cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig11-005c"
     Xcxstatus="in:64b74099a15b29de42b30493"
   >
     <Credits>NASA/JPL-Caltech/L. Lanz (Harvar; This image shows an example of colliding galaxies from a new photo atlas of galactic "train wrecks." The new image combine obser...</Credits>
@@ -93711,6 +93786,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig11-006L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig11-006"
     Xcxstatus="in:64b74490a15b29de42b305bb"
   >
     <Credits>NASA/JPL-Caltech/M. Povich (STSc; Eta Carinae is one of the most massive and brightest stars in the Milky Way. Compared to our own Sun, it is about 100 times as m...</Credits>
@@ -93737,6 +93813,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig11-007aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig11-007a"
     Xcxstatus="in:64bb0fe0d87c275bcc5875bd"
   >
     <Credits>NASA/JPL-Caltech/GLIMPSE-MIPSGAL; This glowing emerald nebula seen by NASA's Spitzer Space Telescope has been sculpted by the powerful light of giant "O" stars. O...</Credits>
@@ -93763,6 +93840,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig11-008L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig11-008"
     Xcxstatus="in:64b74205a15b29de42b304c9"
   >
     <Credits>NASA/JPL-Caltech; Looking like a pair of eyeglasses only a rock star would wear, this nebula brings into focus a murky region of star formation. N...</Credits>
@@ -93789,6 +93867,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig11-009L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig11-009"
     Xcxstatus="in:64b744dda15b29de42b30665"
   >
     <Credits>NASA/JPL-Caltech/J. Turner (UCLA; Looking like a spiders web swirled into a spiral, the galaxy IC 342 presents its delicate pattern of dust in this image from NAS...</Credits>
@@ -93815,6 +93894,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig11-010L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig11-010"
     Xcxstatus="in:64b744dfa15b29de42b30667"
   >
     <Credits>NASA/JPL-Caltech/J. Turner (UCLA; Looking like a spiders web swirled into a spiral, the galaxy IC 342 presents its delicate pattern of dust in this image from NAS...</Credits>
@@ -93841,6 +93921,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig11-011L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig11-011"
     Xcxstatus="in:64bb0febd87c275bcc5875cb"
   >
     <Credits>NASA/JPL-Caltech/J. Hora (Harvar; The  Dumbbell nebula, also known as Messier 27, pumps out infrared light in this image from NASAs Spitzer Space Telescope. The n...</Credits>
@@ -93867,6 +93948,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig11-012L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig11-012"
     Xcxstatus="in:64b7432aa15b29de42b30567"
   >
     <Credits>NASA/JPL-Caltech; Swirling dust clouds and bright newborn stars dominate the view in this image of the Lagoon nebula from NASAs Spitzer Space Tele...</Credits>
@@ -93893,6 +93975,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig11-016L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig11-016"
     Xcxstatus="in:64b7449ca15b29de42b305d5"
   >
     <Credits>NASA/JPL-Caltech; This spectacular spiral galaxy is known to astronomers as Messier 83. Colloquially, it is also called  the Southern Pinwheel due...</Credits>
@@ -93919,6 +94002,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig11-017L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig11-017"
     Xcxstatus="in:64b7449da15b29de42b305d7"
   >
     <Credits>NASA/JPL-Caltech; This spectacular spiral galaxy is known to astronomers as Messier 83. Colloquially, it is also called  the Southern Pinwheel due...</Credits>
@@ -93945,6 +94029,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig11-019L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig11-019"
     Xcxstatus="in:64b7431aa15b29de42b30545"
   >
     <Credits>NASA/JPL-Caltech/B. Williams (NC; This image combines data from four different space telescopes to create a multi-wavelength view of all that remains of the oldes...</Credits>
@@ -93971,6 +94056,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig11-020L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig11-020"
     Xcxstatus="in:64b7431ba15b29de42b30547"
   >
     <Credits>NASA/JPL-Caltech/B. Williams (NC; Infrared images from NASA's Spitzer Space Telescope and Wide-field Infrared Survey Explorer (WISE) are combined in this image of...</Credits>
@@ -93997,6 +94083,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig12-003L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig12-003"
     Xcxstatus="in:64b7432ba15b29de42b30569"
   >
     <Credits>NASA/JPL-Caltech/Univ. of Wiscon; If astronomy had its own Academy Awards, then this part of the Milky Way would have been the Favorite Nebula pick for 2011. Comp...</Credits>
@@ -94023,6 +94110,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig12-004L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig12-004"
     Xcxstatus="in:64b74207a15b29de42b304cb"
   >
     <Credits>X-ray: NASA/CXC/PSU/L.Townsley e; This composite of 30 Doradus, aka the Tarantula Nebula, contains data from Chandra (blue), Hubble (green), and Spitzer (red).  L...</Credits>
@@ -94049,6 +94137,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig12-005L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig12-005"
     Xcxstatus="in:64b7431ba15b29de42b30549"
   >
     <Credits>NASA, ESA, CXC, JPL, Caltech and; This image of the Pinwheel Galaxy, or M101, combines data in the infrared, visible, ultraviolet and x-rays from four of NASAs sp...</Credits>
@@ -94075,6 +94164,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig12-006aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig12-006a"
     Xcxstatus="in:64b7431da15b29de42b3054b"
   >
     <Credits>NASA/JPL-Caltech; This boxy, almost rectangular structure, known as the Retina Nebula or IC 4406, shows its infrared glow in this image from NASA'...</Credits>
@@ -94101,6 +94191,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig12-006bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig12-006b"
     Xcxstatus="in:64b74300a15b29de42b3050d"
   >
     <Credits>NASA/JPL-Caltech; This ball of glowing gas is known as the Eskimo Nebula, or NGC 2392. It is found in the constellation Gemini and is about 3,000 ...</Credits>
@@ -94127,6 +94218,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig12-007L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig12-007"
     Xcxstatus="in:64b749c3a15b29de42b30696"
   >
     <Credits>NASA/JPL-Caltech; The galaxy Messier 100, or M100, shows its swirling spiral in this infrared image from NASAs Spitzer Space Telescope. The arcing...</Credits>
@@ -94153,6 +94245,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig12-008L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig12-008"
     Xcxstatus="in:64b749c4a15b29de42b30698"
   >
     <Credits>NASA/JPL-Caltech; The galaxy Messier 100, or M100, shows its swirling spiral in this infrared image from NASAs Spitzer Space Telescope. The arcing...</Credits>
@@ -94179,6 +94272,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig12-009L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig12-009"
     Xcxstatus="in:64b74207a15b29de42b304cd"
   >
     <Credits>X-ray: NASA/CXC/U.Mich./S.Oey, I; The star cluster NGC 1929 contains massive stars that produce intense radiation, expel matter at high speeds, and race through t...</Credits>
@@ -94205,6 +94299,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig12-011L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig12-011"
     Xcxstatus="in:6544ee2f5dff7c3291e399c9"
   >
     <Credits> NASA/JPL-Caltech; A dying star is throwing a cosmic tantrum in this combined image from NASA's Spitzer Space Telescope and the Galaxy Evolution Ex...</Credits>
@@ -94231,6 +94326,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig12-012L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig12-012"
     Xcxstatus="in:64b744ada15b29de42b305fb"
   >
     <Credits>X-ray: NASA/CXC/SAO/J.Drake et a; The Milky Way and other galaxies in the universe harbor many young star clusters and associations that each contain hundreds to ...</Credits>
@@ -94257,6 +94353,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig12-014L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig12-014"
     Xcxstatus="in:64b744d2a15b29de42b3064b"
   >
     <Credits>NASA/JPL-Caltech; The giant star Zeta Ophiuchi is having a "shocking" effect on the surrounding dust clouds in this infrared image from NASAs Spit...</Credits>
@@ -94283,6 +94380,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig13-004L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig13-004"
     Xcxstatus="in:64b749c5a15b29de42b3069a"
   >
     <Credits>NASA/JPL-Caltech/SINGS Team; How many rings do you see in this striking new image of the galaxy Messier 94 (NGC 4736) as seen by the infrared eyes of NASA’s ...</Credits>
@@ -94309,6 +94407,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig13-005L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig13-005"
     Xcxstatus="in:6544ee305dff7c3291e399cb"
   >
     <Credits>NASA/JPL-Caltech; This cloud of glowing gas is the Iris nebula, as seen in infrared light by NASA's Spitzer Space Telescope. The main cluster of s...</Credits>
@@ -94335,6 +94434,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig13-013L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig13-013"
     Xcxstatus="in:64b7430ba15b29de42b30525"
   >
     <Credits>NASA/JPL-Caltech/J. Hora (Harvar; The brain-like orb called PMR 1 has been nicknamed the "Exposed Cranium" nebula by Spitzer scientists. This planetary nebula, lo...</Credits>
@@ -94361,6 +94461,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig13-014L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig13-014"
     Xcxstatus="in:64b74491a15b29de42b305bd"
   >
     <Credits>NASA/JPL-Caltech/J. Hora (Harvar; The Ghost of Jupiter, also known as NGC 3242, is located roughly 1,400 light-years away in the constellation Hydra. Spitzer's in...</Credits>
@@ -94387,6 +94488,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig13-015L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig13-015"
     Xcxstatus="in:64b74485a15b29de42b305a5"
   >
     <Credits>NASA/JPL-Caltech/J. Hora (Harvar; This planetary nebula, known as NGC 650 or the Little Dumbbell, is about 2,500 light-years from Earth in the Perseus constellati...</Credits>
@@ -94413,6 +94515,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig13-016L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig13-016"
     Xcxstatus="in:64b74305a15b29de42b30517"
   >
     <Credits>NASA/JPL-Caltech/ALMA; Combined observations from NASA's Spitzer Space Telescope and the newly completed Atacama Large Millimeter/submillimeter Array (...</Credits>
@@ -94439,6 +94542,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig13-017aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig13-017a"
     Xcxstatus="in:64b744d3a15b29de42b3064d"
   >
     <Credits>NASA/JPL-Caltech/NRAO; What might look like a colossal jet shooting away from a galaxy turns out to be an illusion. New data from the National Science ...</Credits>
@@ -94465,6 +94569,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig13-017bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig13-017b"
     Xcxstatus="in:64b744d4a15b29de42b3064f"
   >
     <Credits>Spitzer Space Telescope; The thin edge of a distant spiral galaxy appears in sharp relief in the new image from NASAs Spitzer Space Telescope. Infrared l...</Credits>
@@ -94491,6 +94596,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig13-018L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig13-018"
     Xcxstatus="in:64b7431ea15b29de42b3054d"
   >
     <Credits>NASA/JPL-Caltech/M. Brodwin (UMK; The collection of red dots seen near the center of this image show one of several very distant galaxy clusters discovered by com...</Credits>
@@ -94517,6 +94623,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig14-003L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig14-003"
     Xcxstatus="in:64b744bda15b29de42b3061d"
   >
     <Credits>NASA/JPL-Caltech; Roguish runaway stars can have a big impact on their surroundings as they plunge through the Milky Way galaxy. Their high-speed ...</Credits>
@@ -94569,6 +94676,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig14-004aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig14-004a"
     Xcxstatus="in:64b7430da15b29de42b30529"
   >
     <Credits>NASA/JPL-Caltech; This image shows M82, also known as the "Cigar galaxy," in infrared light, as observed by NASA's Spitzer Space Telescope back in...</Credits>
@@ -94595,6 +94703,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig14-004bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig14-004b"
     Xcxstatus="in:64b7430ea15b29de42b3052b"
   >
     <Credits>NASA/JPL-Caltech; The supernova SN 2014J is seen in this image near its peak brightness in the first week of February 2014. It appears as a faint ...</Credits>
@@ -94621,6 +94730,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig14-006aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig14-006a"
     Xcxstatus="in:64b74301a15b29de42b3050f"
   >
     <Credits>NASA/JPL-Caltech/P. Capak (Calte; The clusters warp space around them, magnifying background galaxies. The cluster in this image, known as J0717, is the grouping ...</Credits>
@@ -94647,6 +94757,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig14-009L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig14-009"
     Xcxstatus="in:64bb0fdcd87c275bcc5875b5"
   >
     <Credits>NASA/JPL-Caltech; When searching for the nicest nebulas in the sky it's nice when your friends help you out. This striking star formation region, ...</Credits>
@@ -94673,6 +94784,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig14-010L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig14-010"
     Xcxstatus="in:64b7432ca15b29de42b3056b"
   >
     <Credits>Spitzer Space Telescope; Astronomers have found cosmic clumps so dark, dense and dusty that they throw the deepest shadows ever recorded. The clumps were...</Credits>
@@ -94699,6 +94811,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig14-010bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig14-010b"
     Xcxstatus="in:64b7446fa15b29de42b30575"
   >
     <Credits>Spitzer Space Telescope; Astronomers have found cosmic clumps so dark, dense and dusty that they throw the deepest shadows ever recorded. The clumps were...</Credits>
@@ -94725,6 +94838,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig14-011L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig14-011"
     Xcxstatus="in:64b74470a15b29de42b30577"
   >
     <Credits>NASA/JPL-Caltech/2MASS; Within the swaddling dust of the Serpens Cloud Core, astronomers are studying one of the youngest collections of stars ever seen...</Credits>
@@ -94751,6 +94865,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig14-012L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig14-012"
     Xcxstatus="in:64b74471a15b29de42b30579"
   >
     <Credits>NASA/JPL-Caltech; Within the swaddling dust of the Serpens Cloud Core, astronomers are studying one of the youngest collections of stars ever seen...</Credits>
@@ -94777,6 +94892,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig14-013L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig14-013"
     Xcxstatus="in:64b74208a15b29de42b304cf"
   >
     <Credits>NASA/JPL-Caltech/Goddard; This infrared image from NASA's Spitzer Space Telescope shows N103B -- all that remains from a supernova that exploded a millenn...</Credits>
@@ -94803,6 +94919,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig14-015aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig14-015a"
     Xcxstatus="in:64b742fca15b29de42b30503"
   >
     <Credits>Spitzer Space Telescope; This image shows two clusters of galaxies colliding with one another, the smaller one being known as the Bullet Cluster. NASA's ...</Credits>
@@ -94829,6 +94946,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig14-015bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig14-015b"
     Xcxstatus="in:64b744c9a15b29de42b30637"
   >
     <Credits>Spitzer Space Telescope; NASA's Spitzer Space Telescope captured this image of the galaxy cluster MACS 1149. The observations took place during the teles...</Credits>
@@ -94855,6 +94973,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig14-020L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig14-020"
     Xcxstatus="in:64b749c6a15b29de42b3069c"
   >
     <Credits>NASA/CXC/JPL-Caltech/STScI/NSF/N; A galaxy about 23 million light-years away is the site of impressive, ongoing, fireworks. Rather than paper, powder, and fire, t...</Credits>
@@ -94881,6 +95000,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig14-022L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig14-022"
     Xcxstatus="in:64b74306a15b29de42b30519"
   >
     <Credits>NASA/ESA/JPL-Caltech/GSFC/IAFE; The destructive results of a mighty supernova explosion reveal themselves in a delicate blend of infrared and X-ray light, as se...</Credits>
@@ -94907,6 +95027,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig14-023L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig14-023"
     Xcxstatus="in:64b74492a15b29de42b305bf"
   >
     <Credits>NASA/JPL-Caltech; Millions of galaxies populate the patch of sky known as the COSMOS field, short for Cosmic Evolution Survey, a portion of which ...</Credits>
@@ -94933,6 +95054,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig14-026L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig14-026"
     Xcxstatus="in:64b744dfa15b29de42b30669"
   >
     <Credits>NASA/JPL-Caltech; A new image from NASA's Spitzer Space Telescope, taken in infrared light, shows where the action is taking place in galaxy NGC 1...</Credits>
@@ -94959,6 +95081,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig14-027L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig14-027"
     Xcxstatus="in:64b744e0a15b29de42b3066b"
   >
     <Credits>NASA/JPL-Caltech; The ghostly structures highlighting the peculiar patterns of orbiting stars in the center of the galaxy NGC 1292 stand out vivid...</Credits>
@@ -94985,6 +95108,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig14-029aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig14-029a"
     Xcxstatus="in:64b74492a15b29de42b305c1"
   >
     <Credits>NASA/CFHT/NRAO/JPL-Caltech/Duc/C; A new feature in the evolution of galaxies has been captured in this image of galactic interactions. The two galaxies seen here ...</Credits>
@@ -95011,6 +95135,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig14-031aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig14-031a"
     Xcxstatus="in:64b74209a15b29de42b304d1"
   >
     <Credits>NASA/JPL-Caltech; The Horsehead is only one small feature in the Orion Molecular Cloud Complex, dominated in the center of this view by the brilli...</Credits>
@@ -95037,6 +95162,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig15-002L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig15-002"
     Xcxstatus="in:64b74472a15b29de42b3057b"
   >
     <Credits>NASA/JPL-Caltech; Volunteers using the web-based Milky Way Project brought star-forming features nicknamed "yellowballs" to the attention of resea...</Credits>
@@ -95063,6 +95189,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig15-012L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig15-012"
     Xcxstatus="in:64b742fca15b29de42b30505"
   >
     <Credits>NASA/JPL-Caltech; Scores of baby stars shrouded by dust are revealed in this infrared image of the star-forming region NGC 2174, as seen by NASAs ...</Credits>
@@ -95089,6 +95216,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig15-013L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig15-013"
     Xcxstatus="in:64b744caa15b29de42b30639"
   >
     <Credits>NASA/JPL-Caltech/Gemini/CARMA; The galaxy cluster called MOO J1142+1527 can be seen here as it existed when light left it 8.5 billion years ago. The red galaxi...</Credits>
@@ -95115,6 +95243,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig16-002L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig16-002"
     Xcxstatus="in:64b744e1a15b29de42b3066d"
   >
     <Credits>NASA/JPL-Caltech/University of W; Bow shocks thought to mark the paths of massive, speeding stars are highlighted in this image from NASA's Spitzer Space Telescop...</Credits>
@@ -95141,6 +95270,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig16-003L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig16-003"
     Xcxstatus="in:656d54fff86417282376492b"
   >
     <Credits>NASA/JPL-Caltech/University of W; Bow shocks thought to mark the paths of massive, speeding stars are highlighted in this image from NASA's Wide-field Infrared Su...</Credits>
@@ -95167,6 +95297,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig16-008L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig16-008"
     Xcxstatus="in:64b7420aa15b29de42b304d3"
   >
     <Credits>NASA/JPL-Caltech; The spider part of "The Spider and the Fly" nebulae, IC 417 abounds in star formation, as seen in this infrared image from NASA'...</Credits>
@@ -95193,6 +95324,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig16-17L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig16-17"
     Xcxstatus="in:64bb0febd87c275bcc5875cd"
   >
     <Credits>NASA/JPL-Caltech; Just in time for the 50th anniversary of the TV series "Star Trek," which first aired September 8th,1966, a new infrared image f...</Credits>
@@ -95219,6 +95351,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-sig16-18L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|sig16-18"
     Xcxstatus="in:64b744bea15b29de42b3061f"
   >
     <Credits>NASA/JPL-Caltech; This image of galaxy cluster Abell 2744, also called Pandora's Cluster, was taken by the Spitzer Space Telescope. The gravity of...</Credits>
@@ -95245,6 +95378,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2003-06a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2003-06a1"
     Xcxstatus="in:656d5500f86417282376492d"
   >
     <Credits>NASA/JPL-Caltech/W. Reach (SSC/C; This NASA Spitzer Space Telescope image reveals a glowing stellar nursery embedded within the Elephant's Trunk Nebula, an elonga...</Credits>
@@ -95271,6 +95405,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2003-06a2L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2003-06a2"
     Xcxstatus="in:656d5501f86417282376492f"
   >
     <Credits>Canada-France-Hawaii Telescope /; This image shows a visible light view of the Elephant's Trunk Nebula, an elongated dark globule within the emission nebula IC 13...</Credits>
@@ -95297,6 +95432,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2003-06b1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2003-06b1"
     Xcxstatus="in:656d5502f864172823764931"
   >
     <Credits>NASA/JPL-Caltech/W. Reach (SSC/C; This NASA Spitzer Space Telescope image reveals a glowing stellar nursery within a dark globule in IC 1396 that is opaque in vis...</Credits>
@@ -95323,6 +95459,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2003-06b2L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2003-06b2"
     Xcxstatus="in:656d5503f864172823764933"
   >
     <Credits>NASA/JPL-Caltech/W. Reach (SSC/C; This NASA Spitzer Space Telescope image reveals a glowing stellar nursery within a dark globule that is opaque in visible light....</Credits>
@@ -95349,6 +95486,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2003-06c1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2003-06c1"
     Xcxstatus="in:64b7430fa15b29de42b3052d"
   >
     <Credits>NASA/JPL-Caltech/S. Willner (Har; The magnificent spiral arms of the nearby galaxy Messier 81 are highlighted in this NASA Spitzer Space Telescope image. Located ...</Credits>
@@ -95375,6 +95513,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2003-06d1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2003-06d1"
     Xcxstatus="in:64b74310a15b29de42b3052f"
   >
     <Credits>NASA/JPL-Caltech/K. Gordon (Univ; The magnificent spiral arms of the nearby galaxy Messier 81 are highlighted in this image from NASA's Spitzer Space Telescope. L...</Credits>
@@ -95401,6 +95540,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2003-06d2L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2003-06d2"
     Xcxstatus="in:64b74311a15b29de42b30531"
   >
     <Credits>N.A. Sharp (NOAO/AURA/NSF) ; This image shows a visible-light view of the nearby galaxy Messier 81 (M81).  Located in the northern constellation of Ursa Majo...</Credits>
@@ -95427,6 +95567,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2003-06d3L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2003-06d3"
     Xcxstatus="in:64b74311a15b29de42b30533"
   >
     <Credits>NASA/JPL-Caltech/K. Gordon (Univ; The magnificent spiral arms of the nearby galaxy Messier 81 are highlighted in this image from NASA's Spitzer Space Telescope. L...</Credits>
@@ -95453,6 +95594,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2003-06d4L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2003-06d4"
     Xcxstatus="in:64b74312a15b29de42b30535"
   >
     <Credits>NASA/JPL-Caltech/K. Gordon (Univ; The magnificent spiral arms of the nearby galaxy Messier 81 are highlighted in this image from NASA's Spitzer Space Telescope. L...</Credits>
@@ -95479,6 +95621,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2003-06d5L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2003-06d5"
     Xcxstatus="in:64b74313a15b29de42b30537"
   >
     <Credits>NASA/JPL-Caltech/K. Gordon (Univ; The nearby spiral galaxy, Messier 81 (M81) is shown in this image from NASA's Spitzer Space Telescope. Located in the northern c...</Credits>
@@ -95505,6 +95648,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2003-06f1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2003-06f1"
     Xcxstatus="in:64b74314a15b29de42b30539"
   >
     <Credits>NASA/JPL-Caltech/A. Noriega-Cres; This image from NASA's Spitzer Space Telescope transforms a dark cloud into a silky translucent veil, revealing the molecular ou...</Credits>
@@ -95531,6 +95675,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2003-06f2L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2003-06f2"
     Xcxstatus="in:64b74315a15b29de42b3053b"
   >
     <Credits>Digitized Sky Survey; Visible light view of a dark cloud (known as a 'Bok globule') which is illuminated by the nearby Gum Nebula. Located at a distan...</Credits>
@@ -95557,6 +95702,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-01a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-01a1"
     Xcxstatus="in:64b742eaa15b29de42b304dd"
   >
     <Credits>NASA/JPL-Caltech/B. Brandl (Corn; NASA's Spitzer Space Telescope has captured in stunning detail the spidery filaments and newborn stars of the Tarantula Nebula, ...</Credits>
@@ -95583,6 +95729,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-02a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-02a1"
     Xcxstatus="in:656d5503f864172823764935"
   >
     <Credits>NASA/JPL-Caltech/T. Megeath (Har; A cluster of newborn stars herald their birth in this interstellar Valentine's Day commemorative picture obtained with NASA's Sp...</Credits>
@@ -95609,6 +95756,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-04a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-04a1"
     Xcxstatus="in:64b742eba15b29de42b304df"
   >
     <Credits>NASA/JPL-Caltech/V. Gorjian(JPL); Within the Large Magellanic Cloud (LMC), a nearby and irregularly-shaped galaxy seen in the Southern Hemisphere, lies a star-for...</Credits>
@@ -95635,6 +95783,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-04a2L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-04a2"
     Xcxstatus="in:64b742eca15b29de42b304e1"
   >
     <Credits>NOAO; This image shows a visible-light view of the emission nebula, Henize 206, which lies within the Large Magellanic Cloud (LMC). Th...</Credits>
@@ -95661,6 +95810,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-04a3L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-04a3"
     Xcxstatus="in:64b742eda15b29de42b304e3"
   >
     <Credits>NASA/JPL-Caltech/V. Gorjian(JPL); Within the Large Magellanic Cloud (LMC), a nearby and irregularly-shaped galaxy seen in the Southern Hemisphere, lies a star-for...</Credits>
@@ -95687,6 +95837,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-04a4L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-04a4"
     Xcxstatus="in:64b742eea15b29de42b304e5"
   >
     <Credits>NASA/JPL-Caltech/V. Gorjian(JPL); Within the Large Magellanic Cloud (LMC), a nearby and irregularly-shaped galaxy seen in the Southern Hemisphere, lies a star-for...</Credits>
@@ -95713,6 +95864,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-06a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-06a1"
     Xcxstatus="in:64b744aea15b29de42b305fd"
   >
     <Credits>NASA/JPL-Caltech/A. Marston (EST; Hidden behind a shroud of dust in the constellation Cygnus is an exceptionally bright source of radio emission called DR21. Visi...</Credits>
@@ -95739,6 +95891,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-06b1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-06b1"
     Xcxstatus="in:64b744afa15b29de42b305ff"
   >
     <Credits>NASA/JPL-Caltech/A. Marston (EST; Hidden behind a shroud of dust in the constellation Cygnus is a stellar nursery called DR21, which is giving birth to some of th...</Credits>
@@ -95791,6 +95944,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-07b1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-07b1"
     Xcxstatus="in:64b744bfa15b29de42b30621"
   >
     <Credits>NASA/JPL-Caltech/G. Helou (Calte; Sometimes, the best way to understand how something works is to take it apart. The same is true for galaxies like NGC 300, which...</Credits>
@@ -95817,6 +95971,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-08a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-08a1"
     Xcxstatus="in:64b74493a15b29de42b305c3"
   >
     <Credits>NASA/JPL-Caltech/E. Churchwell (; One of the most prolific birthing grounds in our Milky Way galaxy, a nebula called RCW 49, is exposed in superb detail for the f...</Credits>
@@ -95843,6 +95998,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-09a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-09a1"
     Xcxstatus="in:64b7449ea15b29de42b305d9"
   >
     <Credits>NASA/JPL-Caltech/J. Keene (SSC/C; This image taken by NASA's Spitzer Space Telescope shows in unprecedented detail the galaxy Centaurus A's last big meal: a spira...</Credits>
@@ -95869,6 +96025,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-12a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-12a1"
     Xcxstatus="in:6551ac245dff7c3291e3aee2"
   >
     <Credits>Credit: NASA/JPL-Caltech/M. Rega; This composite infrared image from NASA's Spitzer Space Telescope has captured a nearby spiral galaxy that resembles our own Mil...</Credits>
@@ -95895,6 +96052,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-12a2L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-12a2"
     Xcxstatus="in:6551ac245dff7c3291e3aee4"
   >
     <Credits>Credit: NASA/JPL-Caltech/M. Rega; This infrared image from NASA's Spitzer Space Telescope has captured a nearby spiral galaxy that resembles our own Milky Way. Th...</Credits>
@@ -95921,6 +96079,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-12a3L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-12a3"
     Xcxstatus="in:6551ac255dff7c3291e3aee6"
   >
     <Credits>Credit: NASA/JPL-Caltech/M. Rega; This infrared image from NASA's Spitzer Space Telescope has captured a nearby spiral galaxy that resembles our own Milky Way. Th...</Credits>
@@ -95947,6 +96106,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-13a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-13a1"
     Xcxstatus="in:64b744c0a15b29de42b30623"
   >
     <Credits>NASA/JPL-Caltech/J. Hora (Harvar; This image from NASA's Spitzer Space Telescope shows a dying star (center) surrounded by a cloud of glowing gas and dust. Spitze...</Credits>
@@ -95973,6 +96133,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-14a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-14a1"
     Xcxstatus="in:64b749c6a15b29de42b3069e"
   >
     <Credits>NASA/JPL-Caltech/Z. Wang (Harvar; This infrared image from NASA's Spitzer Space Telescope reveals hidden populations of newborn stars at the heart of the collidin...</Credits>
@@ -95999,6 +96160,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-14a2L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-14a2"
     Xcxstatus="in:64b749c7a15b29de42b306a0"
   >
     <Credits>NASA/JPL-Caltech/Z. Wang (Harvar; This infrared image from NASA's Spitzer Space Telescope reveals hidden populations of newborn stars at the heart of the collidin...</Credits>
@@ -96025,6 +96187,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-14a3L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-14a3"
     Xcxstatus="in:64b749c8a15b29de42b306a2"
   >
     <Credits>M. Rushing/NOAO; This visible-light view of The Antennae Galaxies, a pair of interacting galaxies in the constellation Corvus, shows the dust clo...</Credits>
@@ -96051,6 +96214,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-15a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-15a1"
     Xcxstatus="in:64bb0fe5d87c275bcc5875bf"
   >
     <Credits>NASA/ESA/R. Sankrit and W. Blair; NASA's three Great Observatories -- the Hubble Space Telescope, the Spitzer Space Telescope, and the Chandra X-ray Observatory -...</Credits>
@@ -96077,6 +96241,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-15b1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-15b1"
     Xcxstatus="in:64bb0fe6d87c275bcc5875c1"
   >
     <Credits>NASA/ESA/R. Sankrit and W. Blair; This infrared image from NASA's Spitzer Space Telescope shows the expanding remains of a supernova, called Kepler's supernova re...</Credits>
@@ -96103,6 +96268,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-16a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-16a1"
     Xcxstatus="in:64b74473a15b29de42b3057d"
   >
     <Credits>NASA/JPL-Caltech/H. Kobulnicky (; This infrared image taken by NASA's Spitzer Space Telescope shows a globular cluster previously hidden in the dusty plane of our...</Credits>
@@ -96155,6 +96321,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-18a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-18a1"
     Xcxstatus="in:64b744b0a15b29de42b30601"
   >
     <Credits>NASA/JPL-Caltech/S.Carey (Caltec; A "monster" lurking behind a blanket of cosmic dust is unveiled in this 2004 Halloween image from NASA's Spitzer Space Telescope...</Credits>
@@ -96181,6 +96348,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-19a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-19a1"
     Xcxstatus="in:64b7449fa15b29de42b305db"
   >
     <Credits>DSS; This visible light view of the spiral galaxy M51 comes from the Kitt Peak National Observatory 2.1m telescope, and measures 9.9 ...</Credits>
@@ -96207,6 +96375,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2004-19a2L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2004-19a2"
     Xcxstatus="in:64b7449fa15b29de42b305dd"
   >
     <Credits>NASA/JPL-Caltech/R. Kennicutt (U; NASA's Spitzer Space Telescope has captured these infrared images of the "Whirlpool Galaxy," revealing strange structures bridgi...</Credits>
@@ -96259,6 +96428,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2005-02a2L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2005-02a2"
     Xcxstatus="in:64b74475a15b29de42b30581"
   >
     <Credits>NASA/JPL-Caltech/J. Rho (SSC/Cal; The glowing Trifid Nebula is revealed with near- and mid-infrared views from NASA's Spitzer Space Telescope. The Trifid Nebula i...</Credits>
@@ -96285,6 +96455,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2005-02a3L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2005-02a3"
     Xcxstatus="in:64b74475a15b29de42b30583"
   >
     <Credits>NASA/JPL-Caltech/J. Rho (SSC/Cal; The glowing Trifid Nebula is revealed in an infrared view from NASA's Spitzer Space Telescope. The Trifid Nebula is a giant star...</Credits>
@@ -96311,6 +96482,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2005-02a4L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2005-02a4"
     Xcxstatus="in:64b74476a15b29de42b30585"
   >
     <Credits>NASA/JPL-Caltech/J. Rho (SSC/Cal; The glowing Trifid Nebula is revealed with a mid-infrared view from NASA's Spitzer Space Telescope. The Trifid Nebula is a giant...</Credits>
@@ -96337,6 +96509,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2005-02b4L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2005-02b4"
     Xcxstatus="in:64b74477a15b29de42b30587"
   >
     <Credits>NASA/JPL-Caltech/J. Rho (SSC/Cal; This image shows a close-up infrared view from NASA's Spitzer Space Telescope of the glowing Trifid Nebula, a giant star-forming...</Credits>
@@ -96363,6 +96536,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2005-07a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2005-07a1"
     Xcxstatus="in:64b74479a15b29de42b30589"
   >
     <Credits>NASA/JPL-Caltech/J. Hora (Harvar; NASA's Spitzer Space Telescope finds a delicate flower in the Ring Nebula, as shown in this image. The outer shell of this plane...</Credits>
@@ -96389,6 +96563,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2005-11a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2005-11a1"
     Xcxstatus="in:64b749c9a15b29de42b306a4"
   >
     <Credits>Infrared: NASA/JPL-Caltech/R. Ke; NASA's Spitzer and Hubble Space Telescopes joined forces to create this striking composite image of one of the most popular sigh...</Credits>
@@ -96415,6 +96590,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2005-11a3L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2005-11a3"
     Xcxstatus="in:64b749caa15b29de42b306a6"
   >
     <Credits>NASA/JPL-Caltech/R. Kennicutt (U; NASA's Spitzer Space Telescopes created this striking infrared image of one of the most popular sights in the universe. Messier ...</Credits>
@@ -96441,6 +96617,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2005-14c1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2005-14c1"
     Xcxstatus="in:656d5506f86417282376493b"
   >
     <Credits>NASA/JPL-Caltech/O. Krause (Stew; This stunning multi-mission picture shows off the many sides of the supernova remnant Cassiopeia A. It is made up of images take...</Credits>
@@ -96467,6 +96644,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2005-20a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2005-20a1"
     Xcxstatus="in:64b744c1a15b29de42b30625"
   >
     <Credits>NASA/JPL-Caltech/K. Gordon (Univ; NASA's Spitzer Space Telescope has captured stunning infrared views of the famous Andromeda galaxy to reveal insights that were ...</Credits>
@@ -96493,6 +96671,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2005-20a2L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2005-20a2"
     Xcxstatus="in:64b744c1a15b29de42b30627"
   >
     <Credits>NASA/JPL-Caltech/K. Gordon (Univ; NASA's Spitzer Space Telescope has captured stunning infrared views of the famous Andromeda galaxy to reveal insights that were ...</Credits>
@@ -96519,6 +96698,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2005-23a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2005-23a1"
     Xcxstatus="in:64b744e2a15b29de42b3066f"
   >
     <Credits>NASA/JPL-Caltech/L. Allen (Harva; This image shows an infrared data taken by NASA's Spitzer Space Telescope of a region dubbed the "Mountains of Creation." Toweri...</Credits>
@@ -96545,6 +96725,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2005-24a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2005-24a1"
     Xcxstatus="in:64b745fea15b29de42b3067d"
   >
     <Credits>NASA/JPL-Caltech/R. A. Gutermuth; Located 1,000 light-years from Earth in the constellation Perseus, a reflection nebula called NGC 1333 epitomizes the beautiful ...</Credits>
@@ -96571,6 +96752,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2006-01a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2006-01a1"
     Xcxstatus="in:656d5507f86417282376493d"
   >
     <Credits>NASA/JPL-Caltech/J. Hora (Harvar; The Helix Nebula, which is composed of gaseous shells and disks puffed out by a dying sunlike star, exhibits complex structure o...</Credits>
@@ -96597,6 +96779,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2006-01b1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2006-01b1"
     Xcxstatus="in:656d5508f86417282376493f"
   >
     <Credits>NASA/JPL-Caltech/ESA/J. Hora (Ha; Six hundred and fifty light-years away in the constellation Aquarius, a dead star about the size of Earth, is refusing to fade a...</Credits>
@@ -96623,6 +96806,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2006-08a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2006-08a1"
     Xcxstatus="in:6551ac2b5dff7c3291e3aee8"
   >
     <Credits>NASA/JPL-Caltech/Max-Planck Inst; This false-color composite image of the Stephan's Quintet galaxy cluster clearly shows one of the largest shock waves ever seen ...</Credits>
@@ -96649,6 +96833,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2006-09a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2006-09a1"
     Xcxstatus="in:64b74316a15b29de42b3053d"
   >
     <Credits>NASA/JPL-Caltech/C. Engelbracht ; This image shows an infrared view from NASA's Spitzer Space Telescope of the galaxy Messier 82. A visible-light picture of the "...</Credits>
@@ -96675,6 +96860,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2006-11a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2006-11a1"
     Xcxstatus="in:64b742fda15b29de42b30507"
   >
     <Credits>NASA/JPL-Caltech/D. Elmegreen (V; Something appears to be peering through a shiny red mask, in this new infrared image from NASA's Spitzer Space Telescope. The my...</Credits>
@@ -96701,6 +96887,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2006-11b1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2006-11b1"
     Xcxstatus="in:64b742fea15b29de42b30509"
   >
     <Credits>NASA, ESA/JPL-Caltech/STScI/D. E; These shape-shifting galaxies have taken on the form of a giant mask. The icy blue eyes are actually the cores of two merging ga...</Credits>
@@ -96727,6 +96914,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2006-14a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2006-14a1"
     Xcxstatus="in:64b744c2a15b29de42b30629"
   >
     <Credits>NASA/JPL-Caltech/P. Barmby (Harv; This infrared composite image from NASA's Spitzer Space Telescope shows the Andromeda galaxy, a neighbor to our Milky Way galaxy...</Credits>
@@ -96753,6 +96941,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2006-16a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2006-16a1"
     Xcxstatus="in:64b742efa15b29de42b304e7"
   >
     <Credits>NASA/JPL-Caltech/T. Megeath (Uni; This infrared image from NASA's Spitzer Space Telescope shows the Orion nebula, our closest massive star-making factory, 1,450 l...</Credits>
@@ -96779,6 +96968,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2006-16b1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2006-16b1"
     Xcxstatus="in:64b742f0a15b29de42b304e9"
   >
     <Credits>NASA/JPL-Caltech/T. Megeath (Uni; This infrared image from NASA's Spitzer Space Telescope shows the Orion nebula, our closest massive star-making factory, 1,450 l...</Credits>
@@ -96805,6 +96995,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2006-17a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2006-17a1"
     Xcxstatus="in:64b742f1a15b29de42b304eb"
   >
     <Credits>NASA/JPL-Caltech/M. Meixner (STS; This vibrant image from NASA's Spitzer Space Telescope shows the Large Magellanic Cloud, a satellite galaxy to our own Milky Way...</Credits>
@@ -96831,6 +97022,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2006-17b1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2006-17b1"
     Xcxstatus="in:64b742f1a15b29de42b304ed"
   >
     <Credits>NASA/JPL-Caltech/M. Meixner (STS; This vibrant image from NASA's Spitzer Space Telescope shows the Large Magellanic Cloud, a satellite galaxy to our own Milky Way...</Credits>
@@ -96857,6 +97049,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2006-19a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2006-19a1"
     Xcxstatus="in:656d5509f864172823764941"
   >
     <Credits>NASA/JPL-Caltech/L. Rudnick (Uni; This image from NASA's Spitzer Space Telescope shows the scattered remains of an exploded star named Cassiopeia A. Spitzer's inf...</Credits>
@@ -96883,6 +97076,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2006-20a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2006-20a1"
     Xcxstatus="in:64b742f2a15b29de42b304ef"
   >
     <Credits>NASA/JPL-Caltech/S. Carey (SSC/C; This infrared image from NASA's Spitzer Space Telescope shows what astronomers are referring to as a "snake" (upper left) and it...</Credits>
@@ -96909,6 +97103,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2006-21a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2006-21a1"
     Xcxstatus="in:64b742f3a15b29de42b304f1"
   >
     <Credits>NASA/JPL-Caltech/T. Megeath (Uni; NASA's Spitzer and Hubble Space Telescopes have teamed up to expose the chaos that baby stars are creating 1,500 light-years awa...</Credits>
@@ -96935,6 +97130,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2007-01a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2007-01a1"
     Xcxstatus="in:64b74479a15b29de42b3058b"
   >
     <Credits>NASA/JPL-Caltech/N. Flagey (IAS/; This majestic view taken by NASA's Spitzer Space Telescope tells an untold story of life and death in the Eagle nebula, an indus...</Credits>
@@ -96961,6 +97157,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2007-01c1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2007-01c1"
     Xcxstatus="in:64b7447aa15b29de42b3058d"
   >
     <Credits>NASA/JPL-Caltech/N. Flagey (IAS/; This picture shows lots of stars and dusty structures with clarity. Dusty molecules found on Earth called polycyclic aromatic hy...</Credits>
@@ -96987,6 +97184,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2007-01c3L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2007-01c3"
     Xcxstatus="in:64b7447ba15b29de42b3058f"
   >
     <Credits>NASA/JPL-Caltech/N. Flagey (IAS/; This infrared picture highlights the contrast between the hot, supernova-heated dust (green) and the cooler dust making up the E...</Credits>
@@ -97013,6 +97211,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2007-03a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2007-03a1"
     Xcxstatus="in:656d5509f864172823764943"
   >
     <Credits>NASA/JPL-Caltech/K. Su (Univ. of; This infrared image from NASA's Spitzer Space Telescope shows the Helix nebula, a cosmic starlet often photographed by amateur a...</Credits>
@@ -97039,6 +97238,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2007-07a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2007-07a1"
     Xcxstatus="in:64b74780a15b29de42b30681"
   >
     <Credits>NASA/JPL-Caltech/J. Stauffer (SS; The Seven Sisters, also known as the Pleiades, seem to float on a bed of feathers in a new infrared image from NASA's Spitzer Sp...</Credits>
@@ -97065,6 +97265,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2007-07b1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2007-07b1"
     Xcxstatus="in:64b74781a15b29de42b30683"
   >
     <Credits>NASA/JPL-Caltech/J. Stauffer (SS; The Seven Sisters, also known as the Pleiades, seem to float on a bed of feathers in a new infrared image from NASA's Spitzer Sp...</Credits>
@@ -97091,6 +97292,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2007-08a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2007-08a1"
     Xcxstatus="in:64b742ffa15b29de42b3050b"
   >
     <Credits>NASA/JPL-Caltech/Z. Balog (Univ.; This infrared image from NASA's Spitzer Space Telescope shows the Rosette nebula, a pretty star-forming region more than 5,000 l...</Credits>
@@ -97117,6 +97319,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2007-10a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2007-10a1"
     Xcxstatus="in:64b744a0a15b29de42b305df"
   >
     <Credits>NASA/JPL-Caltech/L. Jenkins (GSF; This mosaic of the central region of the Coma cluster combines infrared and visible-light images to reveal thousands of faint ob...</Credits>
@@ -97143,6 +97346,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2007-13a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2007-13a1"
     Xcxstatus="in:64b74317a15b29de42b3053f"
   >
     <Credits>NASA/JPL-Caltech/K. Rines (Harva; One of the biggest galaxy collisions ever observed is taking place at the center of this image. The four white blobs in the midd...</Credits>
@@ -97169,6 +97373,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2007-19a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2007-19a1"
     Xcxstatus="in:64b744b1a15b29de42b30603"
   >
     <Credits>NASA/JPL-Caltech/UIUC, Caltech/S; A rare, infrared view of a developing star and its flaring jets taken by NASA's Spitzer Space Telescope shows us what our own so...</Credits>
@@ -97195,6 +97400,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2007-19a2L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2007-19a2"
     Xcxstatus="in:64b744b2a15b29de42b30605"
   >
     <Credits>Caltech/AURA; A rare, infrared view of a developing star and its flaring jets taken by NASA's Spitzer Space Telescope  shows us what our own s...</Credits>
@@ -97247,6 +97453,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2007-20bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2007-20b"
     Xcxstatus="in:656d550af864172823764945"
   >
     <Credits>NASA/JPL-Caltech/J. Rho (Caltech; This beautiful bulb might look like a Christmas ornament but it is the blown-out remains of a stellar explosion, or supernova. T...</Credits>
@@ -97273,6 +97480,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2008-03a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2008-03a1"
     Xcxstatus="in:64b744d4a15b29de42b30651"
   >
     <Credits>NASA/JPL-Caltech/Harvard-Smithso; Newborn stars peek out from beneath their natal blanket of dust in this dynamic image of the Rho Ophiuchi dark cloud from NASA's...</Credits>
@@ -97299,6 +97507,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2008-03b1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2008-03b1"
     Xcxstatus="in:64b744d5a15b29de42b30653"
   >
     <Credits>NASA/JPL-Caltech/Harvard-Smithso; Newborn stars peek out from beneath their natal blanket of dust in this dynamic image of the Rho Ophiuchi dark cloud from NASA's...</Credits>
@@ -97325,6 +97534,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2008-07a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2008-07a1"
     Xcxstatus="in:64b744a1a15b29de42b305e1"
   >
     <Credits>NASA/JPL-Caltech/NOAO/AURA/NSF, ; A cluster brimming with millions of stars glistens like an iridescent opal in this image from NASA's Spitzer Space Telescope. Ca...</Credits>
@@ -97377,6 +97587,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2008-09a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2008-09a1"
     Xcxstatus="in:656d550bf864172823764947"
   >
     <Credits>NASA/JPL-Caltech/Y. Kim (Univ. o; This image from NASA's Spitzer Space Telescope highlights dramatic changes in phenomena referred to as light echoes (colored are...</Credits>
@@ -97455,6 +97666,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2008-14aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2008-14a"
     Xcxstatus="in:64b7431fa15b29de42b3054f"
   >
     <Credits>NASA/JPL-Caltech/K. Gordon (STSc; The Pinwheel galaxy, otherwise known as Messier 101, sports bright reddish edges in this new infrared image from NASA's Spitzer ...</Credits>
@@ -97481,6 +97693,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2008-14bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2008-14b"
     Xcxstatus="in:64b74320a15b29de42b30551"
   >
     <Credits>NASA/JPL-Caltech/STScI; The tangled arms of the Pinwheel galaxy, otherwise known as Messier 101, are decked out in red in this new infrared image from N...</Credits>
@@ -97507,6 +97720,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2008-15a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2008-15a1"
     Xcxstatus="in:64b7409aa15b29de42b30495"
   >
     <Credits>NASA/JPL-Caltech/L. Allen &amp; X. K; Generations of stars can be seen in this new infrared portrait from NASA's Spitzer Space Telescope. In this wispy star-forming r...</Credits>
@@ -97533,6 +97747,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2008-17a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2008-17a1"
     Xcxstatus="in:64b744c3a15b29de42b3062b"
   >
     <Credits>NASA/JPL-Caltech/XMM/NTT/MPIA; This painterly portrait of a star-forming cloud, called NGC 346, is a combination of multiwavelength light from NASA's Spitzer S...</Credits>
@@ -97611,6 +97826,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2008-21a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2008-21a1"
     Xcxstatus="in:64b7447ca15b29de42b30591"
   >
     <Credits>NASA/JPL-Caltech/Univ. of Wisc.; NASA's Spitzer Space Telescope has captured a new, infrared view of the choppy star-making cloud called M17, also known as the O...</Credits>
@@ -97715,6 +97931,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2009-14a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2009-14a1"
     Xcxstatus="in:64b741b3a15b29de42b3049b"
   >
     <Credits>NASA/JPL-Caltech/The SINGS Team ; NASA's Spitzer Space Telescope has imaged a wild creature of the dark -- a coiled galaxy with an eye-like object at its center. ...</Credits>
@@ -97741,6 +97958,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2009-15a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2009-15a1"
     Xcxstatus="in:64b744b4a15b29de42b30609"
   >
     <Credits>NASA/JPL-Caltech/J. Hora (Harvar; This infrared picture shows a cloud, known as DR22, bursting with new stars in the Cygnus region of the sky. Spitzer's infrared ...</Credits>
@@ -97767,6 +97985,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2009-15a2L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2009-15a2"
     Xcxstatus="in:64b749cba15b29de42b306a8"
   >
     <Credits>NASA/JPL-Caltech; This infrared picture shows a relatively calm galaxy called NGC 4145. This galaxy has already made most of its stars and has lit...</Credits>
@@ -97793,6 +98012,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2009-15a3L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2009-15a3"
     Xcxstatus="in:64b749cca15b29de42b306aa"
   >
     <Credits>NASA/JPL-Caltech; This infrared picture shows a dying star called NGC 4361. This star was once a lot like our sun, before it evolved and puffed ou...</Credits>
@@ -97871,6 +98091,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2010-02a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2010-02a1"
     Xcxstatus="in:64b74488a15b29de42b305ab"
   >
     <Credits>NASA/JPL-Caltech/STScI; The infrared portrait of the Small Magellanic Cloud, taken by NASA's Spitzer Space Telescope, reveals the stars and dust in this...</Credits>
@@ -97897,6 +98118,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2010-02bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2010-02b"
     Xcxstatus="in:64b74489a15b29de42b305ad"
   >
     <Credits>NASA/JPL-Caltech/K. Gordon (STScI); The infrared portrait of the Small Magellanic Cloud, taken by NASA's Spitzer Space Telescope, reveals the stars and dust in this...</Credits>
@@ -97923,6 +98145,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2010-02cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2010-02c"
     Xcxstatus="in:64b7448aa15b29de42b305af"
   >
     <Credits>NASA/JPL-Caltech/K. Gordon (STScI); The infrared portrait of the Small Magellanic Cloud, taken by NASA's Spitzer Space Telescope, reveals the stars and dust in this...</Credits>
@@ -97975,6 +98198,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2011-03a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2011-03a1"
     Xcxstatus="in:64b744b5a15b29de42b3060b"
   >
     <Credits>NASA/JPL-Caltech/L. Rebull (SSC/; This swirling landscape of stars is known as the North America nebula. In visible light, the region resembles North America, but...</Credits>
@@ -98001,6 +98225,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2011-03a2L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2011-03a2"
     Xcxstatus="in:64b744b6a15b29de42b3060d"
   >
     <Credits>NASA/JPL-Caltech/L. Rebull (SSC/; This swirling landscape of stars is known as the North America nebula. In visible light, the region resembles North America, but...</Credits>
@@ -98027,6 +98252,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2011-03a3L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2011-03a3"
     Xcxstatus="in:64b741f0a15b29de42b3049f"
   >
     <Credits>NASA/JPL-Caltech/L. Rebull (SSC/; This new view of the North America nebula combines both visible and infrared light observations, taken by the Digitized Sky Surv...</Credits>
@@ -98053,6 +98279,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2011-04a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2011-04a1"
     Xcxstatus="in:64b742f4a15b29de42b304f3"
   >
     <Credits>NASA / JPL-Caltech / A. Raga (IC; NASA's Spitzer Space Telescope took this image of a baby star sprouting two identical jets (green lines emanating from fuzzy sta...</Credits>
@@ -98079,6 +98306,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2011-06aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2011-06a"
     Xcxstatus="in:64b742f5a15b29de42b304f5"
   >
     <Credits>NASA/JPL-Caltech/T. Megeath (Uni; This image from NASA's Spitzer Space Telescope shows what lies near the sword of the constellation Orion -- an active stellar nu...</Credits>
@@ -98105,6 +98333,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2012-01aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2012-01a"
     Xcxstatus="in:64b742f6a15b29de42b304f7"
   >
     <Credits>ESA/NASA/JPL-Caltech/STScI; This new image shows the Large Magellanic Cloud galaxy in infrared light as seen by the Herschel Space Observatory, a European S...</Credits>
@@ -98131,6 +98360,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2012-01bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2012-01b"
     Xcxstatus="in:64b7448ba15b29de42b305b1"
   >
     <Credits>ESA/NASA/JPL-Caltech/STScI; This new image shows the Small Magellanic Cloud galaxy in infrared light from the Herschel Space Observatory a European Space Ag...</Credits>
@@ -98157,6 +98387,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2012-02a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2012-02a,spitzer|ssc2012-02a1"
     Xcxstatus="in:64b744b7a15b29de42b3060f"
   >
     <Credits>NASA/JPL-Caltech/Harvard-Smithso; A bubbling cauldron of star birth is highlighted in this new image from NASA's Spitzer Space Telescope. Infrared light that we c...</Credits>
@@ -98209,6 +98440,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2012-04aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2012-04a"
     Xcxstatus="in:64b742f7a15b29de42b304f9"
   >
     <Credits>ESA/NASA/JPL-Caltech/N. Billot (; This new view of the Orion nebula highlights fledging stars hidden in the gas and clouds. It shows infrared observations taken b...</Credits>
@@ -98235,6 +98467,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2012-06aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2012-06a"
     Xcxstatus="in:64b749cda15b29de42b306ac"
   >
     <Credits>NASA/JPL-Caltech; 'The infrared vision of NASA's Spitzer Space Telescope has revealed that the Sombrero galaxy -- named after its appearance in vi...</Credits>
@@ -98261,6 +98494,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2012-06bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2012-06b"
     Xcxstatus="in:64bb0fd5d87c275bcc5875a5"
   >
     <Credits>NASA/JPL-Caltech; New observations from NASA's Spitzer Space Telescope reveal the Sombrero galaxy is not simply a regular flat disk galaxy of star...</Credits>
@@ -98339,6 +98573,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2012-12a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2012-12a1"
     Xcxstatus="in:64b744cba15b29de42b3063d"
   >
     <Credits>NASA/ESA/STScI/W. Zheng (JHU), a; With the combined power of NASA's Spitzer and Hubble space telescopes, as well as a cosmic magnification effect, astronomers hav...</Credits>
@@ -98417,6 +98652,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2012-14a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2012-14a1"
     Xcxstatus="in:64b74323a15b29de42b30557"
   >
     <Credits>NASA/JPL-Caltech/UC Irvine; This image shows a portion of our sky, called the Botes field, in infrared light. Using Spitzer, researchers were able to detect...</Credits>
@@ -98443,6 +98679,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2012-14a2L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2012-14a2"
     Xcxstatus="in:64b74324a15b29de42b30559"
   >
     <Credits>NASA/JPL-Caltech/UC Irvine; This image shows a mysterious, background infrared glow captured by NASA's Spitzer Space Telescope. Using Spitzer, researchers w...</Credits>
@@ -98469,6 +98706,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2013-05a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2013-05a1"
     Xcxstatus="in:64b7447da15b29de42b30593"
   >
     <Credits>NASA/JPL-Caltech/University of W; This infrared image shows a striking example of what is called a hierarchical bubble structure, in which one giant bubble, carve...</Credits>
@@ -98495,6 +98733,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2013-05bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2013-05b"
     Xcxstatus="in:64b74302a15b29de42b30511"
   >
     <Credits>NASA/JPL-Caltech/University of W; Dozens of newborn stars sprouting jets from their dusty cocoons have been spotted in images from NASA's Spitzer Space Telescope....</Credits>
@@ -98521,6 +98760,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2013-05cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2013-05c"
     Xcxstatus="in:64b741f1a15b29de42b304a1"
   >
     <Credits>NASA/JPL-Caltech/University of W; In what may look to some like an undersea image of coral and seaweed, a new image from NASA's Spitzer Space Telescope is showing...</Credits>
@@ -98547,6 +98787,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2013-05d1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2013-05d1"
     Xcxstatus="in:64b741f7a15b29de42b304ad"
   >
     <Credits>NASA/JPL-Caltech/University of W; There are nearly 200 galaxies in this image from NASA's Spitzer Space Telescope. These are part of the Perseus-Pisces superclust...</Credits>
@@ -98573,6 +98814,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2013-07a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2013-07a1"
     Xcxstatus="in:64b744c4a15b29de42b3062d"
   >
     <Credits>NASA/JPL-Caltech; The spectacular swirling arms and central bar of the Sculptor galaxy are revealed in this new view from NASAs Spitzer Space Tele...</Credits>
@@ -98599,6 +98841,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2013-07a2L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2013-07a2"
     Xcxstatus="in:64b744c5a15b29de42b3062f"
   >
     <Credits>NASA/JPL-Caltech; The spectacular swirling arms and central bar of the Sculptor galaxy are revealed in this new starlight view from NASAs Spitzer ...</Credits>
@@ -98625,6 +98868,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2013-07a3L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2013-07a3"
     Xcxstatus="in:64b744c6a15b29de42b30631"
   >
     <Credits>NASA/JPL-Caltech; The spectacular dusty swirling arms and central bar of the Sculptor galaxy are revealed in this new view from NASAs Spitzer Spac...</Credits>
@@ -98677,6 +98921,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2015-03bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2015-03b"
     Xcxstatus="in:64b74496a15b29de42b305c9"
   >
     <Credits>NASA/ESA/STScI/JPL-Caltech/McGil; A massive cluster of galaxies, called SpARCS1049+56, can be seen in this multi-wavelength view from NASA's Hubble and Spitzer sp...</Credits>
@@ -98703,6 +98948,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2017-14a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2017-14a1"
     Xcxstatus="in:64b744a2a15b29de42b305e3"
   >
     <Credits>NASA/JPL-Caltech; NASAs Spitzer Space Telescope has provisionally detected the faint afterglow of the explosive merger of two neutron stars in the...</Credits>
@@ -98729,6 +98975,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2017-14a2L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2017-14a2"
     Xcxstatus="in:64b744a3a15b29de42b305e5"
   >
     <Credits>NASA/JPL-Caltech; NASAs Spitzer Space Telescope has provisionally detected the faint afterglow of the explosive merger of two neutron stars in the...</Credits>
@@ -98781,6 +99028,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2018-05aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2018-05a"
     Xcxstatus="in:64b74318a15b29de42b30541"
   >
     <Credits>NASA-ESA/STScI/AURA/JPL-Caltech; This image of distant interacting galaxies, known collectively as Arp 142, bears an uncanny resemblance to a penguin guarding an...</Credits>
@@ -98807,6 +99055,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2018-14aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2018-14a"
     Xcxstatus="in:64bb0fe7d87c275bcc5875c3"
   >
     <Credits>NASA/JPL-Caltech; The Cat's Paw Nebula, imaged here by NASA's Spitzer Space Telescope, lies inside the Milky Way Galaxy and is located in the cons...</Credits>
@@ -98833,6 +99082,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2018-14bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2018-14b"
     Xcxstatus="in:64bb0fe8d87c275bcc5875c5"
   >
     <Credits>NASA/JPL-Caltech; The Cat's Paw Nebula, imaged here by NASA's Spitzer Space Telescope, is a star-forming region inside the Milky Way Galaxy and is...</Credits>
@@ -98859,6 +99109,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2018-16aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2018-16a"
     Xcxstatus="in:64bb0feed87c275bcc5875d3"
   >
     <Credits>NASA/JPL-Caltech/CXC/ESA/NRAO/J.; This image of supernova remnant G54.1+0.3 includes radio, infrared and X-ray light.
@@ -98887,6 +99138,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2019-03aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2019-03a"
     Xcxstatus="in:6551ac2c5dff7c3291e3aeea"
   >
     <Credits>NASA/JPL-Caltech; This image shows the merger of two galaxies, known as NGC 7752 (larger) and NGC 7753 (smaller), also collectively called Arp86. ...</Credits>
@@ -98913,6 +99165,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2019-03bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2019-03b"
     Xcxstatus="in:64bb0fefd87c275bcc5875d5"
   >
     <Credits>NASA/JPL-Caltech; This image shows the merger of two galaxies, known as NGC 6786 (right) and UGC 11415 (left), also collectively called VII Zw 96....</Credits>
@@ -98939,6 +99192,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2019-03cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2019-03c"
     Xcxstatus="in:64b74324a15b29de42b3055b"
   >
     <Credits>NASA/JPL-Caltech; This image shows two merging galaxies known as Arp 302, also called VV 340. In these images, different colors correspond to diff...</Credits>
@@ -98965,6 +99219,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2019-04aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2019-04a"
     Xcxstatus="in:64b7447ea15b29de42b30595"
   >
     <Credits>NASA/JPL-Caltech; What looks like a red butterfly in space is in reality a nursery for hundreds of baby stars, revealed in this infrared image fro...</Credits>
@@ -98991,6 +99246,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2019-05aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2019-05a"
     Xcxstatus="in:64bb0fd6d87c275bcc5875a7"
   >
     <Credits>NASA/JPL-Caltech/IPAC/Event Hori; This image from NASA's Spitzer Space Telescope shows the elliptical galaxy Messier 87 (M87), the home galaxy of the supermassive...</Credits>
@@ -99017,6 +99273,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2019-05bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2019-05b"
     Xcxstatus="in:64bb0fd7d87c275bcc5875a9"
   >
     <Credits>NASA/JPL-Caltech/IPAC; This image from NASA's Spitzer Space Telescope shows the elliptical galaxy Messier 87 (M87), the home galaxy of the supermassive...</Credits>
@@ -99043,6 +99300,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2019-05cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2019-05c"
     Xcxstatus="in:64bb0fd8d87c275bcc5875ab"
   >
     <Credits>NASA/JPL-Caltech/IPAC; This image from NASA's Spitzer Space Telescope shows the elliptical galaxy Messier 87 (M87), the home galaxy of the supermassive...</Credits>
@@ -99173,6 +99431,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2019-11aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2019-11a"
     Xcxstatus="in:64b744a5a15b29de42b305e9"
   >
     <Credits>NASA/JPL-Caltech; This image shows the Whirlpool galaxy, also known as Messier 51 and NGC 5194/5195, which is actually a pair of galaxies. Located...</Credits>
@@ -99199,6 +99458,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2019-11bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2019-11b"
     Xcxstatus="in:64b744a6a15b29de42b305eb"
   >
     <Credits>NASA/JPL-Caltech; This image shows the Whirlpool galaxy, also known as Messier 51 and NGC 5194/5195, which is actually a pair of galaxies. Located...</Credits>
@@ -99225,6 +99485,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2019-11cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2019-11c"
     Xcxstatus="in:64b744a7a15b29de42b305ed"
   >
     <Credits>NASA/JPL-Caltech; This image shows the Whirlpool galaxy, also known as Messier 51 and NGC 5194/5195, which is actually a pair of galaxies. Located...</Credits>
@@ -99251,6 +99512,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2019-11dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2019-11d"
     Xcxstatus="in:64b744a8a15b29de42b305ef"
   >
     <Credits>NASA/JPL-Caltech; This image shows the Whirlpool galaxy, also known as Messier 51 and NGC 5194/5195, which is actually a pair of galaxies. Located...</Credits>

--- a/imagesets/sky__visible.xml
+++ b/imagesets/sky__visible.xml
@@ -43408,6 +43408,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-102L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|102"
     Xcxstatus="in:653abcb3dba86d239b27cf2b"
   >
     <Credits>X-ray: NASA/CXC/SAO/C. Jones, W.; This composite X-ray (blue)/optical (orange) image of M86 shows gas being swept
@@ -43435,6 +43436,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-103L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|103"
     Xcxstatus="in:65424f9ba5946236dee82f37"
   >
     <Credits>X-ray: NASA/UIUC/Y. Chu &amp;  R. Gr; This composite X-ray (blue)/optical (red and green) image reveals dramatic details of a portion of the Crescent Nebula. About 40...</Credits>
@@ -43461,6 +43463,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-107L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|107"
     Xcxstatus="in:65424f9ca5946236dee82f39"
   >
     <Credits>X-ray: NASA/CXC/Rutgers/J.Warren; Chandra's image (blue) of N63A has been combined with optical (green) and radio (red) images to make this composite image. The X...</Credits>
@@ -43487,6 +43490,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-108L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|108"
     Xcxstatus="in:65424f9da5946236dee82f3b"
   >
     <Credits>NASA/CXC/Ohio U/B.McNamara et al; The Chandra image of Abell 2597 revealed a vast cloud of hot gas with two dark cavities - upper left and lower right - about 100...</Credits>
@@ -43513,6 +43517,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-109L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|109"
     Xcxstatus="in:65424f9ea5946236dee82f3d"
   >
     <Credits>NASA/UMass/D.Wang et al.; This spectacular mosaic of Chandra images reveals hundreds of white dwarf stars, neutron stars, and black holes bathed in an inc...</Credits>
@@ -43539,6 +43544,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-112L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|112"
     Xcxstatus="in:65424f9fa5946236dee82f3f"
   >
     <Credits>NASA/IoA/J.Sanders &amp; A.Fabian; The Chandra image of the Centaurus galaxy cluster shows a long plume-like feature resembling a twisted sheet. The plume is some ...</Credits>
@@ -43565,6 +43571,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-113L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|113"
     Xcxstatus="in:65424fa0a5946236dee82f41"
   >
     <Credits>NASA/CXC/A.Siemiginowska(CfA)/J.; Chandra's image of this highly luminous quasar shows an enormous X-ray jet that extends at least a million light years. The jet ...</Credits>
@@ -43591,6 +43598,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-114L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|114"
     Xcxstatus="in:65424fa1a5946236dee82f43"
   >
     <Credits>NASA/SAO/CXC/M.Markevitch et al.; A bow-shaped shock wave located near the right side of the cluster was revealed in Chandra's image of 1E 0657-56. The shock wave...</Credits>
@@ -43617,6 +43625,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-118L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|118"
     Xcxstatus="in:65424fa2a5946236dee82f45"
   >
     <Credits>NASA/CXC/SAO/A.Vikhlinin et al.; Chandra's image shows two large central galaxies, NGC 4889 (left) and NGC 4874 (right), embedded in a vast 100 million-degree Ce...</Credits>
@@ -43643,6 +43652,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-122L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|122"
     Xcxstatus="in:65424fa3a5946236dee82f47"
   >
     <Credits>NASA/CXC/Penn State/L.Townsley e; Chandra's image shows the drama of star formation and evolution as it is being played out in a nearby galaxy. At least 11 extrem...</Credits>
@@ -43669,6 +43679,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-123L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|123"
     Xcxstatus="in:65424fa4a5946236dee82f49"
   >
     <Credits>NASA/U. Birmingham/A.Read; Chandra's image of Arp 270 shows two galaxies in the early stage of a merger. The hot spots (blue) are thought to be due to the ...</Credits>
@@ -43695,6 +43706,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-124L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|124"
     Xcxstatus="in:65424fa5a5946236dee82f4b"
   >
     <Credits>NASA/SAO/CXC; Chandra's "true color" image of N132D shows a beautiful, complex remnant of the explosion of a massive star. The colors represen...</Credits>
@@ -43721,6 +43733,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-125L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|125"
     Xcxstatus="in:65424fa6a5946236dee82f4d"
   >
     <Credits>NASA/CXC/UVa/S.Randall et al.; The Chandra X-ray image of NGC 4649 reveals a large, bright cloud of hot gas with 165 point-like sources most of which are black...</Credits>
@@ -43747,6 +43760,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-126L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|126"
     Xcxstatus="in:654251cfa5946236dee82f72"
   >
     <Credits>NASA/CXC/UVa/E.Blanton et al.; Chandra's image of this distant galaxy revealed a surprising number of point-like sources that have been identified as black hol...</Credits>
@@ -43773,6 +43787,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-129L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|129"
     Xcxstatus="in:654256f95dff7c3291e3948e"
   >
     <Credits>NASA/CXC/U.Md/A.Wilson et al.; Chandra's image highlights the energetic central regions of the two interacting galaxies that are collectively called the Whirlp...</Credits>
@@ -43799,6 +43814,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-130L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|130"
     Xcxstatus="in:654e41415dff7c3291e3a985"
   >
     <Credits>NASA/CXC/UCSB/C.Martin et al.; Chandra's 27-hour observation of this dwarf galaxy allowed scientists to measure for the first time the concentration of oxygen,...</Credits>
@@ -43851,6 +43867,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-133L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|133"
     Xcxstatus="in:654e41435dff7c3291e3a989"
   >
     <Credits>NASA/CXC/SAO; In August of 1999, NASA released an image of Cassiopeia A, a supernova remnant revealed in never-before-seen X-ray detail. The "...</Credits>
@@ -43877,6 +43894,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-134L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|134"
     Xcxstatus="in:654e41445dff7c3291e3a98b"
   >
     <Credits>NASA/CXC/OCIW/P.Martini et al.; Chandra's observation of A2104 revealed six bright X-ray sources due to active supermassive black holes located in red galaxies....</Credits>
@@ -43903,6 +43921,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-135L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|135"
     Xcxstatus="in:654e41455dff7c3291e3a98d"
   >
     <Credits>NASA/CXC/SAO; Chandra's image reveals the turbulent remains of a supernova explosion that was observed by the Danish astronomer Tycho Brahe in...</Credits>
@@ -43929,6 +43948,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-142L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|142"
     Xcxstatus="in:654e41465dff7c3291e3a98f"
   >
     <Credits>NASA/CXC/CfA/S.Wolk et al.; This Chandra image covers a region about 5 light years across and shows many young stars with hot upper atmospheres. In addition...</Credits>
@@ -43955,6 +43975,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-146L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|146"
     Xcxstatus="in:654e41475dff7c3291e3a991"
   >
     <Credits>NASA/McGill/V.Kaspi et al.; Using the Chandra X-ray Observatory, scientists have pinpointed the exact location of the pulsar within the supernova remnant G1...</Credits>
@@ -43981,6 +44002,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-148L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|148"
     Xcxstatus="in:654e41485dff7c3291e3a993"
   >
     <Credits>NASA/GSFC/M.Corcoran et al.; Chandra has resolved the multitude of individual X-ray sources in one of our galaxy's most active star-forming regions. This gia...</Credits>
@@ -44007,6 +44029,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-150L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|150"
     Xcxstatus="in:654e41495dff7c3291e3a995"
   >
     <Credits>NASA/IoA/A.Fabian et al.; Using Chandra, astronomers have found the most distant cluster of galaxies ever detected in X rays. Approximately 10 billion lig...</Credits>
@@ -44033,6 +44056,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-151L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|151"
     Xcxstatus="in:654e41495dff7c3291e3a997"
   >
     <Credits>NASA/CfA/J. Vrtilek et al.; Chandra reveals remarkable detail and complexity in this image of the galaxy group known as HCG 62. Such galaxy groups, smaller ...</Credits>
@@ -44059,6 +44083,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-152L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|152"
     Xcxstatus="in:654e414a5dff7c3291e3a999"
   >
     <Credits>NASA/PSU/G.Garmire, N.Brandt, et; Chandra's extremely deep image provides a crucial view of one of the most intensively studied patches of the night sky, the Hubb...</Credits>
@@ -44085,6 +44110,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-153L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|153"
     Xcxstatus="in:654e414b5dff7c3291e3a99b"
   >
     <Credits>NASA/JHU/AUI/R.Giacconi et al.; This Chandra image shows that gigantic black holes were much more active in the past than the present. In this deepest X-ray exp...</Credits>
@@ -44111,6 +44137,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-154L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|154"
     Xcxstatus="in:654e414c5dff7c3291e3a99d"
   >
     <Credits>NASA/CNR/L.Piro et al.; Data from this Chandra image suggest that gamma-ray bursts originate in regions of star formation. Several theories exist about ...</Credits>
@@ -44137,6 +44164,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-1555L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|1555"
     Xcxstatus="in:654e414d5dff7c3291e3a99f"
   >
     <Credits>NASA/CfA/J.McClintock &amp; M.Garcia</Credits>
@@ -44163,6 +44191,7 @@ out of the galaxy to form a long tail more than ...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-156L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|156"
     Xcxstatus="in:654e414e5dff7c3291e3a9a1"
   >
     <Credits>NASA/Penn State/F.Bauer et al
@@ -44190,6 +44219,7 @@ NA; Chandra's observations of a large, nearby galaxy in the constellation of Cir
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-159L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|159"
     Xcxstatus="in:654e414f5dff7c3291e3a9a3"
   >
     <Credits>NASA/SAO/G.Fabbiano et al.; This Chandra image is colorized to highlight a population of point-like "ultraluminous" X-ray sources in M82, a starburst galaxy...</Credits>
@@ -44216,6 +44246,7 @@ NA; Chandra's observations of a large, nearby galaxy in the constellation of Cir
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-160L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|160"
     Xcxstatus="in:654e41505dff7c3291e3a9a5"
   >
     <Credits>NASA/CXC/UVa/C.Sarazin et al.; The Chandra image of this galaxy reveals diffuse hot gas dotted with many point-like sources that have been identified as black ...</Credits>
@@ -44242,6 +44273,7 @@ NA; Chandra's observations of a large, nearby galaxy in the constellation of Cir
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-161L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|161"
     Xcxstatus="in:654e41515dff7c3291e3a9a7"
   >
     <Credits>X-ray: NASA/SAO/CXC, Optical: ES; The Chandra image of NGC 253 shows a plume of 5 million degree gas in the central region of the galaxy extending above and below...</Credits>
@@ -44268,6 +44300,7 @@ NA; Chandra's observations of a large, nearby galaxy in the constellation of Cir
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-163L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|163"
     Xcxstatus="in:654e41525dff7c3291e3a9a9"
   >
     <Credits>NASA/RIT/J.Kastner et al.; Chandra's image of NGC 7027 represents the first detection of X-rays from this young planetary nebula that is about 700 years ol...</Credits>
@@ -44294,6 +44327,7 @@ NA; Chandra's observations of a large, nearby galaxy in the constellation of Cir
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-164L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|164"
     Xcxstatus="in:654e41535dff7c3291e3a9ab"
   >
     <Credits>NASA/SAO/CXC; In this wide angle view, the Vela pulsar wind nebula is seen against a background of clouds, or filaments, of multi-million degr...</Credits>
@@ -44320,6 +44354,7 @@ NA; Chandra's observations of a large, nearby galaxy in the constellation of Cir
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-166L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|166"
     Xcxstatus="in:654e41545dff7c3291e3a9ad"
   >
     <Credits>NASA/SAO/R.Kraft et al.; This stunning Chandra X-ray Observatory image of Centaurus A was the result of approximately 20 hours of observation. In additio...</Credits>
@@ -44346,6 +44381,7 @@ NA; Chandra's observations of a large, nearby galaxy in the constellation of Cir
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-168L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|168"
     Xcxstatus="in:654e41555dff7c3291e3a9af"
   >
     <Credits>NASA/MIT/F.Baganoff et al.; During a Chandra observation of the X-ray source located at the galactic center, the source was observed to brighten dramaticall...</Credits>
@@ -44372,6 +44408,7 @@ NA; Chandra's observations of a large, nearby galaxy in the constellation of Cir
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-169L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|169"
     Xcxstatus="in:654e41565dff7c3291e3a9b1"
   >
     <Credits>NASA/CXC/SAO/S.Murray et al.</Credits>
@@ -44398,6 +44435,7 @@ NA; Chandra's observations of a large, nearby galaxy in the constellation of Cir
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-170L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|170"
     Xcxstatus="in:654e41575dff7c3291e3a9b3"
   >
     <Credits>NASA/MIT/B.Gaensler et al.; Chandra's image of the rapidly spinning neutron star, or pulsar, B1509-58 shows a central bright source surrounded by an extreme...</Credits>
@@ -44424,6 +44462,7 @@ NA; Chandra's observations of a large, nearby galaxy in the constellation of Cir
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-173L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|173"
     Xcxstatus="in:65707d222cd220bb5b6d7da9"
   >
     <Credits>NASA/MIT/J.Arabadjis et al.</Credits>
@@ -44450,6 +44489,7 @@ NA; Chandra's observations of a large, nearby galaxy in the constellation of Cir
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-174L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|174"
     Xcxstatus="in:65707d232cd220bb5b6d7dab"
   >
     <Credits>NASA/Penn State/L.Townsley et al; These four Chandra images combine to form a mosaic of a region of the Rosette Nebula. The images move outward from the center of...</Credits>
@@ -44476,6 +44516,7 @@ NA; Chandra's observations of a large, nearby galaxy in the constellation of Cir
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-175L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|175"
     Xcxstatus="in:65707d242cd220bb5b6d7dad"
   >
     <Credits>NASA/CXC/Wijnands et al.; Chandra's observation in March of 2001 of the neutron star KS 1731-260 (pale blue dot just above the middle of the image) showed...</Credits>
@@ -44502,6 +44543,7 @@ NA; Chandra's observations of a large, nearby galaxy in the constellation of Cir
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-176L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|176"
     Xcxstatus="in:65707d242cd220bb5b6d7daf"
   >
     <Credits>NASA/GSFC/N.White, L.Angelini; The Chandra X-ray Observatory image of a previously identified neutron star binary system in the globular cluster M15, revealed ...</Credits>
@@ -44528,6 +44570,7 @@ NA; Chandra's observations of a large, nearby galaxy in the constellation of Cir
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-178L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|178"
     Xcxstatus="in:65707d252cd220bb5b6d7db1"
   >
     <Credits>X-ray: (NASA/SAO/CXC/M.Garcia et; This image of the central region of the Andromeda Galaxy is a composite of Chandra X-ray data (3 pixilated sources) and Hubble o...</Credits>
@@ -44554,6 +44597,7 @@ NA; Chandra's observations of a large, nearby galaxy in the constellation of Cir
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-180L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|180"
     Xcxstatus="in:65707d262cd220bb5b6d7db3"
   >
     <Credits>NASA/CXC/Rutgers/J.Hughes et al.</Credits>
@@ -44580,6 +44624,7 @@ NA; Chandra's observations of a large, nearby galaxy in the constellation of Cir
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-183L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|183"
     Xcxstatus="in:65707d272cd220bb5b6d7db5"
   >
     <Credits>NASA/SAO/CXC/C.Jones et al.; This Chandra image of NGC 4636 shows symmetric arms, or arcs, of 10 million degree gas extending 25,000 light years into a cloud...</Credits>
@@ -44606,6 +44651,7 @@ NA; Chandra's observations of a large, nearby galaxy in the constellation of Cir
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-184L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|184"
     Xcxstatus="in:65707d282cd220bb5b6d7db7"
   >
     <Credits>NASA/NCSSM/C.Olbert et al.; Using this Chandra image, along with radio data from the Very Large Array, three high school students found evidence for a neutr...</Credits>
@@ -44632,6 +44678,7 @@ NA; Chandra's observations of a large, nearby galaxy in the constellation of Cir
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-185L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|185"
     Xcxstatus="in:65707d292cd220bb5b6d7db9"
   >
     <Credits> NASA/IoA/AC Fabian et al.</Credits>
@@ -44658,6 +44705,7 @@ NA; Chandra's observations of a large, nearby galaxy in the constellation of Cir
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-190L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|190"
     Xcxstatus="in:65707d2a2cd220bb5b6d7dbb"
   >
     <Credits>NASA/UMD/A.Wilson et al.; Chandra's image shows a giant football-shaped cavity within X-ray emitting hot gas surrounding the galaxy Cygnus A. The cavity i...</Credits>
@@ -44684,6 +44732,7 @@ NA; Chandra's observations of a large, nearby galaxy in the constellation of Cir
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-191L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|191"
     Xcxstatus="in:65707d2b2cd220bb5b6d7dbd"
   >
     <Credits>NASA/CXC/SAO/H.Marshall et al.</Credits>
@@ -44710,6 +44759,7 @@ NA; Chandra's observations of a large, nearby galaxy in the constellation of Cir
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-194L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|194"
     Xcxstatus="in:65707d2c2cd220bb5b6d7dbf"
   >
     <Credits>NASA/SAO/CXC; The Chandra X-ray image of Sirius A &amp; B, a double star system located 8.6 light years from Earth, shows a bright source and a di...</Credits>
@@ -44736,6 +44786,7 @@ NA; Chandra's observations of a large, nearby galaxy in the constellation of Cir
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-196L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|196"
     Xcxstatus="in:65707d2c2cd220bb5b6d7dc1"
   >
     <Credits>NASA/SAO/CXC/G.Fabbiano et al.</Credits>
@@ -44789,6 +44840,7 @@ insight into how the...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-201L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|201"
     Xcxstatus="in:657b1eec60c68ea9c726b4b5"
   >
     <Credits>NASA/PSU/G.Pavlov et al.; Chandra's bizarre image of the Vela pulsar (bright spot in the center) shows the details of a compact nebula that resembles a gi...</Credits>
@@ -44815,6 +44867,7 @@ insight into how the...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-202L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|202"
     Xcxstatus="in:657b1eed60c68ea9c726b4b7"
   >
     <Credits>NASA/RIT/J.Kastner et al.; The Chandra image of the planetary nebula BD+30 3639 shows a hot bubble of 3 million degree Celsius gas surrounding a dying, Sun...</Credits>
@@ -44841,6 +44894,7 @@ insight into how the...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-203L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|203"
     Xcxstatus="in:657b1eee60c68ea9c726b4b9"
   >
     <Credits>NASA/UMD/A.Wilson et al.; Chandra's image of Pictor A gave scientists their first look at a spectacular X-ray jet. The jet originates near a giant black h...</Credits>
@@ -44867,6 +44921,7 @@ insight into how the...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-208L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|208"
     Xcxstatus="in:657b1eef60c68ea9c726b4bb"
   >
     <Credits>NASA/SRON/MPE; The Chandra image of Cygnus X-3 shows the X-ray source (red) and a halo (green &amp; blue). The halo is due to scattering by interst...</Credits>
@@ -44893,6 +44948,7 @@ insight into how the...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-209L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|209"
     Xcxstatus="in:657b1ef060c68ea9c726b4bd"
   >
     <Credits>X-ray: NASA/CXC/SAO, Optical: NA; The Chandra X-ray image (blue) shows gas that has been heated to millions of degrees Celsius by a shock wave moving into matter ...</Credits>
@@ -44919,6 +44975,7 @@ insight into how the...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-212L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|212"
     Xcxstatus="in:657b1ef160c68ea9c726b4bf"
   >
     <Credits>NASA/CXC/SAO; This image made by NASA's Chandra X-ray Observatory shows the merger of two sub-clusters of galaxies. The sub-clusters are embed...</Credits>
@@ -44945,6 +45002,7 @@ insight into how the...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-214L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|214"
     Xcxstatus="in:657b1ef160c68ea9c726b4c1"
   >
     <Credits>NASA/CXC/SAO/PSU/CMU; M82, at a distance of 11 million light years from Earth, is the nearest starburst galaxy. Massive stars are forming and expiring...</Credits>
@@ -44971,6 +45029,7 @@ insight into how the...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-215L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|215"
     Xcxstatus="in:657b1ef260c68ea9c726b4c3"
   >
     <Credits>NASA/CXC/SAO; This X-ray image shows the central portion of the Andromeda Galaxy. The blue dot in the center of the image is an unusual "cool"...</Credits>
@@ -44997,6 +45056,7 @@ insight into how the...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-216L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|216"
     Xcxstatus="in:657b1ef360c68ea9c726b4c5"
   >
     <Credits>NASA/MIT/PSU; The image has been smoothed to bring out the X-ray emission from an extended cloud of hot gas surrounding the supermassive black...</Credits>
@@ -45023,6 +45083,7 @@ insight into how the...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-217L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|217"
     Xcxstatus="in:657b1ef460c68ea9c726b4c7"
   >
     <Credits>NASA/MIT; This X-ray image of the supernova remnant E0102-72 shows an expanding multimillion degree ring of oxygen that was created deep i...</Credits>
@@ -45049,6 +45110,7 @@ insight into how the...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-218L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|218"
     Xcxstatus="in:657b1ef560c68ea9c726b4c9"
   >
     <Credits>NASA/PSU; This X-ray image shows about a thousand X-ray emitting young stars in the Orion Nebula star cluster. The X rays are produced in ...</Credits>
@@ -45075,6 +45137,7 @@ insight into how the...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-220L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|220"
     Xcxstatus="in:657b1ef560c68ea9c726b4cb"
   >
     <Credits>NASA/GSFC (Mushotzky et al.); This Chandra X-ray Observatory image of a 27.7 hour observation of a region in the direction of the constellation Canes Venatici...</Credits>
@@ -45101,6 +45164,7 @@ insight into how the...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-229L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|229"
     Xcxstatus="in:657b1ef660c68ea9c726b4cd"
   >
     <Credits>NASA/CXC/UMass/Q.D.Wang et al.; Chandra's image reveals a complex of several multimillion degree Celsius gas clouds in the process of merging to form a massive ...</Credits>
@@ -45127,6 +45191,7 @@ insight into how the...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-239L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|239"
     Xcxstatus="in:6596ca6b293f0a574637028d"
   >
     <Credits>NASA/CXC; Beta Ceti is in an advanced stage of evolution called core helium burning. In this stage, the core of the star is very hot (more...</Credits>
@@ -45153,6 +45218,7 @@ insight into how the...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-240L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|240"
     Xcxstatus="in:6596ca6c293f0a574637028f"
   >
     <Credits>NASA/CXC/SAO/Rutgers/J.Hughes; The red, green, and blue regions in this Chandra X-ray image of the supernova remnant Cassiopeia A show where the intensity of l...</Credits>
@@ -45179,6 +45245,7 @@ insight into how the...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-241L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|241"
     Xcxstatus="in:65660692f864172823763dee"
   >
     <Credits>NASA/CXC/SAO; The explosion was seen on Earth in 1054 AD. At the center of the nebula is a rapidly spinning neutron star, or pulsar that emits...</Credits>
@@ -45205,6 +45272,7 @@ insight into how the...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-244L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|244"
     Xcxstatus="in:6596ca6c293f0a5746370291"
   >
     <Credits>NASA/CXC/SAO; The Chandra X-ray image of N132D shows a highly structured remnant, or shell, of 10 million degree Celsius gas that is 80 light ...</Credits>
@@ -45231,6 +45299,7 @@ insight into how the...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-245L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|245"
     Xcxstatus="in:6596ca6d293f0a5746370293"
   >
     <Credits>NASA/CXC/SAO; The Chandra X-ray image of Hydra A, a galaxy cluster 840 million light years from Earth, shows strands of 35-40 million degree C...</Credits>
@@ -45257,6 +45326,7 @@ insight into how the...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-246L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|246"
     Xcxstatus="in:6596ca6e293f0a5746370295"
   >
     <Credits>X-ray: NASA/SAO/CXC/M.Sun et al.; This image is a composite (X-ray, blue and optical, red &amp; green) of the galaxy UGC 6697. The X-rays reveal a sharp edge on the l...</Credits>
@@ -45283,6 +45353,7 @@ insight into how the...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-263L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|263"
     Xcxstatus="in:6596ca6f293f0a5746370297"
   >
     <Credits>NASA/CXC/SAO; The Chandra X-ray image shows the complex nature of the region around Eta Carinae, a massive supergiant star that is 7,500 light...</Credits>
@@ -45309,6 +45380,7 @@ insight into how the...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-275L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|275"
     Xcxstatus="in:6596ca70293f0a5746370299"
   >
     <Credits>NASA/CXC/U.Manitoba/H.Matheson &amp; S.Safi-Harb</Credits>
@@ -45335,6 +45407,7 @@ insight into how the...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-283L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|283"
     Xcxstatus="in:6596ca71293f0a574637029b"
   >
     <Credits>NASA/CXC/Penn State/E.Feigelson ; This Chandra image was produced by observing the Orion Nebula
@@ -45363,6 +45436,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-285L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|285"
     Xcxstatus="in:6596ca72293f0a574637029d"
   >
     <Credits>NASA/CXC/SAO; This X-ray image of the Cassiopeia A (Cas A) supernova remnant is the official first light image of the Chandra X-ray Observator...</Credits>
@@ -45389,6 +45463,7 @@ scie...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-286L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|286"
     Xcxstatus="in:6596ca72293f0a574637029f"
   >
     <Credits>NASA/CXC/SAO; PSR 0540-69 is a neutron star, or pulsar, that is rotating very rapidly, making a complete rotation every one-twentieth of a sec...</Credits>
@@ -45415,6 +45490,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-288L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|288"
     Xcxstatus="in:6596ca73293f0a57463702a2"
   >
     <Credits>NASA/CXC/SAO; NASA's Chandra X-ray Observatory image of the distant galaxy 3C295 shows an explosive galaxy enveloped by a vast cloud of fifty ...</Credits>
@@ -45441,6 +45517,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-289L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|289"
     Xcxstatus="in:6596ca74293f0a57463702a4"
   >
     <Credits>NASA/CXC/SAO; PKS 0637-72 is so distant that we see it as it was 6 billion years ago. It is a luminous quasar that radiates with the power of ...</Credits>
@@ -45467,6 +45544,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-290L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|290"
     Xcxstatus="in:6596ca75293f0a57463702a6"
   >
     <Credits>NASA/CXC/SAO</Credits>
@@ -45493,6 +45571,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-294L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|294"
     Xcxstatus="in:6596ca76293f0a57463702a8"
   >
     <Credits>X-ray: NASA/CXC/RIT/J.Kastner &amp; ; This composite X-ray (blue)/optical (red) image of NGC 40 shows hot gas around a dying, Sun-like star. Planetary nebulas get the...</Credits>
@@ -45519,6 +45598,7 @@ scie...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-295L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|295"
     Xcxstatus="in:65a699fe293f0a5746371336"
   >
     <Credits>X-ray: NASA/CXC/SAO; Optical: NASA/STScI; Infrared: NASA/JPL-Caltech/Steward/O.Krause et al.</Credits>
@@ -45545,6 +45625,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-301L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|301"
     Xcxstatus="in:65a699ff293f0a5746371338"
   >
     <Credits>NASA/CXC/PSU/L.Townsley et al; Chandra's image of Trumpler 14 shows about 1,600 stars and a diffuse glow from hot X-ray producing gas. The cluster has an unusu...</Credits>
@@ -45571,6 +45652,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-302L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|302"
     Xcxstatus="in:65a69a00293f0a574637133a"
   >
     <Credits>NASA/CXC/Rutgers/J.Warren &amp; J.Hu; The Chandra image shows a bubble of hot gaseous supernova debris (green and red) inside a more rapidly moving shell of extremely...</Credits>
@@ -45597,6 +45679,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-304L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|304"
     Xcxstatus="in:65a69a01293f0a574637133c"
   >
     <Credits>X-ray:  NASA/SAO/CXC;  Optical: ; This is a composite Chandra (X-ray/blue) and Hubble (optical/pink &amp; purple) of N132D. The beautiful glowing horseshoe-shaped clo...</Credits>
@@ -45623,6 +45706,7 @@ scie...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-308L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|308"
     Xcxstatus="in:65a69a02293f0a574637133e"
   >
     <Credits>NASA/CXC/IoA/A.Fabian et al.; An accumulation of 270 hours of Chandra observations reveals evidence of the turmoil that has wracked the central region of the ...</Credits>
@@ -45649,6 +45733,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-309L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|309"
     Xcxstatus="in:65a69a03293f0a5746371340"
   >
     <Credits>X-ray: NASA/CXC/U.Illinois/R.Wil; This is a composite X-ray (red and green)/optical (blue) image of two hot gas shells produced by supernova explosions. Although ...</Credits>
@@ -45701,6 +45786,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-312L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|312"
     Xcxstatus="in:65a69a05293f0a5746371344"
   >
     <Credits>NASA/CXC/Rutgers/J.Hughes et al.; Chandra's image of SN 1006 shows X-rays from multimillion degree gas (red/green) and high-energy electrons (blue). In the year 1...</Credits>
@@ -45727,6 +45813,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-314L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|314"
     Xcxstatus="in:65a69a06293f0a5746371346"
   >
     <Credits>Composite: NASA/JPL/Caltech/P.Ap; This image combines data from four different wavelengths of light: infrared (red), visible (green), ultraviolet (blue), and X-ra...</Credits>
@@ -45753,6 +45840,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-315L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|315"
     Xcxstatus="in:65a69a07293f0a5746371348"
   >
     <Credits>X-ray: NASA/CXC/U. Copenhagen/K.; Chandra's observation of the hot halo (blue) surrounding the optical disk (white) of NGC 5746 should help astronomers better und...</Credits>
@@ -45779,6 +45867,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-317L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|317"
     Xcxstatus="in:65d8c466affb32cbf1d96a2f"
   >
     <Credits>X-ray: NASA/CXC/U. Mass/Q.D.Wang; This X-ray/optical composite image shows multimillion degree gas (blue/X-ray) rising above the disk of stars and cooler gas (gra...</Credits>
@@ -45805,6 +45894,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-319L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|319"
     Xcxstatus="in:65d8c467affb32cbf1d96a31"
   >
     <Credits>X-ray: NASA/CXC/AIfA/D.Hudson &amp;; This composite X-ray/radio image of Abell 400 shows radio jets (pink), immersed in a vast cloud of multimillion degree X-ray emi...</Credits>
@@ -45831,6 +45921,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-320L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|320"
     Xcxstatus="in:65d8c468affb32cbf1d96a33"
   >
     <Credits>X-ray:  NASA/CXC/JHU/D.Stricklan; Images from three of NASA's Great Observatories were combined to create this spectacular, multiwavelength view of the starburst ...</Credits>
@@ -45857,6 +45948,7 @@ scie...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-321L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|321"
     Xcxstatus="in:65d8c46aaffb32cbf1d96a35"
   >
     <Credits>X-ray: NASA/CXC/KIPAC/S.Allen et; This composite image shows a vast cloud of hot gas (X-ray/red), surrounding high-energy bubbles (radio/blue) on either side of t...</Credits>
@@ -45909,6 +46001,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-324L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|324"
     Xcxstatus="in:65d8c46caffb32cbf1d96a39"
   >
     <Credits>NASA/UMass/Z.Li &amp; Q.D.Wang; This color-coded Chandra image (red/low energy, green/medium energy, and blue/high energy X-rays) shows the central region of th...</Credits>
@@ -45935,6 +46028,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-330L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|330"
     Xcxstatus="in:65d8c46caffb32cbf1d96a3b"
   >
     <Credits>X-ray: NASA/CXC/CfA/M.Markevitch; This composite image shows the galaxy cluster 1E 0657-56, also known as the
@@ -45962,6 +46056,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-333L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|333"
     Xcxstatus="in:65d8c46daffb32cbf1d96a3d"
   >
     <Credits>NASA/CXC/Penn State/L.Townsley e; Chandra's image of NGC 3576 (lower-energy X-rays in red, higher-energy X-rays in blue) reveals a cluster of point-like X-ray sou...</Credits>
@@ -45988,6 +46083,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-334L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|334"
     Xcxstatus="in:65d8c46eaffb32cbf1d96a3f"
   >
     <Credits>X-ray: NASA/CXC/CfA/W.Forman et ; A long Chandra exposure of M87 has revealed a shock wave in high-energy X-rays as well as evidence for a series of outbursts fro...</Credits>
@@ -46014,6 +46110,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-335L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|335"
     Xcxstatus="in:65660693f864172823763df0"
   >
     <Credits>X-ray: NASA/CXC/ASU/J.Hester et ; The supernova that produced the Crab Nebula was detected by naked-eye observers around the world in 1054 A.D. This composite ima...</Credits>
@@ -46040,6 +46137,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-336L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|336"
     Xcxstatus="in:65dccfebaffb32cbf1d96f90"
   >
     <Credits>X-ray: NASA/CXC/Univ. Waterloo/B; This composite image contains three views of the galaxy cluster MS 0735.6+7421. The optical view from the Hubble Space Telescope...</Credits>
@@ -46066,6 +46164,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-337L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|337"
     Xcxstatus="in:65dccfecaffb32cbf1d96f92"
   >
     <Credits>NASA/CXC/MIT/UMass Amherst/M.D.S; New analysis of an extraordinarily deep Chandra image of Cassiopeia A shows that this supernova remnant accelerates electrons to...</Credits>
@@ -46092,6 +46191,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-338L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|338"
     Xcxstatus="in:65dccfecaffb32cbf1d96f94"
   >
     <Credits>X-ray: NASA/CXC/Caltech/S.Kulkar; In Chandra's X-ray data, N49 shows million-degree gas in its center (blue), while Spitzer reveals much cooler, infrared-emitting...</Credits>
@@ -46118,6 +46218,7 @@ scie...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-339L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|339"
     Xcxstatus="in:65dccfedaffb32cbf1d96f96"
   >
     <Credits>X-ray:  NASA/CXC/Penn State/L.To; In this composite image of one of the many star-forming complexes of W3, the Chandra data are shown in green and blue (lower and...</Credits>
@@ -46144,6 +46245,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-343L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|343"
     Xcxstatus="in:65dccfeeaffb32cbf1d96f98"
   >
     <Credits>NASA/CXC/NCSU/S.Reynolds et al.; A long Chandra observation of the Kepler supernova remnant provides unprecedented detail of one of the youngest supernovas in th...</Credits>
@@ -46170,6 +46272,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-344L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|344"
     Xcxstatus="in:65dccfefaffb32cbf1d96f9a"
   >
     <Credits>NASA/CXC/Eureka Scientific/M.Rob;  G11.2-0.3 is a circularly symmetric supernova remnant that contains a dense, rotating dead star at its center, representing a t...</Credits>
@@ -46196,6 +46299,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-345L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|345"
     Xcxstatus="in:65dccff0affb32cbf1d96f9c"
   >
     <Credits>X-ray: NASA/CXC/U.Colorado/Linsk; A composite image of the Eagle Nebula (M16) with NASA's Chandra X-ray Observatory and the Hubble Space Telescope penetrates the ...</Credits>
@@ -46222,6 +46326,7 @@ scie...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-346L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|346"
     Xcxstatus="in:65dccff1affb32cbf1d96f9e"
   >
     <Credits>X-ray: NASA/CXC/PSU/S.Park &amp; D.B; This composite image of Supernova 1987A shows the effects of a powerful shock wave moving away from the explosion. Bright spots ...</Credits>
@@ -46248,6 +46353,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-348L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|348"
     Xcxstatus="in:65dccff1affb32cbf1d96fa0"
   >
     <Credits>X-ray: NASA/CXC/CfA/R.Hickox et ; This panorama is the largest contiguous field ever obtained by the Chandra X-ray Observatory. These data, when combined with inf...</Credits>
@@ -46274,6 +46380,7 @@ scie...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-349L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|349"
     Xcxstatus="in:65e5f0e2affb32cbf1d97cee"
   >
     <Credits>X-ray: NASA/CXC/Univ. of Bristol; X-ray data from NASA's Chandra X-ray Observatory and radio observations from the NSF's Very Large Array show that a role reversa...</Credits>
@@ -46404,6 +46511,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-359L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|359"
     Xcxstatus="in:66070803dc7be96c90c533fd"
   >
     <Credits>X-ray: NASA/CXC/GSFC/M.Corcoran; This composite image of Eta Carinae from NASA's Chandra X-ray Observatory and Hubble Space Telescope shows the remnants of a mas...</Credits>
@@ -46430,6 +46538,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-361L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|361"
     Xcxstatus="in:66070804dc7be96c90c533ff"
   >
     <Credits>NASA/CXC/Penn State/G.Garmire et; Chandra's X-ray image of RCW 103 shows the debris left behind when a star at least 8 times more massive than the Sun exploded at...</Credits>
@@ -46482,6 +46591,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-368L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|368"
     Xcxstatus="in:66070806dc7be96c90c53403"
   >
     <Credits>X-ray: NASA/CXC/UVic./A.Mahdavi et al. Optical/Lensing: CFHT/UVic./A.Mahdavi et al.</Credits>
@@ -46508,6 +46618,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-369L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|369"
     Xcxstatus="in:66070807dc7be96c90c53405"
   >
     <Credits>NASA/CXC/UIUC/R.Williams et al.;; With its millions of stars and relatively close proximity, the Small Magellanic Cloud offers astronomers a chance to study pheno...</Credits>
@@ -46560,6 +46671,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-371L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|371"
     Xcxstatus="in:66070809dc7be96c90c53409"
   >
     <Credits>X-ray: NASA/CXC/MSU/M.Sun et al; H-alpha/Optical: SOAR (MSU/NOAO/UNC/CNPq-Brazil)/M.Sun et al.</Credits>
@@ -46586,6 +46698,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-376L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|376"
     Xcxstatus="in:6607080adc7be96c90c5340b"
   >
     <Credits>X-ray: NASA/CXC/Penn State/S.Par; G292.0+1.8 is a young supernova remnant located in our galaxy. This deep Chandra image shows a spectacularly detailed, rapidly e...</Credits>
@@ -46612,6 +46725,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-378L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|378"
     Xcxstatus="in:6607080bdc7be96c90c5340d"
   >
     <Credits>X-ray: NASA/CXC/CfA/S.Wolk et al; A composite image of X-ray (purple) and optical data of NGC
@@ -46639,6 +46753,7 @@ scie...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-380L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|380"
     Xcxstatus="in:6607080cdc7be96c90c5340f"
   >
     <Credits>X-ray: NASA/CXC/Wesleyan Univ./R; A composite image of M51, also known as the
@@ -46667,6 +46782,7 @@ Chandra finds point-like X-ray sou...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-381L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|381"
     Xcxstatus="in:6607080ddc7be96c90c53411"
   >
     <Credits>X-ray: NASA/CXC/CfA/D.Evans et al.; Optical/UV: NASA/STScI; Radio: NSF/VLA/CfA/D.Evans et al., STFC/JBO/MERLIN</Credits>
@@ -46693,6 +46809,7 @@ Chandra finds point-like X-ray sou...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-382L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|382"
     Xcxstatus="in:661fef50befbe21fbdf49b71"
   >
     <Credits>NASA/CXC/CfA/R.Kraft et al.</Credits>
@@ -46719,6 +46836,7 @@ Chandra finds point-like X-ray sou...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-384L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|384"
     Xcxstatus="in:661fef51befbe21fbdf49b73"
   >
     <Credits>NASA/CXC/Univ. de Liège/Y. Naze; This Chandra X-ray Observatory image shows Westerlund 2, a young star cluster with an estimated age of about one or two million ...</Credits>
@@ -46745,6 +46863,7 @@ Chandra finds point-like X-ray sou...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-385L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|385"
     Xcxstatus="in:661fef52befbe21fbdf49b75"
   >
     <Credits> X-ray: NASA/CXC/Penn State/G. G; This image of the elliptical galaxy NGC 1132 and its surrounding region combines data from NASA's Chandra X-ray Observatory and ...</Credits>
@@ -46771,6 +46890,7 @@ Chandra finds point-like X-ray sou...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-387L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|387"
     Xcxstatus="in:661fef53befbe21fbdf49b77"
   >
     <Credits>NASA/CXC/GSFC/F.P.Gavriil et al.; A deep Chandra X-ray Observatory image shows the supernova remnant Kes 75 that was created when a massive star exploded.  The pu...</Credits>
@@ -46797,6 +46917,7 @@ Chandra finds point-like X-ray sou...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-388L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|388"
     Xcxstatus="in:661fef54befbe21fbdf49b79"
   >
     <Credits>NASA/CXC/NCSU/K.J.Borkowski et a; The supernova remnant (SNR) N132D is the brightest in the Large Magellanic Cloud, and it belongs to a rare class of oxygen-rich ...</Credits>
@@ -46823,6 +46944,7 @@ Chandra finds point-like X-ray sou...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-397L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|397"
     Xcxstatus="in:661fef55befbe21fbdf49b7b"
   >
     <Credits>X-ray: NASA/CXC/Rutgers/G.Cassam; This is a composite image of the SN 1006 supernova remnant, which is located about 7000 light years from Earth. Shown here are X...</Credits>
@@ -46849,6 +46971,7 @@ Chandra finds point-like X-ray sou...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-398L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|398"
     Xcxstatus="in:661fef56befbe21fbdf49b7d"
   >
     <Credits>X-ray (NASA/CXC/Univ. of Califor; A composite image of data from NASA's Chandra X-ray Observatory (shown in purple) and Hubble Space Telescope (blue) shows the gi...</Credits>
@@ -46875,6 +46998,7 @@ Chandra finds point-like X-ray sou...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-399L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|399"
     Xcxstatus="in:661fef57befbe21fbdf49b7f"
   >
     <Credits>X-ray: NASA/CXC/SAO; Optical: NA; A composite image of data from NASA’s Chandra X-ray Observatory (blue) and Hubble Space Telescope (red and purple) of NGC 6543 s...</Credits>
@@ -46901,6 +47025,7 @@ Chandra finds point-like X-ray sou...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-402L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|402"
     Xcxstatus="in:661fef57befbe21fbdf49b81"
   >
     <Credits>X-ray(NASA/CXC/Stanford/S.Allen); This image shows a system where two massive galaxy clusters have collided and in doing so have forced the separation between dar...</Credits>
@@ -46927,6 +47052,7 @@ Chandra finds point-like X-ray sou...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-403L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|403"
     Xcxstatus="in:661fef58befbe21fbdf49b83"
   >
     <Credits>X-ray: NASA/CXC/MIT/E.-H Peng et; This image of Abell 1689 is a composite of data from the Chandra X-ray Observatory (purple) and the Hubble Space Telescope (yell...</Credits>
@@ -46953,6 +47079,7 @@ Chandra finds point-like X-ray sou...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-404L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|404"
     Xcxstatus="in:661fef59befbe21fbdf49b85"
   >
     <Credits>X-ray (NASA/CXC/Columbia/F.Bauer; This composite image shows the central regions of the nearby Circinus galaxy, located about 12 million light years away. Data fr...</Credits>
@@ -46979,6 +47106,7 @@ Chandra finds point-like X-ray sou...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-405L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|405"
     Xcxstatus="in:661fef5abefbe21fbdf49b87"
   >
     <Credits>X-ray: NASA/CXC/CfA/S.Wolk et al; In Chandra’s X-ray image (blue) of RCW 108, over 400 sources of X-ray light are seen. Many of these X-ray sources are young star...</Credits>
@@ -47005,6 +47133,7 @@ Chandra finds point-like X-ray sou...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-406L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|406"
     Xcxstatus="in:661fef5bbefbe21fbdf49b89"
   >
     <Credits>X-ray (NASA/CXC/INAF/G.Brunetti ; A composite image of X-ray data from Chandra (colored blue) and radio emission from the Giant Meterwave Radio Telescope (orange)...</Credits>
@@ -47031,6 +47160,7 @@ Chandra finds point-like X-ray sou...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-407L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|407"
     Xcxstatus="in:661fef5cbefbe21fbdf49b8b"
   >
     <Credits>X-ray: NASA/CXC/CfA/M.Markevitch; This view of the Bullet Cluster is a combination of X-rays from Chandra (red) and optical data from the Hubble and Magellan tele...</Credits>
@@ -47057,6 +47187,7 @@ Chandra finds point-like X-ray sou...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-408L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|408"
     Xcxstatus="in:65660694f864172823763df2"
   >
     <Credits>NASA/CXC/SAO/F.Seward et al; In the Crab Nebula, a rapidly rotating neutron star, or pulsar (white dot near the center),
@@ -47084,6 +47215,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-409L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|409"
     Xcxstatus="in:661fef5dbefbe21fbdf49b8d"
   >
     <Credits>X-ray (NASA/CXC/MPE/A.Finoguenov; This is a composite image of M84 with X-ray data from Chandra (blue) and radio emission from the Very Large Array (red) overlaid...</Credits>
@@ -47110,6 +47242,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-410L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|410"
     Xcxstatus="in:661fef5ebefbe21fbdf49b8f"
   >
     <Credits>NASA/CXC/JHU/K.Kuntz et al.; This Chandra image of M101 is one of the longest exposures ever obtained of a spiral galaxy in X-rays. The point-like sources in...</Credits>
@@ -47136,6 +47269,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-418L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|418"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO, Infrared: N; This composite image of the Tycho supernova remnant combines X-ray and infrared observations obtained with NASA's Chandra and Sp...</Credits>
@@ -47162,6 +47296,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-421L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|421"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/Harvard/J.Neilse; The inset of this graphic shows Chandra's X-ray image of GRS 1915+105 in context of a crowded field seen in optical and infrared...</Credits>
@@ -47188,6 +47323,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-425L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|425"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/CfA/F.Massaro, e; This composite image of X-ray (red), radio (dark blue), and optical (light blue) data shows activity from the central black hole...</Credits>
@@ -47214,6 +47350,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-427L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|427"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/Penn State/S.Par; A new composite image from NASA's Chandra X-ray Observatory (purple) and Spitzer Space Telescope (red and green) shows a superno...</Credits>
@@ -47240,6 +47377,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-430L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|430"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/CfA/E.O'Sullivan; This composite image of X-rays from Chandra (colored light blue) and optical data from the Canada-France-Hawaii Telescope (yello...</Credits>
@@ -47266,6 +47404,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-431L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|431"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/MIT/D.Dewey et a; This composite image of X-rays from Chandra and optical data from Hubble shows new details of the aftermath of a massive star th...</Credits>
@@ -47292,6 +47431,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-432L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|432"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/PSU/K. Getman et; This composite image of X-rays from Chandra (violet) and infrared data from Spitzer (red, green, and blue) reveals a beautiful s...</Credits>
@@ -47318,6 +47458,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-434L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|434"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/U.Waterloo/C.Kir; This composite image of the Hydra A galaxy cluster shows 10-million-degree gas observed by Chandra (blue) and jets of radio emis...</Credits>
@@ -47344,6 +47485,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-436L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|436"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/MIT/C.Canizares,; NGC 6240 is a system in which two supermassive black holes are a mere 3,000 light years apart. These black holes (the two bright...</Credits>
@@ -47370,6 +47512,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-437L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|437"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/INAF/S.Andreon e; This is a composite image of the most distant galaxy cluster yet detected. This image contains X-rays from NASA's Chandra X-ray ...</Credits>
@@ -47396,6 +47539,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-438L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|438"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Southampton/W. H; New evidence from Chandra suggests that the neutron star at the center of the Cas A supernova remnant has an ultra-thin carbon a...</Credits>
@@ -47422,6 +47566,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-441L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|441"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/M.Machacek;; This composite image of a collision between two galaxies, NGC 6872 and IC 4970, contains X-rays from Chandra (purple), infrared ...</Credits>
@@ -47448,6 +47593,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-443L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|443"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/UA/J. Irwin et a; X-rays from Chandra and optical spectra from the Magellan telescopes provide evidence that a star was destroyed a black hole in ...</Credits>
@@ -47474,6 +47620,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-444L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|444"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/MIT/F.K. Baganoff et al; This Chandra image of Sgr A* and the region around it was based on almost two weeks of observing time.  A theoretical model base...</Credits>
@@ -47500,6 +47647,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-445L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|445"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/UVa/M. Sun, et a; This composite image of X-rays (blue) and optical and hydrogen light (yellow and red) shows two spectacular tails stretching beh...</Credits>
@@ -47526,6 +47674,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-446L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|446"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/SAO/P. Green et ; This composite image shows the effects of two galaxies caught in the act of merging. A Chandra X-ray Observatory image shows a p...</Credits>
@@ -47552,6 +47701,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-447L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|447"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/MPA/M.Gilfanov &amp;; This composite image of M31 (a.k.a. the Andromeda galaxy) contains X-rays from Chandra (gold), optical emission (light blue), an...</Credits>
@@ -47578,6 +47728,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-448L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|448"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/MIT/C.Canizares,; This composite image (X-rays from Chandra in red, optical data in green, and radio emission in blue) shows NGC 1068, one of the ...</Credits>
@@ -47604,6 +47755,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-449L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|449"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray:  NASA/CXC/SAO/T.Temim et; A composite image from Chandra (blue) and Spitzer (green and red-yellow) data shows the dusty remains of a collapsed star.  The ...</Credits>
@@ -47630,6 +47782,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-450L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|450"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/SAO/A. Vikhlinin; This composite image of the galaxy cluster Abell 3376 combines Chandra and ROSAT X-ray data (gold), an optical image from the Di...</Credits>
@@ -47656,6 +47809,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-453L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|453"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: (NASA/CXC/Penn State/S.Pa; This composite image of data from Chandra (blue) and Hubble (yellow and purple) depicts the scene of a supernova explosion's aft...</Credits>
@@ -47682,6 +47836,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-454L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|454"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/SAO/Li et al.),; The large image here shows an optical view, with the Digitized Sky Survey, of the Andromeda Galaxy, otherwise known as M31. The ...</Credits>
@@ -47708,6 +47863,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-455L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|455"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/M.Karovska e; The inset box in this graphic contains a composite image of X-ray data from Chandra (red), optical data from the Hubble Space Te...</Credits>
@@ -47734,6 +47890,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-456L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|456"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/F.Civano et ; Evidence for a recoiling black hole has been found using data from Chandra (colored blue in this composite image), Hubble (gold)...</Credits>
@@ -47760,6 +47917,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-457L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|457"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/Univ of Strasbou; Combined data from Chandra (red, green, and blue) as well as optical light (light blue) and hydrogen emission (gold) reveals a m...</Credits>
@@ -47786,6 +47944,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-458L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|458"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/UMD/Hodges-Kluck; The close-up view in the inset shows a composite image of the galaxy 4C +00.58 in X-rays from Chandra (gold) and radio waves fro...</Credits>
@@ -47812,6 +47971,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-459L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|459"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/J.DePasquale; This composite image of the Antennae galaxies contains X-rays from Chandra (blue), optical data from Hubble (gold and brown), an...</Credits>
@@ -47838,6 +47998,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-460L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|460"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/KIPAC/N. Werner,; This composite image shows the eruption of a galactic "super-volcano" in the galaxy M87.  X-rays from Chandra (blue) show the cl...</Credits>
@@ -47864,6 +48025,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-461L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|461"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/SAO/M.Markevitch; This is a composite image of the northern part of the galaxy cluster Abell 1758 showing the effects of a collision between two s...</Credits>
@@ -47890,6 +48052,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-462L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|462"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/SAO/J. Wang et a; This X-ray and optical image shows the Rosette star formation region, located about 5,000 light years from Earth. The Chandra X-...</Credits>
@@ -47916,6 +48079,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-463L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|463"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/RIT/J.Kastner et al), Optical (UCO/Lick/STScI/M.Perrin et al); Illustration: NASA/CXC/M.Weiss</Credits>
@@ -47942,6 +48106,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-464L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|464"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/T.Temim et a; G327.1-1.1 is the aftermath of a massive star that exploded and left behind a highly magnetic, rapidly spinning neutron star cal...</Credits>
@@ -47968,6 +48133,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-466L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|466"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/A.Siemiginowska et al, Optical: AURA/Gemini Obs.</Credits>
@@ -47994,6 +48160,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-467L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|467"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/D.Patnaude et al, Optical: ESO/VLT, Infrared: NASA/JPL/Caltech</Credits>
@@ -48020,6 +48187,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-468L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|468"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/S.Randall et; This composite image shows an intergalactic "weather map" around the elliptical galaxy NGC 5813. Just like a weather map for Ear...</Credits>
@@ -48046,6 +48214,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-469L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|469"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/J.Hughes et ; This composite image contains X-ray data from Chandra (green and blue) that show heated material in the center of a shell genera...</Credits>
@@ -48072,6 +48241,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-470L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|470"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Northwestern Univ/D.Haggard et al, Optical: SDSS</Credits>
@@ -48098,6 +48268,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-471L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|471"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/Wesleyan/R.Kilgard et a; M82 is a galaxy where stars are forming at rates that are tens or even hundreds of times higher than in a normal galaxy. In this...</Credits>
@@ -48150,6 +48321,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-473L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|473"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/Virginia/A.Reine; Combined observations from Chandra (purple), the Very Large Array (yellow) along with Hubble (red, green, and blue) have provide...</Credits>
@@ -48176,6 +48348,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-474L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|474"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/MIT/S.Rappaport et al, Optical: NASA/STScI</Credits>
@@ -48202,6 +48375,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-476L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|476"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/UNAM/Ioffe/D.Page,P.Shternin et al; Optical: NASA/STScI; Illustration: NASA/CXC/M.Weiss</Credits>
@@ -48228,6 +48402,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-477L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|477"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/CfA/J.Wang et al.; Optical: Isaac Newton Group of Telescopes, La Palma/Jacobus Kapteyn Telescope, Radio: NSF/NRAO/VLA</Credits>
@@ -48254,6 +48429,7 @@ powers the dramatic activity seen by...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-478L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|478"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Rutgers/K.Erikse; A long Chandra observation of Tycho has revealed a pattern
@@ -48282,6 +48458,7 @@ s...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-479L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|479"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/Warwick/A.Levan et al.; The center of this image contains an extraordinary gamma-ray burst (GRB 110328A) observed with Chandra. The burst was first seen...</Credits>
@@ -48308,6 +48485,7 @@ s...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-480L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|480"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/U. of Sydney/G.Ander; Data from Chandra and Spitzer of a region near the Galactic
@@ -48336,6 +48514,7 @@ h...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-481L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|481"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/Chinese Academy of Scie; This Chandra image of the Tycho supernova remnant contains new evidence for what triggered the original supernova explosion.  Ty...</Credits>
@@ -48362,6 +48541,7 @@ h...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-482L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|482"
     Xcxstatus="in:65660694f864172823763df4"
   >
     <Credits>NASA/CXC/MSFC/M.Weisskopf et al; This image represents a sequence of Chandra observations of the Crab Nebula taken from September 2010 through April 2011.  Durin...</Credits>
@@ -48388,6 +48568,7 @@ h...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-483L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|483"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/PSU/L.Townsley et al.</Credits>
@@ -48414,6 +48595,7 @@ h...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-484L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|484"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/U.Hawaii/E.Treis; This composite image combines the deepest X-ray image ever taken with optical and infrared data from Hubble.  Astronomers obtain...</Credits>
@@ -48440,6 +48622,7 @@ h...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-485L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|485"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/ITA/INAF/J.Merte; This composite image features one of the most complicated and dramatic collisions between galaxy clusters ever seen.   Known off...</Credits>
@@ -48466,6 +48649,7 @@ h...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-486L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|486"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/IUSS/A.De Luca e; Astronomers using Chandra have found evidence for a possible long, X- ray bright tail extending from the pulsar called PSR J0357...</Credits>
@@ -48492,6 +48676,7 @@ h...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-487L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|487"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Univ. of Alabama; This composite image contains X-rays from Chandra (blue) and optical data from the VLT (gold) of the galaxy NGC 3115.  Using the...</Credits>
@@ -48518,6 +48703,7 @@ h...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-488L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|488"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray NASA/CXC/IfA/D.Sanders et ; This composite image of VV 340 contains X-ray data from Chandra (purple)
@@ -48545,6 +48731,7 @@ and optical data from Hubble (red, green, blue). The tw...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-489L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|489"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/G.Fabbiano e; Evidence for a pair of supermassive black holes in a spiral
@@ -48572,6 +48759,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-491L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|491"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/CfA/S.Wolk; IR: ; This composite image of NGC 281 contains X-ray data from Chandra (purple) with infrared observations from Spitzer (red, green, b...</Credits>
@@ -48598,6 +48786,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-492L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|492"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/U. Texas at Arlington/S.Park et al, ROSAT; Infrared: 2MASS/UMass/IPAC-Caltech/NASA/NSF</Credits>
@@ -48624,6 +48813,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-494L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|494"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/JPL-Caltech/B. Williams (NC; This image combines data from four different space telescopes to create a multi-wavelength view of all that remains of the oldes...</Credits>
@@ -48650,6 +48840,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-495L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|495"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/PSU/L.Townsley e; About 2,400 massive stars in the center of 30 Doradus are producing intense radiation and powerful winds as they blow off materi...</Credits>
@@ -48676,6 +48867,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-497L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|497"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/BU/E.Blanton; Optical: ESO/VLT</Credits>
@@ -48702,6 +48894,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-498L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|498"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray &amp; Optical: NASA/CXC/Univ.P; In this composite image, X-rays from Chandra and XMM-Newton (blue) have been combined with optical data from the Cerro Tololo In...</Credits>
@@ -48728,6 +48921,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-499L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|499"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Rutgers/J.Hughes; This galaxy cluster, which has been nicknamed "El Gordo" for the "big" or "fat" one in Spanish, is a remarkable object.  Found i...</Credits>
@@ -48754,6 +48948,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-500L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|500"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/I.Lovchinsky; G350.1+0.3 is a young and exceptionally bright supernova remnant in our Galaxy.  While many supernova remnants are nearly circul...</Credits>
@@ -48780,6 +48975,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-501L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|501"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/MIT/F. Baganoff ; A new study provides a possible explanation of mysterious X-ray flares detected by Chandra over the period of several years.  It...</Credits>
@@ -48806,6 +49002,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-503L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|503"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA, ESA, CFHT, CXO, M.J. Jee (; This composite image shows the distribution of dark matter, galaxies, and hot gas in the core of the merging galaxy cluster Abel...</Credits>
@@ -48832,6 +49029,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-504L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|504"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Caltech/A.Newman; Two teams of astronomers have used data from Chandra and other telescopes to map the distribution of dark matter in three dimens...</Credits>
@@ -48884,6 +49082,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-506L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|506"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/UCDavis/W.Dawson; This composite image shows Chandra (red) and Hubble (yellow and white) data of the galaxy cluster system that has been nicknamed...</Credits>
@@ -48910,6 +49109,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-507L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|507"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/PSU/L.Townsley e; This composite of 30 Doradus, aka the Tarantula Nebula, contains data from Chandra (blue), Hubble (green), and Spitzer (red).  L...</Credits>
@@ -48936,6 +49136,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-511L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|511"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Royal Military C; This composite image shows the galaxy UGC 5189A in X-ray data from Chandra (purple) and optical data from Hubble (red, green and...</Credits>
@@ -48962,6 +49163,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-512L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|512"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/JPL-Caltech/ESA/CfA; This composite image of M101 (aka, the "Pinwheel Galaxy") combines data from four of NASA's space-based telescopes.  X-rays from...</Credits>
@@ -48988,6 +49190,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-513L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|513"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/F.Civano et ; Chandra and other telescopes have shown that the galaxy CID-42 likely contains a massive black hole being ejected at several mil...</Credits>
@@ -49014,6 +49217,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-515L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|515"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/UC Berkeley/J.To; Using Chandra, XMM-Newton, and the Parkes radio telescope, researchers have found evidence for what may be the fastest moving pu...</Credits>
@@ -49040,6 +49244,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-518L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|518"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/STScI/K.Long et ; Using Chandra, astronomers have detected X-rays from the remains of a supernova that was spotted from Earth over 50 years ago.  ...</Credits>
@@ -49092,6 +49297,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-520L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|520"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/U.Mich./S.Oey, I; The star cluster NGC 1929 contains massive stars that produce intense radiation, expel matter at high speeds, and race through t...</Credits>
@@ -49118,6 +49324,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-521L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|521"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/D.Patnaude, ; This composite image of Kepler's supernova remnant shows different colors ranging from lower to higher energies: red, yellow, gr...</Credits>
@@ -49144,6 +49351,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-524L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|524"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/George Mason Uni; One of the lowest mass supermassive black holes ever observed in the middle of a galaxy has been identified, thanks to NASA's Ch...</Credits>
@@ -49170,6 +49378,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-525L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|525"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/J.Drake et a; This composite image of the star cluster Cygnus OB2 contains X-rays from Chandra (blue), infrared data from Spitzer (red), and o...</Credits>
@@ -49196,6 +49405,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-526L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|526"
     Xcxstatus="queue:chandra"
   >
     <Credits>Inset X-ray (NASA/CXC/IAA-CSIC/M; The inset image on the right is a close-up view of A30 showing X-ray data from NASA's Chandra X-ray Observatory in purple and Hu...</Credits>
@@ -49222,6 +49432,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-527L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|527"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/NRC/C.Cheung et ; This composite image shows GB 1428+4217, a quasar that contains the most distant X-ray jet ever observed.  This view contains X-...</Credits>
@@ -49248,6 +49459,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-528L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|528"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/SAO/A.Prestwich ; NGC 922 was formed by the collision between two galaxies one seen in this composite image (where X-rays from Chandra are red and...</Credits>
@@ -49274,6 +49486,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-529L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|529"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/Ohio State Univ./C.Grie; This multiwavelength image of the galaxy NGC 3627 contains X-rays from Chandra (blue), infrared data from Spitzer (red), and opt...</Credits>
@@ -49300,6 +49513,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-531L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|531"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/Univ of Toronto/M.Duran; This deep image from NASA's Chandra X-ray Observatory shows the Vela pulsar, a neutron star that was formed when a massive star ...</Credits>
@@ -49326,6 +49540,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-532L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|532"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Univ of Michigan; DEM L50 (a.k.a. N186) is what astronomers call a superbubble.  These objects are found in regions where massive stars have forme...</Credits>
@@ -49352,6 +49567,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-533L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|533"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/MIT/L.Lopez et a; This highly distorted supernova remnant may contain the most recent black hole formed in the Milky Way galaxy. The composite ima...</Credits>
@@ -49378,6 +49594,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-534L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|534"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/Michigan State/A.Steine; New results from Chandra and other X-ray telescopes have provided one of the most reliable determinations yet of the relation be...</Credits>
@@ -49404,6 +49621,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-535L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|535"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Univ of Michigan; The previously unknown remains of a shattered star have been found by NASA's Swift satellite.  A follow-up Chandra observation h...</Credits>
@@ -49430,6 +49648,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-536L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|536"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/NCSU/M.Burkey et; Over 400 years ago, Johannes Kepler and many others witnessed the appearance of a new "star" in the sky. Today, this object is k...</Credits>
@@ -49456,6 +49675,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-537L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|537"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Univ.Potsdam/L.O; New Chandra observations have been used to make the first detection of X-ray emission from young stars with masses similar to ou...</Credits>
@@ -49508,6 +49728,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-539L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|539"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/SAO/E.Nardini et; Scientists have used Chandra to make a detailed study of an enormous cloud of hot gas enveloping two large, colliding galaxies i...</Credits>
@@ -49534,6 +49755,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-540L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|540"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/A.Siemiginow; The intense gravity of a supermassive black hole can be tapped to produce immense power in the form of jets moving at millions o...</Credits>
@@ -49560,6 +49782,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-542L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|542"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/SAO/R.Barnard, Z; Twenty-six black hole candidates - the largest number found in a galaxy outside our own - have been discovered in the Milky Way'...</Credits>
@@ -49586,6 +49809,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-543L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|543"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/NCSU/K.Borkowski; A new Chandra observation is providing important details about the most recent supernova known to have exploded in the Milky Way...</Credits>
@@ -49612,6 +49836,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-544L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|544"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/IAA-CSIC/N.Ruiz ; When a star like our Sun uses up all of the hydrogen in its core, it becomes what is called a "planetary nebula."  During this s...</Credits>
@@ -49638,6 +49863,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-546L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|546"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Huntingdon Inst.; A massive multimillion-degree cloud of gas has been revealed in X-ray data from Chandra (purple) that have been combined with op...</Credits>
@@ -49664,6 +49890,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-547L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|547"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/UMass/D.Wang et al.,; One of the biggest observing campaigns ever performed by Chandra has provided new understanding into why gas near the giant blac...</Credits>
@@ -49690,6 +49917,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-548L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|548"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/F.Seward et ; This composite image contains data from Chandra (purple) that provides evidence for the survival of a companion star from the bl...</Credits>
@@ -49716,6 +49944,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-549L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|549"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/MPE/J.Sanders et; Enormous arms of hot gas have been revealed in the Coma galaxy cluster in data from NASA's Chandra X-ray Observatory and ESA's X...</Credits>
@@ -49742,6 +49971,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-550L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|550"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/MSU/J.Strader et; The densest galaxy in the nearby Universe may have been found. The galaxy, known as M60-UCD1, is located near a massive elliptic...</Credits>
@@ -49768,6 +49998,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-551L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|551"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/ICE/A.Papitto et; These two images from NASA's Chandra X-ray Observatory show a large change in X-ray brightness of a rapidly rotating neutron sta...</Credits>
@@ -49794,6 +50025,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-552L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|552"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/APC/Universite Paris Di; Researchers have found evidence that the normally dim region very close to the supermassive black hole at the center of the Milk...</Credits>
@@ -49872,6 +50104,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-554eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|554a,chandra|554b,chandra|554c,chandra|554d,chandra|554e,chandra|554f,chandra|554g,chandra|554h"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/SAO; This collection of images represents the thousands of observations that are permanently stored and accessible to the world in th...</Credits>
@@ -49898,6 +50131,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-556L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|556"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/UCLA/Z.Li et al;; New evidence has been uncovered for the presence of a jet of high-energy particles blasting out of the Milky Way's supermassive ...</Credits>
@@ -49924,6 +50158,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-557L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|557"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Univ. of Wiscons; The youngest member of an important class of objects called X-ray binaries has been found using data from Chandra (blue) and the...</Credits>
@@ -49950,6 +50185,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-559L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|559"
     Xcxstatus="queue:chandra"
   >
     <Credits>redit: X-ray: NASA/CXC/Univ. of Alabama/W.P.Maksym et al &amp; NASA/CXC/GSFC/UMD/D.Donato, et al; Optical: CFHT.</Credits>
@@ -49976,6 +50212,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-560L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|560"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Stanford/J.Hlava; Astronomers have used NASA's Chandra X-ray Observatory and other telescopes to reveal one of the most powerful black holes known...</Credits>
@@ -50002,6 +50239,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-561L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|561"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/U.Birmingham/M.B; Centaurus A is a galaxy well known for a gargantuan jet blasting away from a central supermassive black hole, which is seen in t...</Credits>
@@ -50028,6 +50266,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-562L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|562"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/ISDC/L.Pavan et ; An extraordinary jet trailing behind a runaway pulsar is seen in this composite image that contains X-ray data from Chandra (pur...</Credits>
@@ -50054,6 +50293,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-563L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|563"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Univ of Michigan; Multiple images of a distant quasar known as RX J1131-1231 are visible in this combined view from Chandra (pink) and Hubble (red...</Credits>
@@ -50080,6 +50320,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-564L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|564,chandra|811c"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/UAH/M.Sun et al;; This image combines NASA/ESA Hubble Space Telescope observations with data from the Chandra X-ray Observatory. As well as the el...</Credits>
@@ -50106,6 +50347,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-565L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|565,chandra|809"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA, ESA, J. Jee (Univ. of California, Davis), J. Hughes (Rutgers Univ.), F. Menanteau (Rutgers Univ. &amp; Univ. of Illinois, Urbana-Champaign), C. Sifon (Leiden Obs.), R. Mandelbum (Carnegie Mellon Univ.), L. Barrientos (Univ. Catolica de Chile), and K. Ng (Univ. of California, Davis)</Credits>
@@ -50132,6 +50374,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-566L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|566"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Morehead State U; Supernova remnants are created when a massive star explodes and its remains are hurled into space. Astronomers have found a supe...</Credits>
@@ -50158,6 +50401,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-568L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|568"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/PSU/K.Getman, E.; Astronomers have studied two star clusters to gain insight on how clusters of stars like our Sun form. This composite image show...</Credits>
@@ -50184,6 +50428,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-569L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|569"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Stanford Univ/N.; This four-panel of images represents a sample of giant elliptical galaxies observed by Chandra and the Hershel Space Observatory...</Credits>
@@ -50236,6 +50481,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-570aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|570,chandra|570a"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Wesleyan Univ./R; This image contains nearly a million seconds worth of Chandra observing time (purple) along with optical data from the Hubble Sp...</Credits>
@@ -50262,6 +50508,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-571L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|571"
     Xcxstatus="queue:chandra"
   >
     <Credits> X-ray: NASA/CXC/SAO/E.Bulbul, e; A new study of the Perseus galaxy cluster, shown in this image, and others using Chandra and XMM-Newton has revealed a mysteriou...</Credits>
@@ -50288,6 +50535,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-572L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|572"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Caltech/P.Ogle e; NGC 4258 is a spiral galaxy well known to astronomers for having two so-called anomalous arms that glow in X-ray, optical, and r...</Credits>
@@ -50314,6 +50562,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-576L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|576"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/SAO/R.Margutti et al; New Chandra data gives insight into the explosion that produced SN 2014J, one of the closest supernovas discovered in decades.  ...</Credits>
@@ -50340,6 +50589,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-577L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|577"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/IAFE/G.Dubner et; The destructive results of a powerful supernova explosion are seen in a delicate tapestry of X-ray light in this new image.  The...</Credits>
@@ -50366,6 +50616,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-578L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|578"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/GSFC/K.Hamaguchi, et al.</Credits>
@@ -50392,6 +50643,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-580L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|580"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Univ. of Toulous; Ultraluminous X-ray Sources (ULXs) are objects that produce more X-rays than most "normal" X-ray binary systems, in which a star...</Credits>
@@ -50522,6 +50774,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-581fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|581a,chandra|581b,chandra|581c,chandra|581d,chandra|581e,chandra|581f"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Universita di Bo; With the passing of Chandra's 15th anniversary, the Chandra Data Archive, which houses all of the mission's data, continues to g...</Credits>
@@ -50574,6 +50827,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-582bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|582a,chandra|582b"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/Stanford/I.Zhuravleva e; Chandra observations of the Perseus and Virgo galaxy clusters have provided direct evidence that turbulence is helping to preven...</Credits>
@@ -50600,6 +50854,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-583L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|583"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/Univ. of Wisconsin/Y.Ba; The supermassive black hole at the center of the Milky Way may be producing tiny particles, called neutrinos, that have virtuall...</Credits>
@@ -50626,6 +50881,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-584bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|584a,chandra|584b"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/GSFC/T.Temim et al.
@@ -50653,6 +50909,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-585L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|585"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/S.Mineo et a; X-ray data from Chandra have revealed that NGC 2207 and IC 2163, currently in the process of colliding with one another, have pr...</Credits>
@@ -50679,6 +50936,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-586L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|586"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/INAF/P.Tozzi, et al; Optical: NAOJ/Subaru and ESO/VLT; Infrared: ESA/Herschel</Credits>
@@ -50783,6 +51041,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-587eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|587a,chandra|587b,chandra|587c,chandra|587d,chandra|587e"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO; UV: NASA/JPL-Caltech; Optical: NASA/STScI; IR: NASA/JPL-Caltech</Credits>
@@ -50809,6 +51068,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-588L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|588"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/Amherst College/D.Hagga; Astronomers have detected the largest X-ray flare ever from the supermassive black hole at the center of the Milky Way, known as...</Credits>
@@ -50835,6 +51095,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-589L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|589"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/U.Texas/S.Post et al, Infrared: 2MASS/UMass/IPAC-Caltech/NASA/NSF</Credits>
@@ -50861,6 +51122,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-590L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|590"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/M.Mezcua et ; A newly discovered object in the galaxy NGC 2276 may prove to be an important black hole that helps fill in the evolutionary sto...</Credits>
@@ -50887,6 +51149,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-591L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|591"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Michigan State U; A new Chandra study of over 200 galaxy clusters has helped determine how giant black holes at their centers affect the growth an...</Credits>
@@ -50913,6 +51176,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-592L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|592"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/RIKEN/D.Takei et; Using NASA's Chandra X-ray Observatory, astronomers have studied the "classical nova" called GK Persei.  Classical novas are out...</Credits>
@@ -51069,6 +51333,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-593fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|593a,chandra|593b,chandra|593c,chandra|593d,chandra|593e,chandra|593f"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Ecole Polytechni; These galaxy clusters are part of a large study using Chandra and Hubble that sets new limits on how dark matter - the mysteriou...</Credits>
@@ -51095,6 +51360,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-594L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|594"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/IASF Palermo/M.Del Santo et al; Optical: NASA/STScI</Credits>
@@ -51121,6 +51387,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-596L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|596"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/INAF/F.Coti Zelati et a; Since its discovery two years ago when it gave off a burst of X-rays, astronomers have been actively monitoring the magnetar, du...</Credits>
@@ -51147,6 +51414,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-599L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|599"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/S.Randall et; Astronomers have used NASA's Chandra X-ray Observatory to show that a supermassive black hole at the center of a group of galaxi...</Credits>
@@ -51173,6 +51441,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-600L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|600"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Univ. of Wiscons; Chandra data of Circinus X-1 reveal a set of four rings that appear as circles around the neutron star, providing a rare opportu...</Credits>
@@ -51199,6 +51468,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-601L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|601"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/S.Wolk et al; NGC 1333 is a cluster that contains many stars that are less than two million years old, which is very young in astronomical ter...</Credits>
@@ -51225,6 +51495,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-606L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|606"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Univ of Michigan; The smallest supermassive black hole ever detected in the center of a galaxy has been identified using observations with Chandra...</Credits>
@@ -51251,6 +51522,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-607L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|607"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Univ of Hamburg/; Astronomers have found evidence for a "radio phoenix" in the collision of two galaxy clusters, where vast clouds of high-energy ...</Credits>
@@ -51277,6 +51549,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-609L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|609"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/MIT/M.McDonald e; New observations of the galaxy cluster SPT-CLJ2344-4243 at X-ray, ultraviolet, and optical wavelengths are helping astronomers b...</Credits>
@@ -51433,6 +51706,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-610fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|610a,chandra|610b,chandra|610c,chandra|610d,chandra|610e,chandra|610f"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/UMass/S.Johnson ; These six images represent the potential for new images and discoveries housed in the Chandra Data Archive. To celebrate October...</Credits>
@@ -51459,6 +51733,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-612L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|612"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/GSFC/M.Corcoran ; Delta Orionis is a complex star system that contains five stars in total. Two of those stars are in a close orbit where one pass...</Credits>
@@ -51485,6 +51760,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-613L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|614"
     Xcxstatus="queue:chandra"
   >
     <Credits>Wide Field Optical: Focal Pointe; The Jellyfish Nebula is the remnant of a supernova that occurred over 10,000 years ago in our galaxy. New Chandra observations s...</Credits>
@@ -51511,6 +51787,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-615L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|615"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/University of Bo; An extraordinary ribbon of hot gas trailing behind a galaxy like a tail has been discovered using data from NASA's Chandra X-ray...</Credits>
@@ -51537,6 +51814,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-617L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|617"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Univ of Missouri; Astronomers have made the most detailed study yet of an extremely massive young galaxy cluster using three of NASA's Great Obser...</Credits>
@@ -51563,6 +51841,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-620L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|620"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Univ of Hertford; The Pictor A galaxy has a supermassive black hole at its center, and material falling onto the black hole is driving an enormous...</Credits>
@@ -51589,6 +51868,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-621L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|621"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/ISAS/A.Simionesc; Jets in the early Universe give astronomers a way to probe the growth of black holes at a very early epoch in the cosmos. Using ...</Credits>
@@ -51641,6 +51921,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-622bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|622a,chandra|622b"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/G.Ogrean et ; These two galaxy clusters are part of the "Frontier Fields" project, which uses some of the world's most powerful telescopes to ...</Credits>
@@ -51667,6 +51948,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-624L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|624"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray (NASA/CXC/CfA/S.Chakrabort; Scientists have found the likely trigger for the most recent supernova in the Milky Way, by studying the remnant called G1.9+0.3...</Credits>
@@ -51771,6 +52053,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-626dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|626a,chandra|626b,chandra|626c,chandra|626d"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Univ. of Alabama; These four galaxy clusters were part of a large survey of over 300 clusters used to investigate dark energy, the mysterious ener...</Credits>
@@ -51797,6 +52080,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-627L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|627"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/GSFC/B.Williams ; By combining observations from over 15 years with the Chandra X-ray Observatory and 30 years with the Very Large Array, scientis...</Credits>
@@ -51823,6 +52107,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-630L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|630"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Univ. of Alberta; By combining data from Chandra and several other telescopes, astronomers have identified the true nature of an unusual source in...</Credits>
@@ -51849,6 +52134,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-633L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|633"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/ETH Zurich/L.Sar; New data from Chandra and other telescopes of a cosmic 'blob' and a gas bubble could be a new way to probe the past activity of ...</Credits>
@@ -51875,6 +52161,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-634L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|634"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/NCSU/K.Borkowski; New Chandra observations of the G11.2-0.3 supernova remnant in our Galaxy have stripped away its connection to an event recorded...</Credits>
@@ -51901,6 +52188,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-635L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|635"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Université Pari; The galaxy cluster CL J1001+0220 is the most distant galaxy cluster ever discovered and may have been caught right after birth, ...</Credits>
@@ -51927,6 +52215,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-636L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|636"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/University of Am; Using Chandra and other X-ray observatories, astronomers have found evidence for what is likely one of the most extreme pulsars,...</Credits>
@@ -51953,6 +52242,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-638L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|638"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/UNH/D.Lin et al;; Using Chandra and XMM-Newton, astronomers have discovered an extremely luminous, variable X-ray source located outside the core ...</Credits>
@@ -52109,6 +52399,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-640fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|640a,chandra|640b,chandra|640c,chandra|640d,chandra|640e,chandra|640f"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/SAO; The Chandra Data Archive is a sophisticated digital system that ultimately contains all of the data obtained by the telescope, c...</Credits>
@@ -52135,6 +52426,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-641L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|641"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/UA/J.Irwin et al.; Astronomers have found a pair of extraordinary objects that dramatically burst in X-rays. This discovery, obtained with NASA's C...</Credits>
@@ -52161,6 +52453,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-643L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|643"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/M.McCollough; A snapshot of the life cycle of stars has been captured where a stellar nursery is reflecting X-rays from a source powered by an...</Credits>
@@ -52187,6 +52480,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-645L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|645"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/PSU/L.Townsley e; This composite image captures the star formation region called NGC 6357 located within the Milky Way galaxy. X-rays from Chandra...</Credits>
@@ -52213,6 +52507,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-646L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|646"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/R. van Weere; Astronomers have discovered what happens when the eruption from a supermassive black hole is swept up by the collision and merge...</Credits>
@@ -52239,6 +52534,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-647L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|647"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Penn State/B.Luo; Made with over 7 million seconds of Chandra observing time, this image is part of the Chandra Deep Field-South (CDF-S) and is th...</Credits>
@@ -52265,6 +52561,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-648L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|648"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/PSU/B.Posselt et; This four-panel graphic shows the two pulsars, Geminga (upper left) and B0355+54 (upper right), observed by Chandra. In both of ...</Credits>
@@ -52291,6 +52588,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-66L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|66"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Bristol U./M. Hardcastle et al.; Radio: NRAO/AUI/NSF/Bristol U./M. Hardcastle</Credits>
@@ -52317,6 +52615,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-71L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|71"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/U.Leicester/U.London/R.Soria &amp; K.Wu</Credits>
@@ -52343,6 +52642,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-74L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|74"
     Xcxstatus="queue:chandra"
   >
     <Credits> X-ray: NASA/CXC/ESO/P.Rosati et al.; Optical: ESO/VLT/P.Rosati et al.</Credits>
@@ -52395,6 +52695,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-80L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|80"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/PSU/S.Park et al.</Credits>
@@ -52421,6 +52722,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-81L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|81"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/SAO/CXC/G.Fabbiano et al.</Credits>
@@ -52447,6 +52749,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-82L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|82"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/SAO/G.Fabbiano et al</Credits>
@@ -52473,6 +52776,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-87L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|87"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/MIT/F.K.Baganoff et al.</Credits>
@@ -52499,6 +52803,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-90L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|90"
     Xcxstatus="queue:chandra"
   >
     <Credits> NASA/CXC/PSU/D.M.Alexander, F.E.Bauer, W.N.Brandt et al.</Credits>
@@ -52525,6 +52830,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-92L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|92"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/MIT/UCSB/P.Ogle et al.; Optical: NASA/STScI/A.Capetti et al.</Credits>
@@ -52551,6 +52857,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-93L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|93"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/PSU/L.Townsley et al.</Credits>
@@ -52577,6 +52884,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-94L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|94"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/M.Machacek et al.</Credits>
@@ -52603,6 +52911,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-97L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|97"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/W. Forman et al.</Credits>
@@ -99827,6 +100136,7 @@ Gemini Observatory</Credits>
     TileLevels="4"
     Url="http://www.worldwidetelescope.org/wwtweb/tiles.aspx?q={1},{2},{3},1129358135"
     WidthFactor="2"
+    Xastropix_ids="chandra|395"
     Xcxstatus="queue:chandra"
   >
     <Credits>Chandra X-ray: NASA/CXC/HSC/J. Keohane et al.; ROSAT X-ray: NASA/ROSAT; Optical: NOAO/CTIO/P.F. Winkler et al.; Radio: NSF/NRAO/VLA/G. Dubner et al.
@@ -100414,6 +100724,7 @@ This composite shows a classic example of a mixed-morphology supernova remnant k
     TileLevels="4"
     Url="http://www.worldwidetelescope.org/wwtweb/tiles.aspx?q={1},{2},{3},251702032"
     WidthFactor="2"
+    Xastropix_ids="chandra|400"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/CfA/W. Forman et al.; Radio: NRAO/AUI/NSF/W. Cotton; Optical: NASA/ESA/Hubble Heritage Team (STScI/AURA), and R. Gendler. This image is a composite of visible (or optical), radio, and X-ray data of the giant elliptical galaxy, M87. M87 lies at a distance of 60 million light years and is the largest galaxy in the Virgo cluster of galaxies</Credits>
@@ -100962,6 +101273,7 @@ A composite image of X-ray (orange) and radio (blue) data from NASA’s Chandra 
     TileLevels="5"
     Url="http://www.worldwidetelescope.org/wwtweb/tiles.aspx?q={1},{2},{3},90554641"
     WidthFactor="2"
+    Xastropix_ids="chandra|401"
     Xcxstatus="in:6559a4ed8a2fdcee25a05723"
   >
     <Credits>X-ray: NASA/CXC/IoA/A.Fabian et al.; Radio: NRAO/VLA/G. Taylor; Optical: NASA/ESA/Hubble Heritage (STScI/AURA) &amp; Univ. of Cambridge/IoA/A. Fabian

--- a/imagesets/sky__visible.xml
+++ b/imagesets/sky__visible.xml
@@ -39224,7 +39224,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001321{Q}?g=138"
     WidthFactor="2"
     Xastropix_ids="stsci|2005-37a"
-    Xcxstatus="queue:hubble"
+    Xcxstatus="in:66737b0c643c1aaca06dfa41"
   >
     <Credits>Credit: NASA, ESA, J. Hester and A. Loll (Arizona State University)</Credits>
     <CreditsUrl>http://hubblesite.org/contents/news-releases/2005/news-2005-37.html</CreditsUrl>

--- a/imagesets/sky__visible.xml
+++ b/imagesets/sky__visible.xml
@@ -40816,7 +40816,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     ElevationModel="False"
     FileType=".png"
     Generic="False"
-    Name="NGC 7257: Spiral Disk and Globular Star Clusters at the Core of a Colliding Galaxy"
+    Name="NGC 7252: Spiral Disk and Globular Star Clusters at the Core of a Colliding Galaxy"
     Projection="Tan"
     QuadTreeMap="0123"
     Rotation="-124.413734954982"

--- a/imagesets/sky__visible.xml
+++ b/imagesets/sky__visible.xml
@@ -36458,6 +36458,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000000210{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-23a"
     Xcxstatus="in:6564c45ef864172823763c1f"
   >
     <Credits>Credit: ESA, NASA, K. Sharon (Tel Aviv University) and E. Ofek (Caltech)</Credits>
@@ -36645,6 +36646,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000001000{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-16a"
     Xcxstatus="in:6573279f5077f2f4480b0039"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (STScI/AURA) Acknowledgment: W. Blair (JHU) and D. Malin (David Malin Images)</Credits>
@@ -36914,6 +36916,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000001220{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2005-02b"
     Xcxstatus="in:657c642517aa40fc703f3af5"
   >
     <Credits>Credit: NASA, ESA and H.E. Bond (STScI)</Credits>
@@ -36993,6 +36996,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000001310{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-24b"
     Xcxstatus="in:657c642817aa40fc703f3afb"
   >
     <Credits>Credit: NASA, ESA, and The Hubble Heritage Team (STScI/AURA) Acknowledgment: W. Keel (University of Alabama, Tuscaloosa)</Credits>
@@ -37126,6 +37130,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000002030{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-01h"
     Xcxstatus="in:65982949293f0a5746370450"
   >
     <Credits>Credit: NASA, N. Benitez (JHU), T. Broadhurst (The Hebrew University), H. Ford (JHU), M. Clampin(STScI), G. Hartig (STScI), G. Illingworth (UCO/Lick Observatory), the ACS Science Team and ESA</Credits>
@@ -37365,6 +37370,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000002300{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-06d"
     Xcxstatus="in:65982950293f0a5746370460"
   >
     <Credits>Credit: NASA and The Hubble Heritage Team (STScI/AURA)</Credits>
@@ -37391,6 +37397,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000002310{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2004-10a"
     Xcxstatus="in:65982951293f0a5746370462"
   >
     <Credits>Credit: NASA and The Hubble Heritage Team (AURA/STScI)</Credits>
@@ -37417,6 +37424,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="6"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000002320{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-11a"
     Xcxstatus="in:65982951293f0a5746370464"
   >
     <Credits>Credit: NASA, NOAO, ESA, the Hubble Helix Nebula Team,  M. Meixner (STScI), and T.A. Rector (NRAO).</Credits>
@@ -37470,6 +37478,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="5"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000003000{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2004-13c"
     Xcxstatus="in:65aea0703d5676423ec14c12"
   >
     <Credits>Image Credit: NASA, ESA, and The Hubble Heritage Team (AURA/STScI) Acknowledgment: F. Bresolin (Institute for Astronomy, U. Hawaii)  and the Digitized Sky Survey</Credits>
@@ -37576,6 +37585,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000003200{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-01c"
     Xcxstatus="in:65d8c47eaffb32cbf1d96a5f"
   >
     <Credits>Credit: NASA, N. Benitez (JHU), T. Broadhurst (The Hebrew University), H. Ford (JHU), M. Clampin(STScI), G. Hartig (STScI), G. Illingworth (UCO/Lick Observatory), the ACS Science Team and ESA</Credits>
@@ -38087,6 +38097,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="6"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000012020{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-10a"
     Xcxstatus="in:65e5f0f6affb32cbf1d97d1a"
   >
     <Credits>Credit for Hubble Image: NASA and ESA Acknowledgment: K.D. Kuntz (GSFC), F. Bresolin (University of Hawaii), J. Trauger (JPL), J. Mould (NOAO), and Y.-H. Chu (University of Illinois, Urbana) Credit for CFHT Image: Canada-France-Hawaii Telescope/ J.-C. Cuillandre/Coelum Credit for NOAO Image: G. Jacoby, B. Bohannan, M. Hanna/ NOAO/AURA/NSF</Credits>
@@ -38661,6 +38672,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000000211{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-10d"
     Xcxstatus="in:661fef60befbe21fbdf49b93"
   >
     <Credits>Credit: NASA, ESA and H.E. Bond (STScI)</Credits>
@@ -38741,6 +38753,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000000301{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2007-15a"
     Xcxstatus="in:661fef63befbe21fbdf49b99"
   >
     <Credits>Credit: NASA, ESA, and The Hubble Heritage Team (STScI/AURA)-ESA/Hubble Collaboration</Credits>
@@ -38875,6 +38888,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001021{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-10b"
     Xcxstatus="in:661fef67befbe21fbdf49ba3"
   >
     <Credits>Credit: NASA, ESA and H.E. Bond (STScI)</Credits>
@@ -39143,6 +39157,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001301{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-14b"
     Xcxstatus="in:661fef71befbe21fbdf49bb7"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (STScI/AURA)</Credits>
@@ -39196,6 +39211,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001321{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2005-37a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, J. Hester and A. Loll (Arizona State University)</Credits>
@@ -39599,6 +39615,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002331{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-10e"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA and H.E. Bond (STScI)</Credits>
@@ -39652,6 +39669,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003011{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-45d"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, G. Miley and R. Overzier (Leiden Observatory), and  the ACS Science Team</Credits>
@@ -39786,6 +39804,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="5"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003121{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-14a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and The Hubble Heritage Team (STScI/AURA) Acknowledgment: J. Gallagher (University of Wisconsin), M. Mountain  (STScI), and P. Puxley (National Science Foundation)</Credits>
@@ -39812,6 +39831,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003131{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-01a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, N. Benitez (JHU), T. Broadhurst (Racah Institute of  Physics/The Hebrew University), H. Ford (JHU), M. Clampin (STScI),  G. Hartig (STScI),  G. Illingworth (UCO/Lick Observatory), the  ACS Science Team and ESA The members of the ACS science team are: H.C. Ford (JHU),  G.D. Illingworth (UCO/Lick Observatory), N. Benitez (JHU),  M. Clampin (STScI), G.F. Hartig (STScI), D.R. Ardila (JHU),  F. Bartko (Bartko Science &amp; Technology), J.P. Blakeslee (JHU),  R.J. Bouwens (UCO/Lick Observatory), T.J. Broadhurst (Racah  Institute of Physics, The Hebrew University), R.A. Brown (STScI),  C.J. Burrows (STScI), E.S. Cheng (NASA-GSFC), N.J.G. Cross (JHU),  P.D. Feldman (JHU), M. Franx (Leiden Observatory), D.A. Golimowski  (JHU), C. Gronwall (Pennsylvania State University), L. Infante  (Pontificia Universidad Catolica de Chile), R.A. Kimble (NASA-GSFC),  J.E. Krist (STScI), M.P. Lesser (Steward Observatory), A.R. Martel  (JHU), F. Menanteau (JHU), G.R. Meurer (JHU), G.K. Miley (Leiden  Observatory), M. Postman (STScI), P. Rosati (European Southern  Observatory), M. Sirianni (JHU), W.B. Sparks (STScI), H.D. Tran  (JHU), Z.I. Tsvetanov (JHU), R.L. White (STScI/JHU), and  W. Zheng (JHU)</Credits>
@@ -39838,6 +39858,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003201{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2004-45a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: NASA, ESA, and The Hubble Heritage Team (STScI)</Credits>
@@ -40105,6 +40126,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="5"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000010021{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-24a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, The Hubble Heritage Team and A. Riess (STScI)</Credits>
@@ -40158,6 +40180,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000010101{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-01d"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, N. Benitez (JHU), T. Broadhurst (The Hebrew University), H. Ford (JHU), M. Clampin(STScI), G. Hartig (STScI), G. Illingworth (UCO/Lick Observatory), the ACS Science Team and ESA</Credits>
@@ -41002,6 +41025,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001002{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-01f"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, N. Benitez (JHU), T. Broadhurst (The Hebrew University), H. Ford (JHU), M. Clampin(STScI), G. Hartig (STScI), G. Illingworth (UCO/Lick Observatory), the ACS Science Team and ESA</Credits>
@@ -41028,6 +41052,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="5"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001012{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-37b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and H. Richer (University of British Columbia)</Credits>
@@ -41108,6 +41133,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001102{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2005-37b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, CXC, JPL-Caltech, J. Hester and A. Loll (Arizona State Univ.), R. Gehrz (Univ. Minn.), and STScI</Credits>
@@ -41188,6 +41214,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001212{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-30a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (AURA/STScI) Acknowledgment: D. Garnett (U. Arizona), J. Hester (ASU), and J. Westphal (Caltech)</Credits>
@@ -41322,6 +41349,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001322{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2004-04b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NOAO/AURA/NSF and N.A. Sharp (NOAO)</Credits>
@@ -41561,6 +41589,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000002212{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-50b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and H. Bond (STScI)</Credits>
@@ -41803,6 +41832,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="5"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000003102{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2005-12a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, S. Beckwith (STScI), and The Hubble Heritage Team (STScI/AURA)</Credits>
@@ -41829,6 +41859,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000003112{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2004-32b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, C.R. O'Dell (Vanderbilt University), and M. Meixner, P. McCullough</Credits>
@@ -42231,6 +42262,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000010112{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2004-17g"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: NASA, ESA, and The Hubble Heritage Team (AURA/STScI) Acknowledgment: F. Yusef-Zadeh (Northwestern Univ.)</Credits>
@@ -42865,6 +42897,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000000333{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-10i"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA and H.E. Bond (STScI)</Credits>
@@ -42891,6 +42924,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001023{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2004-04a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA and The Hubble Heritage Team (AURA/STScI) Acknowledgment: S. Smartt (Institute of Astronomy) and  D. Richstone (U. Michigan)</Credits>
@@ -43187,6 +43221,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001313{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-01e"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, N. Benitez (JHU), T. Broadhurst (The Hebrew University), H. Ford (JHU), M. Clampin(STScI), G. Hartig (STScI), G. Illingworth (UCO/Lick Observatory), the ACS Science Team and ESA</Credits>
@@ -43697,6 +43732,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003033{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-01g"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, N. Benitez (JHU), T. Broadhurst (The Hebrew University), H. Ford (JHU), M. Clampin(STScI), G. Hartig (STScI), G. Illingworth (UCO/Lick Observatory), the ACS Science Team and ESA</Credits>
@@ -43750,6 +43786,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003113{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-50c"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and H. Bond (STScI)</Credits>
@@ -43911,6 +43948,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003313{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-10c"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA and H.E. Bond (STScI)</Credits>
@@ -43991,6 +44029,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="1"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000010003{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2007-10a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, P. Challis and R. Kirshner (Harvard-Smithsonian Center for Astrophysics)</Credits>
@@ -44044,6 +44083,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000010033{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-12b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA and J. Blakeslee (JHU)</Credits>
@@ -44178,6 +44218,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="5"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000010203{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-28a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA and The Hubble Heritage Team (STScI/AURA)</Credits>

--- a/imagesets/sky__visible.xml
+++ b/imagesets/sky__visible.xml
@@ -36537,6 +36537,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000000300{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2001-04d"
     Xcxstatus="in:6564c461f864172823763c25"
   >
     <Credits>Photo credits: NASA, Rogier Windhorst (Arizona State University, Tempe, AZ), and the Hubble mid-UV team</Credits>
@@ -36563,6 +36564,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000000310{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1994-24a"
     Xcxstatus="in:6573279c5077f2f4480b0033"
   >
     <Credits>Credit: C.R. O'Dell/Rice University; NASA</Credits>
@@ -36589,6 +36591,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000000320{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1995-07a"
     Xcxstatus="in:6573279d5077f2f4480b0035"
   >
     <Credits>Credit: Hubble Space Telescope WFPC Team, NASA, STScI</Credits>
@@ -36667,6 +36670,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000001010{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1996-38b"
     Xcxstatus="in:657327a05077f2f4480b003b"
   >
     <Credits>Credit: A. Caulet (ST-ECF, ESA) and NASA</Credits>
@@ -36693,6 +36697,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000001020{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1997-38h"
     Xcxstatus="in:657327a05077f2f4480b003d"
   >
     <Credits>Credit: Howard Bond (Space Telescope Science Institute), Robin Ciardullo (Pennsylvania State University) and NASA</Credits>
@@ -36773,6 +36778,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000001110{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1995-01b"
     Xcxstatus="in:657327a35077f2f4480b0043"
   >
     <Credits>Credit: J.P. Harrington and K.J. Borkowski (University of Maryland), and NASA</Credits>
@@ -36826,6 +36832,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000001130{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1996-01c"
     Xcxstatus="in:657327a55077f2f4480b0047"
   >
     <Credits>Credit: R. Williams (STScI), the Hubble Deep Field Team and NASA</Credits>
@@ -36852,6 +36859,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000001200{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2000-21c"
     Xcxstatus="in:657c642417aa40fc703f3af3"
   >
     <Credits>Credits: NASA and Jeffrey Kenney and Elizabeth Yale (Yale University)</Credits>
@@ -37009,6 +37017,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000001320{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1996-01a"
     Xcxstatus="in:657c642917aa40fc703f3afd"
   >
     <Credits>Credit: Robert Williams and the Hubble Deep Field Team (STScI) and NASA</Credits>
@@ -37061,6 +37070,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000002000{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1999-35d"
     Xcxstatus="in:657c642b17aa40fc703f3b01"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (AURA/STScI).</Credits>
@@ -37140,6 +37150,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000002100{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-13f"
     Xcxstatus="in:6598294a293f0a5746370452"
   >
     <Credits>Credit: NASA, The NICMOS Group (STScI, ESA) and The NICMOS Science Team (Univ. of Arizona)</Credits>
@@ -37157,7 +37168,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     ElevationModel="False"
     FileType=".png"
     Generic="False"
-    Name="Orion Nebula ( NGC 1976, M42)"
+    Name="Orion Nebula (NGC 1976, M42)"
     Projection="Tan"
     QuadTreeMap="0123"
     Rotation="0.120705811722216"
@@ -37166,10 +37177,11 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000002110{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1995-45a"
     Xcxstatus="in:6598294b293f0a5746370454"
   >
     <Credits>Photo Credit: NASA and C.R. O'Dell (Vanderbilt University)</Credits>
-    <CreditsUrl>http://hubblesite.org/contents/news-releases/2002/news-2002-05.html</CreditsUrl>
+    <CreditsUrl>http://hubblesite.org/contents/news-releases/1995/news-1995-45.html</CreditsUrl>
     <ThumbnailUrl>http://www.worldwidetelescope.org/wwtweb/thumbnail.aspx?name=937991171</ThumbnailUrl>
   </ImageSet>
   <ImageSet
@@ -37219,6 +37231,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000002130{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2001-04c"
     Xcxstatus="in:6598294c293f0a5746370458"
   >
     <Credits>Photo credits: NASA, Rogier Windhorst (Arizona State University, Tempe, AZ), and the Hubble mid-UV team</Credits>
@@ -37297,6 +37310,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000002220{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1996-21b"
     Xcxstatus="in:6598294e293f0a574637045c"
   >
     <Credits>Credit: A. Sandage (Carnegie Observatories), A. Saha (Space Telescope Science Institute), G.A. Tammann, and L. Labhardt (Astronomical Institute, University of Basel), F.D. Macchetto and N. Panagia (Space Telescope Science Institute and European Space Agency) and NASA</Credits>
@@ -37745,6 +37759,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="5"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000003330{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-11g"
     Xcxstatus="in:65dccffeaffb32cbf1d96fbe"
   >
     <Credits>Credit: NASA, H. Ford (JHU), G. Illingworth (UCSC/LO), M.Clampin (STScI), G. Hartig (STScI), the ACS Science Team, and ESA  The ACS Science Team:  H. Ford, G. Illingworth, M. Clampin, G. Hartig, T. Allen, K. Anderson, F. Bartko, N. Benitez, J. Blakeslee, R. Bouwens, T. Broadhurst, R. Brown, C. Burrows, D. Campbell, E. Cheng, N. Cross, P. Feldman, M. Franx, D. Golimowski, C. Gronwall, R. Kimble, J. Krist, M. Lesser, D. Magee, A. Martel, W. J. McCann, G. Meurer, G. Miley, M. Postman, P. Rosati, M. Sirianni, W. Sparks, P. Sullivan, H. Tran, Z. Tsvetanov, R. White, and R. Woodruff.</Credits>
@@ -37798,6 +37813,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000010010{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1995-02b"
     Xcxstatus="in:65dcd000affb32cbf1d96fc2"
   >
     <Credits>Kirk Borne (STScI), and NASA</Credits>
@@ -37824,6 +37840,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000010020{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-15e"
     Xcxstatus="in:65dcd001affb32cbf1d96fc4"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (STScI/AURA)</Credits>
@@ -37931,6 +37948,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="5"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000010120{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-11b,stsci|2002-11f"
     Xcxstatus="in:65e5f0f2affb32cbf1d97d12"
   >
     <Credits>Credit: NASA, H. Ford (JHU), G. Illingworth (UCSC/LO), M.Clampin (STScI), G. Hartig (STScI), the ACS Science Team, and ESA  The ACS Science Team:  H. Ford, G. Illingworth, M. Clampin, G. Hartig, T. Allen, K. Anderson, F. Bartko, N. Benitez, J. Blakeslee, R. Bouwens, T. Broadhurst, R. Brown, C. Burrows, D. Campbell, E. Cheng, N. Cross, P. Feldman, M. Franx, D. Golimowski, C. Gronwall, R. Kimble, J. Krist, M. Lesser, D. Magee, A. Martel, W. J. McCann, G. Meurer, G. Miley, M. Postman, P. Rosati, M. Sirianni, W. Sparks, P. Sullivan, H. Tran, Z. Tsvetanov, R. White, and R. Woodruff.</Credits>
@@ -37957,6 +37975,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000010130{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-15a"
     Xcxstatus="in:65e5f0f3affb32cbf1d97d14"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (STScI/AURA) Acknowledgment: R. Fesen (Dartmouth) and J. Morse (Univ. of Colorado)</Credits>
@@ -38663,6 +38682,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000000221{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1997-38e"
     Xcxstatus="in:661fef61befbe21fbdf49b95"
   >
     <Credits>Credits: Howard Bond (Space Telescope Science Institute), Robin Ciardullo (Pennsylvania State University) and NASA</Credits>
@@ -38689,6 +38709,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="0"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000000231{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1995-02c"
     Xcxstatus="in:661fef62befbe21fbdf49b97"
   >
     <Credits>Kirk Borne (STScI), and NASA</Credits>
@@ -38768,6 +38789,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000000331{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1999-35e"
     Xcxstatus="in:661fef65befbe21fbdf49b9d"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (AURA/STScI).</Credits>
@@ -39034,6 +39056,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="1"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001211{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-02d"
     Xcxstatus="in:661fef6ebefbe21fbdf49bb1"
   >
     <Credits>Image credit: D. Hunter (Lowell Observ.) and A. Aloisi (JHU)</Credits>
@@ -39192,6 +39215,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001331{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2000-07a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, Andrew Fruchter and the ERO Team [Sylvia Baggett (STScI), Richard Hook (ST-ECF), Zoltan Levay (STScI)]</Credits>
@@ -39353,6 +39377,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002111{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1998-12b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: Jim Flood (Amateur Astronomers Inc., Sperry Observatory), Max Mutchler (STScI)</Credits>
@@ -39432,6 +39457,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002201{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1994-52f"
     Xcxstatus="queue:hubble"
   >
     <Credits>Mark Dickinson (STScI) and NASA</Credits>
@@ -39485,6 +39511,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="1"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002221{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1997-34f"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: Brad Whitmore (STScI) and NASA</Credits>
@@ -39511,6 +39538,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002231{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-15d"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (STScI/AURA)</Credits>
@@ -39828,6 +39856,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003211{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1999-04a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: The Hubble Heritage Team (AURA/STScI/NASA)</Credits>
@@ -39854,6 +39883,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003221{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1994-02b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, STScI</Credits>
@@ -40092,6 +40122,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000010031{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2001-04b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Photo credits: NASA, Rogier Windhorst (Arizona State University, Tempe, AZ), and the Hubble mid-UV team</Credits>
@@ -40198,6 +40229,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="5"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000010131{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-11d"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, H. Ford (JHU), G. Illingworth (UCSC/LO), M.Clampin (STScI), G. Hartig (STScI), the ACS Science Team, and ESA  The ACS Science Team:  H. Ford, G. Illingworth, M. Clampin, G. Hartig, T. Allen, K. Anderson, F. Bartko, N. Benitez, J. Blakeslee, R. Bouwens, T. Broadhurst, R. Brown, C. Burrows, D. Campbell, E. Cheng, N. Cross, P. Feldman, M. Franx, D. Golimowski, C. Gronwall, R. Kimble, J. Krist, M. Lesser, D. Magee, A. Martel, W. J. McCann, G. Meurer, G. Miley, M. Postman, P. Rosati, M. Sirianni, W. Sparks, P. Sullivan, H. Tran, Z. Tsvetanov, R. White, and R. Woodruff.</Credits>
@@ -40224,6 +40256,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="1"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000010201{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1994-16b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Dr. John Hutchings, Dominion Astrophysical Observatory, NASA</Credits>
@@ -40773,6 +40806,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000000212{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1999-35a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (AURA/STScI).</Credits>
@@ -40825,6 +40859,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000000232{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1993-11b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: : B. Whitmore (STScI), and NASA Co-investigators: : Francois Schweizer of the Carnegie Institution of Washington, Washington, D.C., and Claus Leitherer, Kirk Borne, and Carmelle Robert of STScI.</Credits>
@@ -40851,6 +40886,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="5"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000000302{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1994-10a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: C.R. O'Dell/ Rice University NASA</Credits>
@@ -41248,6 +41284,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001312{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1999-06a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: Carl Grillmair (California Institute of Technology) and NASA</Credits>
@@ -41353,7 +41390,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000002012{Q}?g=138"
     WidthFactor="2"
-    Xastropix_ids="stsci|2000-23b,stsci|2000-23c"
+    Xastropix_ids="stsci|2000-23b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: Brian D. Moore and J. Jeff Hester (Arizona State University)</Credits>
@@ -41646,6 +41683,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000002322{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1997-34d"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: Brad Whitmore (STScI) and NASA</Credits>
@@ -41699,6 +41737,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000003012{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1997-38d"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credits: Bruce Balick (University of Washington), Jason Alexander (University of Washington), Arsen Hajian (U.S. Naval Observatory), Yervant Terzian (Cornell University), Mario Perinotto (University of Florence, Italy), Patrizio Patriarchi (Arcetri Observatory, Italy) and NASA</Credits>
@@ -41911,6 +41950,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000003222{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2001-08f"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA and R. de Grijs (Inst. of Astronomy, Cambridge, UK)</Credits>
@@ -41964,6 +42004,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000003302{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1995-44a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, STScI, J. Hester and P. Scowen (Arizona State University)</Credits>
@@ -41990,6 +42031,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000003312{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-15f"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (STScI/AURA)</Credits>
@@ -42042,6 +42084,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000010002{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1999-16a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: The Hubble Heritage Team (AURA/STScI/NASA)</Credits>
@@ -42674,6 +42717,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000000223{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1998-32d"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: Rodger I. Thompson (University of Arizona) and NASA</Credits>
@@ -42754,6 +42798,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000000313{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1996-38a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: A. Caulet (ST-ECF, ESA) and NASA</Credits>
@@ -42859,6 +42904,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="1"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001033{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1995-44c"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, STScI, J. Hester and P. Scowen (Arizona State University)</Credits>
@@ -43073,6 +43119,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001233{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2001-33a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit:  NASA and The Hubble Heritage Team (STScI/AURA) Acknowledgment: A. Cool (SFSU)</Credits>
@@ -43152,6 +43199,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001323{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1995-01a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: J.P. Harrington and K.J. Borkowski (University of Maryland), and NASA</Credits>
@@ -43285,6 +43333,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002103{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1996-17b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Nino Panagia (Space Telescope Science Institute and European Space Agency) and NASA</Credits>
@@ -43364,6 +43413,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002203{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1995-44b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, STScI, J. Hester and P. Scowen (Arizona State University)</Credits>
@@ -43552,6 +43602,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002333{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-15h"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (STScI/AURA)</Credits>
@@ -43578,6 +43629,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="1"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003003{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1998-28a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: The Hubble Heritage Team (AURA/STScI/NASA)</Credits>
@@ -43898,6 +43950,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003333{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2001-37a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credits: NASA and The Hubble Heritage Team (STScI/AURA)  Acknowledgment: R. Windhorst (ASU)</Credits>
@@ -44057,6 +44110,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000010123{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1995-49b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: C.R. O'Dell/Rice University; NASA</Credits>

--- a/imagesets/sky__visible.xml
+++ b/imagesets/sky__visible.xml
@@ -51304,6 +51304,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-554aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|554a"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/SAO; This collection of images represents the thousands of observations that are permanently stored and accessible to the world in th...</Credits>
@@ -51330,6 +51331,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-554bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|554b"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/SAO; This collection of images represents the thousands of observations that are permanently stored and accessible to the world in th...</Credits>
@@ -51356,7 +51358,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-554eL{1}X{2}Y{3}.png"
     WidthFactor="1"
-    Xastropix_ids="chandra|554a,chandra|554b,chandra|554c,chandra|554d,chandra|554e,chandra|554f,chandra|554g,chandra|554h"
+    Xastropix_ids="chandra|554e"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/SAO; This collection of images represents the thousands of observations that are permanently stored and accessible to the world in th...</Credits>
@@ -51733,7 +51735,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-570aL{1}X{2}Y{3}.png"
     WidthFactor="1"
-    Xastropix_ids="chandra|570,chandra|570a"
+    Xastropix_ids="chandra|570a"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Wesleyan Univ./R; This image contains nearly a million seconds worth of Chandra observing time (purple) along with optical data from the Hubble Sp...</Credits>
@@ -51922,6 +51924,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-581aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|581a"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/ESA-ESTEC/E.Wins; With the passing of Chandra's 15th anniversary, the Chandra Data Archive, which houses all of the mission's data, continues to g...</Credits>
@@ -51948,6 +51951,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-581cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|581c"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Univ. of Manitob; With the passing of Chandra's 15th anniversary, the Chandra Data Archive, which houses all of the mission's data, continues to g...</Credits>
@@ -51974,6 +51978,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-581dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|581d"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO, Optical: NA; With the passing of Chandra's 15th anniversary, the Chandra Data Archive, which houses all of the mission's data, continues to g...</Credits>
@@ -52000,6 +52005,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-581eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|581e"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO; Infared: NA; With the passing of Chandra's 15th anniversary, the Chandra Data Archive, which houses all of the mission's data, continues to g...</Credits>
@@ -52026,7 +52032,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-581fL{1}X{2}Y{3}.png"
     WidthFactor="1"
-    Xastropix_ids="chandra|581a,chandra|581b,chandra|581c,chandra|581d,chandra|581e,chandra|581f"
+    Xastropix_ids="chandra|581f"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Universita di Bo; With the passing of Chandra's 15th anniversary, the Chandra Data Archive, which houses all of the mission's data, continues to g...</Credits>
@@ -52053,6 +52059,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-582aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|582a"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/Stanford/I.Zhuravleva e; Chandra observations of the Perseus and Virgo galaxy clusters have provided direct evidence that turbulence is helping to preven...</Credits>
@@ -52079,7 +52086,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-582bL{1}X{2}Y{3}.png"
     WidthFactor="1"
-    Xastropix_ids="chandra|582a,chandra|582b"
+    Xastropix_ids="chandra|582b"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/Stanford/I.Zhuravleva e; Chandra observations of the Perseus and Virgo galaxy clusters have provided direct evidence that turbulence is helping to preven...</Credits>
@@ -52133,7 +52140,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-584bL{1}X{2}Y{3}.png"
     WidthFactor="1"
-    Xastropix_ids="chandra|584a,chandra|584b"
+    Xastropix_ids="chandra|584b"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/GSFC/T.Temim et al.
@@ -52215,6 +52222,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-587aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|587a"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO; UV: NASA/JP; This montage features images of five different objects, ranging from a distant galaxy to a relatively close supernova remnant.  ...</Credits>
@@ -52241,6 +52249,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-587bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|587b"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Rutgers/J.Hughes; This montage features images of five different objects, ranging from a distant galaxy to a relatively close supernova remnant.  ...</Credits>
@@ -52267,6 +52276,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-587dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|587d"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO; Optical: NA; This montage features images of five different objects, ranging from a distant galaxy to a relatively close supernova remnant.  ...</Credits>
@@ -52293,7 +52303,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-587eL{1}X{2}Y{3}.png"
     WidthFactor="1"
-    Xastropix_ids="chandra|587a,chandra|587b,chandra|587c,chandra|587d,chandra|587e"
+    Xastropix_ids="chandra|587e"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO; UV: NASA/JPL-Caltech; Optical: NASA/STScI; IR: NASA/JPL-Caltech</Credits>
@@ -52455,6 +52465,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-593aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|593a"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Ecole Polytechni; These galaxy clusters are part of a large study using Chandra and Hubble that sets new limits on how dark matter - the mysteriou...</Credits>
@@ -52481,6 +52492,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-593bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|593b"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Ecole Polytechni; These galaxy clusters are part of a large study using Chandra and Hubble that sets new limits on how dark matter - the mysteriou...</Credits>
@@ -52507,6 +52519,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-593cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|593c"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Ecole Polytechni; These galaxy clusters are part of a large study using Chandra and Hubble that sets new limits on how dark matter - the mysteriou...</Credits>
@@ -52533,6 +52546,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-593dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|593d"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Ecole Polytechni; These galaxy clusters are part of a large study using Chandra and Hubble that sets new limits on how dark matter - the mysteriou...</Credits>
@@ -52559,6 +52573,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-593eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|593e"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Ecole Polytechnique Federale de Lausanne, Switzerland/D.Harvey &amp; NASA/CXC/Durham Univ/R.Massey; Optical &amp; Lensing Map: NASA, ESA, D. Harvey (Ecole Polytechnique Federale de Lausanne, Switzerland) and R. Massey (Durham University, UK)</Credits>
@@ -52585,7 +52600,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-593fL{1}X{2}Y{3}.png"
     WidthFactor="1"
-    Xastropix_ids="chandra|593a,chandra|593b,chandra|593c,chandra|593d,chandra|593e,chandra|593f"
+    Xastropix_ids="chandra|593f"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Ecole Polytechni; These galaxy clusters are part of a large study using Chandra and Hubble that sets new limits on how dark matter - the mysteriou...</Credits>
@@ -52828,6 +52843,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-610aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|610a"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Univ. of Georgia; These six images represent the potential for new images and discoveries housed in the Chandra Data Archive. To celebrate October...</Credits>
@@ -52854,6 +52870,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-610bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|610b"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/PUS/E.Helder et ; These six images represent the potential for new images and discoveries housed in the Chandra Data Archive. To celebrate October...</Credits>
@@ -52880,6 +52897,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-610cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|610c"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/F.Seward et ; These six images represent the potential for new images and discoveries housed in the Chandra Data Archive. To celebrate October...</Credits>
@@ -52906,6 +52924,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-610dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|610d"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Univ. of Waterlo; These six images represent the potential for new images and discoveries housed in the Chandra Data Archive. To celebrate October...</Credits>
@@ -52932,6 +52951,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-610eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|610e"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Cambridge/S.Alle; These six images represent the potential for new images and discoveries housed in the Chandra Data Archive. To celebrate October...</Credits>
@@ -52958,7 +52978,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-610fL{1}X{2}Y{3}.png"
     WidthFactor="1"
-    Xastropix_ids="chandra|610a,chandra|610b,chandra|610c,chandra|610d,chandra|610e,chandra|610f"
+    Xastropix_ids="chandra|610f"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/UMass/S.Johnson ; These six images represent the potential for new images and discoveries housed in the Chandra Data Archive. To celebrate October...</Credits>
@@ -53147,6 +53167,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-622aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|622a"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/G.Ogrean et ; These two galaxy clusters are part of the "Frontier Fields" project, which uses some of the world's most powerful telescopes to ...</Credits>
@@ -53173,7 +53194,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-622bL{1}X{2}Y{3}.png"
     WidthFactor="1"
-    Xastropix_ids="chandra|622a,chandra|622b"
+    Xastropix_ids="chandra|622b"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/SAO/G.Ogrean et ; These two galaxy clusters are part of the "Frontier Fields" project, which uses some of the world's most powerful telescopes to ...</Credits>
@@ -53227,6 +53248,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-626aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|626a"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Univ. of Alabama; These four galaxy clusters were part of a large survey of over 300 clusters used to investigate dark energy, the mysterious ener...</Credits>
@@ -53253,6 +53275,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-626bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|626b"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Univ. of Alabama; These four galaxy clusters were part of a large survey of over 300 clusters used to investigate dark energy, the mysterious ener...</Credits>
@@ -53279,6 +53302,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-626cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|626c"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Univ. of Alabama; These four galaxy clusters were part of a large survey of over 300 clusters used to investigate dark energy, the mysterious ener...</Credits>
@@ -53305,7 +53329,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-626dL{1}X{2}Y{3}.png"
     WidthFactor="1"
-    Xastropix_ids="chandra|626a,chandra|626b,chandra|626c,chandra|626d"
+    Xastropix_ids="chandra|626d"
     Xcxstatus="queue:chandra"
   >
     <Credits>X-ray: NASA/CXC/Univ. of Alabama; These four galaxy clusters were part of a large survey of over 300 clusters used to investigate dark energy, the mysterious ener...</Credits>
@@ -53521,6 +53545,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-640aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|640a"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/SAO; The Chandra Data Archive is a sophisticated digital system that ultimately contains all of the data obtained by the telescope, c...</Credits>
@@ -53547,6 +53572,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-640bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|640b"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/SAO; The Chandra Data Archive is a sophisticated digital system that ultimately contains all of the data obtained by the telescope, c...</Credits>
@@ -53573,6 +53599,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-640cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|640c"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/SAO; The Chandra Data Archive is a sophisticated digital system that ultimately contains all of the data obtained by the telescope, c...</Credits>
@@ -53599,6 +53626,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-640dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|640d"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/SAO; The Chandra Data Archive is a sophisticated digital system that ultimately contains all of the data obtained by the telescope, c...</Credits>
@@ -53625,6 +53653,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-640eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="chandra|640e"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/SAO; The Chandra Data Archive is a sophisticated digital system that ultimately contains all of the data obtained by the telescope, c...</Credits>
@@ -53651,7 +53680,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Chandra-640fL{1}X{2}Y{3}.png"
     WidthFactor="1"
-    Xastropix_ids="chandra|640a,chandra|640b,chandra|640c,chandra|640d,chandra|640e,chandra|640f"
+    Xastropix_ids="chandra|640f"
     Xcxstatus="queue:chandra"
   >
     <Credits>NASA/CXC/SAO; The Chandra Data Archive is a sophisticated digital system that ultimately contains all of the data obtained by the telescope, c...</Credits>

--- a/imagesets/sky__visible.xml
+++ b/imagesets/sky__visible.xml
@@ -36484,6 +36484,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000000220{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-21a"
     Xcxstatus="in:6564c45ff864172823763c21"
   >
     <Credits>Credit: NASA and The Hubble Heritage Team (AURA/STScI) Acknowledgment: A. Cool (SFSU)</Credits>
@@ -36718,6 +36719,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000001030{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2005-35b"
     Xcxstatus="in:657327a15077f2f4480b003f"
   >
     <Credits>Credit: NASA, ESA, and The Hubble Heritage Team (STScI/AURA) Acknowledgment: A. Nota (STScI/ESA)</Credits>
@@ -36744,6 +36746,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000001100{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2004-21a"
     Xcxstatus="in:657327a25077f2f4480b0041"
   >
     <Credits>Credit: NASA, ESA, J. Blakeslee and H. Ford (Johns Hopkins University)</Credits>
@@ -36796,6 +36799,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000001120{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-55a"
     Xcxstatus="in:657327a45077f2f4480b0045"
   >
     <Credits>Credit: NASA, ESA, and the Hubble Heritage Team (STScI/AURA)-ESA/Hubble Collaboration Acknowledgment: D. Gouliermis (Max Planck Institute for Astronomy, Heidelberg)</Credits>
@@ -36926,6 +36930,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000001230{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2005-11a"
     Xcxstatus="in:657c642617aa40fc703f3af7"
   >
     <Credits>Credit: NASA, ESA, and The Hubble Heritage Team (STScI/AURA) Acknowledgment: P. Goudfrooij (STScI)</Credits>
@@ -37082,6 +37087,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000002010{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-09a"
     Xcxstatus="in:657c642b17aa40fc703f3b03"
   >
     <Credits>Credit: NASA and The Hubble Heritage Team (STScI/AURA) Acknowledgment: W. Sparks (STScI) and R. Sahai (JPL)</Credits>
@@ -37186,6 +37192,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000002120{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2001-23a"
     Xcxstatus="in:6598294b293f0a5746370456"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (STScI/AURA)  Acknowledgment: C. Conselice (U. Wisconsin/STScI)</Credits>
@@ -37472,6 +37479,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000003020{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2000-15a"
     Xcxstatus="in:65aea0713d5676423ec14c14"
   >
     <Credits>Credit: NASA and The Hubble Heritage Team (STScI/AURA)  Acknowledgment: W. P. Blair (JHU)</Credits>
@@ -37498,6 +37506,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000003110{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-35a"
     Xcxstatus="in:65d8c47caffb32cbf1d96a5b"
   >
     <Credits>Credit: NASA, ESA, and the Hubble Heritage Team (STScI/AURA) Acknowledgment: J. Green (University of Colorado, Boulder)</Credits>
@@ -37576,6 +37585,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000003210{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1999-33d"
     Xcxstatus="in:65d8c47faffb32cbf1d96a61"
   >
     <Credits>Credit: NASA, John Trauger (Jet Propulsion Laboratory) and James Westphal (California Intitute of Technology)</Credits>
@@ -37602,6 +37612,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000003220{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-25a"
     Xcxstatus="in:65d8c481affb32cbf1d96a63"
   >
     <Credits>Credit: NASA and The Hubble Heritage Team (STScI/AURA)</Credits>
@@ -37654,6 +37665,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000003300{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2001-02a"
     Xcxstatus="in:65d8c483affb32cbf1d96a67"
   >
     <Credits>Credits: NASA, William C. Keel (University of Alabama, Tuscaloosa)</Credits>
@@ -37706,6 +37718,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000003320{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2001-25a"
     Xcxstatus="in:65dccffdaffb32cbf1d96fbc"
   >
     <Credits>Image Credits: NASA, ESA, and Martino Romaniello (European Southern Observatory, Germany)  Acknowledgments: The image processing for this image was done by Martino Romaniello, Richard Hook, Bob Fosbury and the Hubble European Space Agency Information Center.</Credits>
@@ -37758,6 +37771,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000010000{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-22a"
     Xcxstatus="in:65dccfffaffb32cbf1d96fc0"
   >
     <Credits>Image Credit: NASA, J. English (U. Manitoba), S. Hunsberger, S. Zonak, J. Charlton, S. Gallagher (PSU), and L. Frattare (STScI) Science Credit: NASA, C. Palma, S. Zonak, S. Hunsberger, J. Charlton, S. Gallagher, P. Durrell (The Pennsylvania State University) and J. English (University of Manitoba)</Credits>
@@ -37836,6 +37850,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000010030{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-01a"
     Xcxstatus="in:65dcd002affb32cbf1d96fc6"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (STScI/AURA) Acknowledgment: Bo Reipurth (University of Hawaii)</Credits>
@@ -37862,6 +37877,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000010100{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2001-21a"
     Xcxstatus="in:65dcd002affb32cbf1d96fc8"
   >
     <Credits>Credit: NASA, N. Walborn and J. Maíz-Apellániz (Space Telescope Science Institute, Baltimore, MD), R. Barbá (La Plata Observatory, La Plata, Argentina)</Credits>
@@ -37888,6 +37904,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="1"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000010110{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1999-10g"
     Xcxstatus="in:65dcd003affb32cbf1d96fca"
   >
     <Credits>Credit: Torsten Boeker, Space Telescope Science Institute (STScI) , and NASA</Credits>
@@ -38593,6 +38610,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="1"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000000201{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2004-24d"
     Xcxstatus="in:661fef5fbefbe21fbdf49b91"
   >
     <Credits>Credit: NASA, ESA and D. Bennett (University of Notre Dame)</Credits>
@@ -38723,6 +38741,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000000311{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2007-17b"
     Xcxstatus="in:661fef64befbe21fbdf49b9b"
   >
     <Credits>Credit: NASA, ESA, M.J. Jee and H. Ford (Johns Hopkins University)</Credits>
@@ -38775,6 +38794,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001001{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1995-24f"
     Xcxstatus="in:661fef65befbe21fbdf49b9f"
   >
     <Credits>STScI &amp; NASA</Credits>
@@ -38879,6 +38899,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001101{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-14a"
     Xcxstatus="in:661fef69befbe21fbdf49ba7"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (STScI/AURA)  Acknowledgment: C.R. O'Dell (Vanderbilt University)</Credits>
@@ -38905,6 +38926,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001111{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2004-25a"
     Xcxstatus="in:661fef6abefbe21fbdf49ba9"
   >
     <Credits>Image Credit: NASA, ESA and The Hubble Heritage Team (STScI/AURA) Acknowledgment: S. Smartt (The Queen's University of Belfast)</Credits>
@@ -38931,6 +38953,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001121{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-05a"
     Xcxstatus="in:661fef6bbefbe21fbdf49bab"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (STScI/AURA)  Acknowledgment: C. R. O'Dell (Vanderbilt University)</Credits>
@@ -38957,6 +38980,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001131{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2007-12a"
     Xcxstatus="in:661fef6cbefbe21fbdf49bad"
   >
     <Credits>Credit: NASA, ESA, and J. -P. Kneib (Laboratorie d'Astrophysique de Marseille)</Credits>
@@ -38983,6 +39007,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001201{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1999-01a"
     Xcxstatus="in:661fef6dbefbe21fbdf49baf"
   >
     <Credits>Credit: The Hubble Heritage Team (AURA/STScI/NASA)</Credits>
@@ -39035,6 +39060,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001221{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2001-28b"
     Xcxstatus="in:661fef6fbefbe21fbdf49bb3"
   >
     <Credits>Credits: NASA, Gerald Cecil (University of North Carolina), Sylvain Veilleux (University of Maryland), Joss Bland-Hawthorn (Anglo- Australian Observatory), and Alex Filippenko (University of California at Berkeley).</Credits>
@@ -39113,6 +39139,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001311{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2007-04a"
     Xcxstatus="in:661fef72befbe21fbdf49bb9"
   >
     <Credits>Credit: NASA, ESA, and the Hubble Heritage Team (STScI/AURA) - ESA/Hubble Collaboration</Credits>
@@ -39191,6 +39218,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002001{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-23a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credits: NASA and The Hubble Heritage Team (STScI/AURA) Acknowledgment: R. Knacke (Penn State Erie)</Credits>
@@ -39217,6 +39245,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002011{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2007-09a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and K. Noll (STScI) Acknowledgment: The Hubble Heritage Team (STScI/AURA)</Credits>
@@ -39243,6 +39272,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002021{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1997-07a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: Massimo Stiavelli (STScI), and NASA</Credits>
@@ -39269,6 +39299,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002031{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1998-14c"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: E.J. Schreier (STScI), and NASA</Credits>
@@ -39295,6 +39326,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002101{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2004-31b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and The Hubble Heritage Team (STScI/AURA) Acknowledgment: Y. Momany (University of Padua)</Credits>
@@ -39347,6 +39379,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002121{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2000-12a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, The Hubble Heritage Team (STScI/AURA)</Credits>
@@ -39425,6 +39458,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002211{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-13a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and The Hubble Heritage Team (STScI/AURA) Acknowledgment: P. McCullough (STScI)</Credits>
@@ -39503,6 +39537,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000002301{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2005-28b,stsci|2007-31b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and S. Beckwith (STScI) and the HUDF Team</Credits>
@@ -39607,6 +39642,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="5"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003021{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-30a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration Acknowledgment: R. Fesen (Dartmouth College) and J. Long (ESA/Hubble)</Credits>
@@ -39633,6 +39669,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003031{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-19a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (STScI/AURA) Acknowledgment: A. Gomez (Cerro Tololo Inter-American Observatory)</Credits>
@@ -39659,6 +39696,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003101{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-13a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, The NICMOS Group (STScI, ESA) and The NICMOS Science Team (Univ. of Arizona)</Credits>
@@ -39685,6 +39723,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003111{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2005-28c"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA and B. Mobasher (STScI/ESA)</Credits>
@@ -39867,6 +39906,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003301{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1998-21b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credits: G. Fritz Benedict, Andrew Howell, Inger Jorgensen,                David Chapell (University of                Texas), Jeffery Kenney (Yale                University), and Beverly J. Smith (CASA,                University of Colorado), and NASA</Credits>
@@ -39893,6 +39933,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003311{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-41a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and the Hubble Heritage Team (STScI/AURA) Acknowledgment: Y.-H. Chu (University of Illinois, Urbana - Champaign) and Y. Nazé (Universite de Liège, Belgium)</Credits>
@@ -39919,6 +39960,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003321{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-12a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (STScI/AURA)  Acknowledgment: D. Garnett (University of Arizona)</Credits>
@@ -39997,6 +40039,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000010011{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1999-41a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA and The Hubble Heritage Team (STScI)</Credits>
@@ -40101,6 +40144,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000010111{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2001-22a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credits: NASA, Jayanne English (University of Manitoba), Sally Hunsberger (Pennsylvania State University), Zolt Levay (Space Telescope Science Institute), Sarah Gallagher (Pennsylvania State University), and Jane Charlton (Pennsylvania State University)   Science Credits: Sarah Gallagher (Pennsylvania State University), Jane Charlton (Pennsylvania State University), Sally Hunsberger (Pennsylvania State University), Dennis Zaritsky (University of Arizona), and Bradley Whitmore (Space Telescope Science Institute)</Credits>
@@ -40127,6 +40171,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000010121{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-14a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (STScI/AURA) Acknowledgment: M. Donahue (STScI) and J. Trauger (JPL)</Credits>
@@ -40674,6 +40719,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000000132{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2000-37a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credits: Credits: NASA, Andrew S. Wilson (University of Maryland); Patrick L. Shopbell (Caltech); Chris Simpson (Subaru Telescope); Thaisa Storchi-Bergmann and F. K. B. Barbosa (UFRGS, Brazil); and Martin J. Ward (University of Leicester, U.K.)</Credits>
@@ -40700,6 +40746,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000000202{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-21a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (STScI/AURA)  Acknowledgment: Ray A. Lucas (STScI/AURA)</Credits>
@@ -40882,6 +40929,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000000332{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-18b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (STScI/AURA)</Credits>
@@ -40960,6 +41008,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001022{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2005-09a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and The Hubble Heritage Team (STScI/AURA) Acknowledgment: M. Gregg (Univ. Calif.-Davis and Inst. for Geophysics  and Planetary Physics, Lawrence Livermore Natl. Lab.)</Credits>
@@ -40986,6 +41035,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="1"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001032{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1998-11g"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credits: Sun Kwok and Kate Su (University of Calgary), Bruce Hrivnak (Valparaiso University), and NASA</Credits>
@@ -41038,6 +41088,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001122{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2004-46a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA and A.Zijlstra (UMIST, Manchester, UK)</Credits>
@@ -41116,6 +41167,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001222{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2000-25a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (STScI/AURA)</Credits>
@@ -41142,6 +41194,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001232{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-33c"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and G. Meylan (Ecole Polytechnique Federale de Lausanne)</Credits>
@@ -41168,6 +41221,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001302{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2001-39a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credits: NASA, ESA, and The Hubble Heritage Team (STScI/AURA)  Acknowledgment: C. R. O'Dell (Vanderbilt University) and L. Bianchi (Johns Hopkins University and Osservatorio Astronomico, Torinese, Italy)</Credits>
@@ -41246,6 +41300,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001332{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-46a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and the Hubble Heritage Team (STScI/AURA)-ESA/Hubble  Collaboration Acknowledgment: B. Whitmore (Space Telescope Science Institute)</Credits>
@@ -41298,6 +41353,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000002012{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2000-23b,stsci|2000-23c"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: Brian D. Moore and J. Jeff Hester (Arizona State University)</Credits>
@@ -41376,6 +41432,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000002102{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1998-39a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: The Hubble Heritage Team (STScI/AURA/NASA)</Credits>
@@ -41402,6 +41459,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000002132{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2000-06a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: NASA, The Hubble Heritage Team (AURA/STScI)</Credits>
@@ -41428,6 +41486,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000002202{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2001-05a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: NASA, ESA and The Hubble Heritage Team (STScI/AURA) Acknowledgment: R. Sahai (Jet Propulsion Lab) and B. Balick (University of Washington)</Credits>
@@ -41480,6 +41539,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000002222{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2004-02c"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: F. Owen (NRAO), W. Keel (U. AL), M. Ledlow (Gemini Obs.),  G. Morrison (UNM), V. Andersen (U. AL)</Credits>
@@ -41532,6 +41592,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000002302{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2005-25b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, R. Sahai and J. Trauger (Jet Propulsion Laboratory) and the WFPC2 Science Team</Credits>
@@ -41558,6 +41619,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000002312{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-10b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA and the Hubble Heritage Team (STScI/AURA)</Credits>
@@ -41610,6 +41672,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000002332{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2004-35a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, Y. Izotov (Main Astronomical Observatory, Kyiv, UA) and T. Thuan (University of Virginia)</Credits>
@@ -41662,6 +41725,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000003032{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2004-15b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: NASA, ESA, and The Hubble Heritage Team (AURA/STScI) Acknowledgment: J. Higdon (Cornell U.) and I. Jordan (STScI)</Credits>
@@ -41740,6 +41804,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000003122{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-34b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and K. Sahu (STScI)</Credits>
@@ -41792,6 +41857,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000003202{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2005-20a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and The Hubble Heritage Team (STScI/AURA) Acknowledgment: J. Blakeslee (JHU) and R. Thompson (University of Arizona)</Credits>
@@ -41818,6 +41884,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="5"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000003212{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-54b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and J. Maíz Apellániz (Instituto de Astrofísica  de Andalucía, Spain)</Credits>
@@ -41870,6 +41937,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000003232{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-26a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and C. Wilson (McMaster University, Hamilton, Ontario, Canada)</Credits>
@@ -42000,6 +42068,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000010012{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2001-16a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and D. Maoz (Tel-Aviv University and Columbia University) Members of the group of scientists involved in these observations are: Dan Maoz (Tel-Aviv University, Israel and Columbia University, USA), Aaron J. Barth (Harvard-Smithsonian Center for Astrophysics, USA), Luis C. Ho (The Observatories of the Carnegie Institution of Washington, USA), Amiel Sternberg (Tel-Aviv University, Israel) and Alexei V. Filippenko (University of California, Berkeley, USA).</Credits>
@@ -42026,6 +42095,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000010022{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-16a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA and Michael Corbin (CSC/STScI)</Credits>
@@ -42052,6 +42122,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000010032{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2004-29n"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and The Hubble Heritage Team (STScI/AURA)  Acknowledgment: R. Sankrit and W. Blair (Johns Hopkins University)</Credits>
@@ -42078,6 +42149,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="1"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000010102{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1997-34e"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: Brad Whitmore (STScI) and NASA</Credits>
@@ -42130,6 +42202,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000010122{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2000-20a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA and The Hubble Heritage Team (STScI/AURA)</Credits>
@@ -42156,6 +42229,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="1"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000010132{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1997-38a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: Bruce Balick (University of Washington), Vincent Icke (Leiden University, The Netherlands), Garrelt Mellema (Stockholm University), and NASA</Credits>
@@ -42520,6 +42594,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000000133{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-06a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (STScI/AURA) Acknowledgment: C.R. O'Dell (Vanderbilt University)</Credits>
@@ -42572,6 +42647,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000000213{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1994-09a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: J. Hester/Arizona state University NASA.</Credits>
@@ -42624,6 +42700,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000000233{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-04a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, NRAO/AUI/NSF and W. Keel (University of Alabama, Tuscaloosa)</Credits>
@@ -42650,6 +42727,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000000303{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2001-11a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, Mohammad Heydari-Malayeri (Observatoire de Paris, France)</Credits>
@@ -42702,6 +42780,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000000323{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2001-34a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA &amp; Mohammad Heydari-Malayeri (Observatoire de Paris, France)</Credits>
@@ -42806,6 +42885,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001103{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2005-30a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and The Hubble Heritage Team (STScI/AURA) Acknowledgment: J.C. Green (Univ. of Colorado) and the Cosmic Origins Spectrograph (COS) GTO Team; NASA/CXO/SAO</Credits>
@@ -42832,6 +42912,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001113{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-07a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, The Hubble Heritage Team, (STScI/AURA) and A. Riess (STScI)</Credits>
@@ -42858,6 +42939,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001123{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2000-01a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (STScI)</Credits>
@@ -42884,6 +42966,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="5"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001133{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2005-04a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA and A. Nota (STScI/ESA)</Credits>
@@ -42910,6 +42993,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001203{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2001-07a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (STScI/AURA) Acknowledgment: J.C. Howk (Johns Hopkins University) and B.D. Savage (University of Wisconsin-Madison)</Credits>
@@ -42962,6 +43046,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001223{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1998-12c"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: Jim Flood (Amateur Astronomers Inc., Sperry Observatory), Max Mutchler (STScI)</Credits>
@@ -43014,6 +43099,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001303{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2007-05c"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and A. Pellerin (STScI)</Credits>
@@ -43092,6 +43178,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001333{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-29a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA and The Hubble Heritage Team (STScI/AURA)  Acknowledgment: M.S. Oey (Lowell Observatory) and Y.-H. Chu (U. of Illinois)</Credits>
@@ -43118,6 +43205,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002013{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2004-01b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, J. Blakeslee (Johns Hopkins University),  M. Postman (Space Telescope Science Institute), and P. Rosati (European Southern  Observatory)</Credits>
@@ -43144,6 +43232,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002023{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-10d"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit for Hubble telescope photos: NASA and H. Richer (University of British Columbia)</Credits>
@@ -43222,6 +43311,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002113{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2000-14a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA and The Hubble Heritage Team (STScI/AURA)</Credits>
@@ -43300,6 +43390,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002213{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2007-18a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: NASA, ESA, A. Sarajedini (University of Florida) and G. Piotto (University of Padua [Padova]) Science Credit: NASA, ESA, and G. Piotto (University of Padua [Padova])</Credits>
@@ -43326,6 +43417,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002223{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2004-26a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, Y. Nazé (University of Liège, Belgium) and Y.-H. Chu (University of Illinois, Urbana)</Credits>
@@ -43352,6 +43444,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002233{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2005-15f"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: X-ray: NASA/CXC/Rutgers/J.Warren et al.; Optical: NASA/STScI/U. Ill/Y.Chu; Radio: ATCA/U. Ill/J.Dickel et al.</Credits>
@@ -43378,6 +43471,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002303{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-38c"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, D. Bennett (University of Notre Dame), and J. Anderson (Rice University)</Credits>
@@ -43404,6 +43498,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002313{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1999-26a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: The Hubble Heritage Team (AURA/ STScI/ NASA)</Credits>
@@ -43430,6 +43525,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="5"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000002323{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-11e"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, H. Ford (JHU), G. Illingworth (UCSC/LO), M.Clampin (STScI), G. Hartig (STScI), the ACS Science Team, and ESA  The ACS Science Team:  H. Ford, G. Illingworth, M. Clampin, G. Hartig, T. Allen, K. Anderson, F. Bartko, N. Benitez, J. Blakeslee, R. Bouwens, T. Broadhurst, R. Brown, C. Burrows, D. Campbell, E. Cheng, N. Cross, P. Feldman, M. Franx, D. Golimowski, C. Gronwall, R. Kimble, J. Krist, M. Lesser, D. Magee, A. Martel, W. J. McCann, G. Meurer, G. Miley, M. Postman, P. Rosati, M. Sirianni, W. Sparks, P. Sullivan, H. Tran, Z. Tsvetanov, R. White, and R. Woodruff.</Credits>
@@ -43508,6 +43604,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003023{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2000-34a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (STScI/AURA) Acknowledgment: Roger Lynds (KPNO/NOAO)</Credits>
@@ -43560,6 +43657,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003103{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2002-24a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credits for X-ray Image:  NASA/CXC/ASU/J. Hester et al. Credits for Optical Image: NASA/HST/ASU/J. Hester et al.</Credits>
@@ -43612,6 +43710,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003133{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2005-01a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and The Hubble Heritage Team (STScI/AURA) Acknowledgment: P. Knezek (WIYN)</Credits>
@@ -43638,6 +43737,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003203{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2007-08a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and The Hubble Heritage Team (STScI/AURA) Acknowledgment: J. Blakeslee (Washington State University)</Credits>
@@ -43664,6 +43764,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003213{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-17b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: European Space Agency &amp; NASA Acknowledgment: E. Olszewski (University of Arizona)</Credits>
@@ -43690,6 +43791,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="5"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003233{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-51d"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and B. McNamara (University of Waterloo and Ohio University)</Credits>
@@ -43716,6 +43818,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="5"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003303{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-15a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA and T.M. Brown (STScI)</Credits>
@@ -43768,6 +43871,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000003323{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-20a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image Credit: NASA and The Hubble Heritage Team (STScI/AURA) Acknowledgment: Y.-H. Chu (UIUC), S. Kulkarni (Caltech), and R. Rothschild (UCSD)</Credits>
@@ -43846,6 +43950,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000010023{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2004-06a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: ESA, NASA and P. Anders (Göttingen University Galaxy Evolution Group, Germany</Credits>
@@ -43898,6 +44003,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000010103{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1998-17a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: S. R. Kulkarni and S. G. Djorgovski (Caltech), the Caltech GRB Team , and NASA</Credits>
@@ -43924,6 +44030,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000010113{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-39a,stsci|2009-18d"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: X-ray: NASA/CXC/M.Markevitch et al. Optical: NASA/STScI; Magellan/U.Arizona/D.Clowe et al. Lensing Map: NASA/STScI; ESO WFI; Magellan/U.Arizona/D.Clowe et al. </Credits>
@@ -43976,6 +44083,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000010133{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|1998-28d"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: The Hubble Heritage Team (AURA/STScI/NASA)</Credits>
@@ -44080,6 +44188,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="5"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000012133{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-30b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration Acknowledgment: R. Fesen (Dartmouth College) and J. Long (ESA/Hubble)</Credits>

--- a/imagesets/sky__visible.xml
+++ b/imagesets/sky__visible.xml
@@ -81457,7 +81457,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c10L{1}X{2}Y{3}.png"
     WidthFactor="1"
-    Xastropix_ids="esahubble|opo9738c,esahubble|opo9738c1,esahubble|opo9738c10"
+    Xastropix_ids="esahubble|opo9738c10"
     Xcxstatus="queue:hubble"
   >
     <Credits>Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble Gallery of Planetary Nebulae....</Credits>
@@ -81673,6 +81673,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c1L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9738c1"
     Xcxstatus="queue:hubble"
   >
     <Credits>Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble Gallery of Planetary Nebulae....</Credits>
@@ -81699,7 +81700,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c21L{1}X{2}Y{3}.png"
     WidthFactor="1"
-    Xastropix_ids="esahubble|opo9738c2,esahubble|opo9738c21"
+    Xastropix_ids="esahubble|opo9738c21"
     Xcxstatus="queue:hubble"
   >
     <Credits>Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble Gallery of Planetary Nebulae....</Credits>

--- a/imagesets/sky__visible.xml
+++ b/imagesets/sky__visible.xml
@@ -34181,6 +34181,7 @@ Image description: An image of a young star-forming region filled with wispy blu
     TileLevels="6"
     Url="http://data1.wwtassets.org/packages/2023/11_euclid/euclid-ero-horsehead/{1}/{3}/{3}_{2}.png"
     WidthFactor="2"
+    Xastropix_ids="ensci|euclid20231107c,ensci|euclid20231107c2"
     Xcxstatus="in:654ab5b95dff7c3291e3a358"
   >
     <Credits>ESA/Euclid/Euclid Consortium/NASA, image processing by J.-C. Cuillandre (CEA Paris-Saclay), G. Anselm</Credits>
@@ -34216,6 +34217,7 @@ Image description: An image of a young star-forming region filled with wispy blu
     TileLevels="6"
     Url="http://data1.wwtassets.org/packages/2023/11_euclid/euclid-ero-ic342/{1}/{3}/{3}_{2}.png"
     WidthFactor="2"
+    Xastropix_ids="ensci|euclid20231107a,ensci|euclid20231107a2"
     Xcxstatus="in:654c63105dff7c3291e3a74a"
   >
     <Credits>ESA/Euclid/Euclid Consortium/NASA, image processing by J.-C. Cuillandre (CEA Paris-Saclay), G. Anselmi</Credits>
@@ -34251,6 +34253,7 @@ Image description: An image of a young star-forming region filled with wispy blu
     TileLevels="6"
     Url="http://data1.wwtassets.org/packages/2023/11_euclid/euclid-ero-ngc6397/{1}/{3}/{3}_{2}.png"
     WidthFactor="2"
+    Xastropix_ids="ensci|euclid20231107d,ensci|euclid20231107d2"
     Xcxstatus="in:6551b7295dff7c3291e3af07"
   >
     <Credits>ESA/Euclid/Euclid Consortium/NASA, image processing by J.-C. Cuillandre (CEA Paris-Saclay), G. Anselmi</Credits>
@@ -34288,6 +34291,7 @@ The challenge is that it is typically difficult to observe an entire globular cl
     TileLevels="6"
     Url="http://data1.wwtassets.org/packages/2023/11_euclid/euclid-ero-ngc6822/{1}/{3}/{3}_{2}.png"
     WidthFactor="2"
+    Xastropix_ids="ensci|euclid20231107b,ensci|euclid20231107b2"
     Xcxstatus="in:654c63125dff7c3291e3a74c"
   >
     <Credits>ESA/Euclid/Euclid Consortium/NASA, image processing by J.-C. Cuillandre (CEA Paris-Saclay), G. Anselmi</Credits>
@@ -34319,6 +34323,7 @@ The challenge is that it is typically difficult to observe an entire globular cl
     TileLevels="6"
     Url="http://data1.wwtassets.org/packages/2023/11_euclid/euclid-ero-perseuscluster/{1}/{3}/{3}_{2}.png"
     WidthFactor="2"
+    Xastropix_ids="ensci|euclid20231107e,ensci|euclid20231107e2"
     Xcxstatus="in:654b8bcf5dff7c3291e3a572"
   >
     <Credits>ESA/Euclid/Euclid Consortium/NASA, image processing by J.-C. Cuillandre (CEA Paris-Saclay), G. Anselmi</Credits>
@@ -35381,6 +35386,7 @@ The challenge is that it is typically difficult to observe an entire globular cl
     TileLevels="6"
     Url="http://data1.wwtassets.org/packages/2024/05_euclid/euclid-ero-messier78/{1}/{3}/{3}_{2}.png"
     WidthFactor="2"
+    Xastropix_ids="ensci|euclid20240523c"
     Xcxstatus="in:664f517d78020dc3dc898a38"
   >
     <Credits>ESA/Euclid/Euclid Consortium/NASA, image processing by J.-C. Cuillandre (CEA Paris-Saclay), G. Anselmi</Credits>

--- a/imagesets/sky__visible.xml
+++ b/imagesets/sky__visible.xml
@@ -24208,7 +24208,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m3-burrell-schmid/L{1}X{2}Y{3}.png"
     WidthFactor="2"
-    Xastropix_ids="noirlab|noao-m3,noirlab|noao-m3-burrell-schmid"
+    Xastropix_ids="noirlab|noao-m3-burrell-schmid"
     Xcxstatus="in:642762ac975014bc743f16d7"
   >
     <Credits>N.A.Sharp, Vanessa Harvey/REU program/NOIRLab/NSF/AURA</Credits>
@@ -25411,7 +25411,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m90/L{1}X{2}Y{3}.png"
     WidthFactor="2"
-    Xastropix_ids="noirlab|noao-m9,noirlab|noao-m90"
+    Xastropix_ids="noirlab|noao-m90"
     Xcxstatus="in:642762c1975014bc743f1701"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -27402,7 +27402,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-wlm-dwarf/L{1}X{2}Y{3}.png"
     WidthFactor="2"
-    Xastropix_ids="noirlab|noao-wlm,noirlab|noao-wlm-dwarf"
+    Xastropix_ids="noirlab|noao-wlm-dwarf"
     Xcxstatus="in:642762e2975014bc743f1747"
   >
     <Credits>P. Massey/Lowell Observatory and K. Olsen/NOIRLab/NSF/AURA</Credits>
@@ -62259,6 +62259,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1724cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1724c"
     Xcxstatus="queue:eso"
   >
     <ThumbnailUrl>http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eso1724c.jpg</ThumbnailUrl>
@@ -62283,7 +62284,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1724caL{1}X{2}Y{3}.png"
     WidthFactor="1"
-    Xastropix_ids="eso|eso1724c,eso|eso1724ca"
+    Xastropix_ids="eso|eso1724ca"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/P. Weilbacher; The planetary nebula NGC 6563 resides in a crowded starry region of the sky. In natural sky conditions many of these stars remai...</Credits>
@@ -64192,6 +64193,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-etaL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eta"
     Xcxstatus="queue:eso"
   >
     <ThumbnailUrl>http://wwtfiles.blob.core.windows.net/vamp/thumb-ESO-eta.jpg</ThumbnailUrl>
@@ -64216,7 +64218,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-etamosaicnm2L{1}X{2}Y{3}.png"
     WidthFactor="1"
-    Xastropix_ids="eso|eta,eso|etamosaicnm2"
+    Xastropix_ids="eso|etamosaicnm2"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/IDA/Danish 1.5 m/R.Gendler, ; The Carina Nebula is a large bright nebula that surrounds several clusters of stars. It contains two of the most massive and lum...</Credits>
@@ -98685,7 +98687,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2012-02a1L{1}X{2}Y{3}.png"
     WidthFactor="1"
-    Xastropix_ids="spitzer|ssc2012-02a,spitzer|ssc2012-02a1"
+    Xastropix_ids="spitzer|ssc2012-02a1"
     Xcxstatus="in:64b744b7a15b29de42b3060f"
   >
     <Credits>NASA/JPL-Caltech/Harvard-Smithso; A bubbling cauldron of star birth is highlighted in this new image from NASA's Spitzer Space Telescope. Infrared light that we c...</Credits>
@@ -98712,6 +98714,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Spitzer-ssc2012-02aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="spitzer|ssc2012-02a"
     Xcxstatus="in:64b744b8a15b29de42b30611"
   >
     <Credits>NASA/JPL-Caltech/Harvard-Smithsonian CfA</Credits>
@@ -99918,7 +99921,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-004c1L{1}X{2}Y{3}.png"
     WidthFactor="1"
-    Xastropix_ids="wise|WISE2010-004c,wise|WISE2010-004c1"
+    Xastropix_ids="wise|WISE2010-004c1"
     Xcxstatus="in:649e45db1e6961df10c1957d"
   >
     <Credits>NASA/JPL-Caltech/WISE Team; This image from NASA's Wide-field Infrared Survey Explorer, or WISE, highlights the Andromeda galaxy's older stellar population ...</Credits>
@@ -99972,6 +99975,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-004cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-004c"
     Xcxstatus="in:649e45d21e6961df10c19568"
   >
     <Credits>NASA/JPL-Caltech/WISE Team</Credits>
@@ -101022,6 +101026,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-041L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="wise|WISE2010-041"
     Xcxstatus="in:649e45e81e6961df10c1959d"
   >
     <Credits>NASA/JPL-Caltech/UCLA; This image shows a puffy, dying star, or planetary nebula, known as NGC 1514. The object is actually a pair of stars -- one star...</Credits>
@@ -101048,7 +101053,7 @@ The saturated yellow point at the center ...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Wise-WISE2010-041bL{1}X{2}Y{3}.png"
     WidthFactor="1"
-    Xastropix_ids="wise|WISE2010-041,wise|WISE2010-041b"
+    Xastropix_ids="wise|WISE2010-041b"
     Xcxstatus="in:649e45de1e6961df10c19585"
   >
     <Credits>Caltech/Palomar; This visible-light image is from the Digitized Sky Survey, based at the Space Telescope Science Institute in Baltimore, Md. The ...</Credits>

--- a/imagesets/sky__visible.xml
+++ b/imagesets/sky__visible.xml
@@ -80,6 +80,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/03_sn-1987a_cc/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|03_sn-1987a_cc"
     Xcxstatus="in:654a32aa5dff7c3291e3a1be"
   >
     <Credits>ESO</Credits>
@@ -108,6 +109,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/05_sn-1987a_cc/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|05_sn-1987a_cc"
     Xcxstatus="in:654a32ab5dff7c3291e3a1c0"
   >
     <Credits>ESO</Credits>
@@ -136,6 +138,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/06_sn-1987a_cc/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|06_sn-1987a_cc"
     Xcxstatus="in:654a32ac5dff7c3291e3a1c2"
   >
     <Credits>ESO</Credits>
@@ -164,6 +167,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/10_sn-1987a_cc/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|10_sn-1987a_cc"
     Xcxstatus="in:654a32ad5dff7c3291e3a1c4"
   >
     <Credits>ESO</Credits>
@@ -192,6 +196,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/16_sn-1987a_cc/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|16_sn-1987a_cc"
     Xcxstatus="in:654a32ae5dff7c3291e3a1c6"
   >
     <Credits>ESO</Credits>
@@ -220,6 +225,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/20171102_whya/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|20171102_whya"
     Xcxstatus="in:654a32af5dff7c3291e3a1c8"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO), Takigawa et al.</Credits>
@@ -248,6 +254,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/ann11075a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|ann11075a"
     Xcxstatus="in:654a35e35dff7c3291e3a1d9"
   >
     <Credits>ESA/Hubble and NASA</Credits>
@@ -276,6 +283,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/ann18006a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|ann18006a"
     Xcxstatus="in:654a35e55dff7c3291e3a1db"
   >
     <Credits>ESO</Credits>
@@ -304,6 +312,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/ann18006b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|ann18006b"
     Xcxstatus="in:654a35e55dff7c3291e3a1dd"
   >
     <Credits>ESO</Credits>
@@ -332,6 +341,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/ann21010a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|ann21010a"
     Xcxstatus="in:654a35e65dff7c3291e3a1df"
   >
     <Credits>ESO/J. Emerson/VISTA Acknowledgment: Cambridge Astronomical Survey Unit</Credits>
@@ -360,6 +370,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/ann21010b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|ann21010b"
     Xcxstatus="in:654a35e75dff7c3291e3a1e1"
   >
     <Credits>CONCERTO team/A. Beelen, ESO</Credits>
@@ -388,6 +399,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/ann21010c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|ann21010c"
     Xcxstatus="in:654a35e85dff7c3291e3a1e3"
   >
     <Credits>CONCERTO team/A. Beelen, ESO</Credits>
@@ -416,6 +428,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/ann21010d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|ann21010d"
     Xcxstatus="in:654a35e95dff7c3291e3a1e5"
   >
     <Credits>CONCERTO team/A. Beelen, ESO</Credits>
@@ -444,6 +457,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso-2613/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso-2613"
     Xcxstatus="in:654a35ea5dff7c3291e3a1e7"
   >
     <Credits>ESO/IDA/Danish 1.5 m/R. Gendler, J.-E. Ovaldsen, C. Thöne and C. Féron</Credits>
@@ -472,6 +486,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0004b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0004b"
     Xcxstatus="in:654a35eb5dff7c3291e3a1e9"
   >
     <Credits>ESO</Credits>
@@ -500,6 +515,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0005a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0005a"
     Xcxstatus="in:654b8bb75dff7c3291e3a556"
   >
     <Credits>ESO</Credits>
@@ -528,6 +544,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0005b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0005b"
     Xcxstatus="in:654b8bb95dff7c3291e3a558"
   >
     <Credits>ESO</Credits>
@@ -556,6 +573,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0005c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0005c"
     Xcxstatus="in:654b8bbb5dff7c3291e3a55a"
   >
     <Credits>ESO</Credits>
@@ -584,6 +602,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0006b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0006b"
     Xcxstatus="in:654b8bbd5dff7c3291e3a55c"
   >
     <Credits>ESO</Credits>
@@ -612,6 +631,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0007a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0007a"
     Xcxstatus="in:654b8bbe5dff7c3291e3a55e"
   >
     <Credits>ESO/P. BarthelAcknowledgments: Mark Neeser (Kapteyn Institute, Groningen) and Richard Hook (ST/ECF, Garching, Germany). </Credits>
@@ -640,6 +660,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0007b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0007b"
     Xcxstatus="in:654b8bbf5dff7c3291e3a560"
   >
     <Credits>ESO/P. Barthel</Credits>
@@ -668,6 +689,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0007c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0007c"
     Xcxstatus="in:654b8bc05dff7c3291e3a562"
   >
     <Credits>ESO/P. Barthel</Credits>
@@ -696,6 +718,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0024a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0024a"
     Xcxstatus="in:654b8bc15dff7c3291e3a564"
   >
     <Credits>ESO</Credits>
@@ -752,6 +775,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0030a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0030a"
     Xcxstatus="in:654b8bc55dff7c3291e3a568"
   >
     <Credits>ESO</Credits>
@@ -780,6 +804,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0031a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0031a"
     Xcxstatus="in:654b8bc75dff7c3291e3a56a"
   >
     <Credits>ESO </Credits>
@@ -808,6 +833,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0031b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0031b"
     Xcxstatus="in:654b8bca5dff7c3291e3a56c"
   >
     <Credits>ESO</Credits>
@@ -836,6 +862,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0034a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0034a"
     Xcxstatus="in:654b8bcb5dff7c3291e3a56e"
   >
     <Credits>ESO</Credits>
@@ -864,6 +891,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0037a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0037a"
     Xcxstatus="in:654b8bcd5dff7c3291e3a570"
   >
     <Credits>ESO</Credits>
@@ -920,6 +948,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0102a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0102a"
     Xcxstatus="in:65621c898a2fdcee25a061a1"
   >
     <Credits>ESO</Credits>
@@ -948,6 +977,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0102b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0102b"
     Xcxstatus="in:65621c8a8a2fdcee25a061a3"
   >
     <Credits>ESO</Credits>
@@ -976,6 +1006,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0104a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0104a"
     Xcxstatus="in:65621c8b8a2fdcee25a061a5"
   >
     <Credits>ESO/M.McCaughrean et al. (AIP)</Credits>
@@ -1004,6 +1035,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0104c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0104c"
     Xcxstatus="in:65621c8c8a2fdcee25a061a7"
   >
     <Credits>ESO/M.McCaughrean et al. (AIP)</Credits>
@@ -1032,6 +1064,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0106a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0106a"
     Xcxstatus="in:65621c8d8a2fdcee25a061a9"
   >
     <Credits>AURA</Credits>
@@ -1060,6 +1093,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0109a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0109a"
     Xcxstatus="in:65621c8e8a2fdcee25a061ab"
   >
     <Credits>ESO</Credits>
@@ -1088,6 +1122,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0116a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0116a"
     Xcxstatus="in:65621c8f8a2fdcee25a061ad"
   >
     <Credits>ESO</Credits>
@@ -1116,6 +1151,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0116b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0116b"
     Xcxstatus="in:65621c908a2fdcee25a061af"
   >
     <Credits>ESO</Credits>
@@ -1144,6 +1180,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0116c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0116c"
     Xcxstatus="in:65621c918a2fdcee25a061b1"
   >
     <Credits>ESO</Credits>
@@ -1172,6 +1209,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0116d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0116d"
     Xcxstatus="in:65621c928a2fdcee25a061b3"
   >
     <Credits>ESO</Credits>
@@ -1200,6 +1238,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0116e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0116e"
     Xcxstatus="in:65621c928a2fdcee25a061b5"
   >
     <Credits>ESO</Credits>
@@ -1228,6 +1267,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0116f/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0116f"
     Xcxstatus="in:65621c938a2fdcee25a061b7"
   >
     <Credits>ESO</Credits>
@@ -1256,6 +1296,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0122a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0122a"
     Xcxstatus="in:656f389df864172823764b39"
   >
     <Credits>ESO</Credits>
@@ -1284,6 +1325,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0122b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0122b"
     Xcxstatus="in:656f3925f864172823764b3b"
   >
     <Credits>ESO</Credits>
@@ -1312,6 +1354,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0124a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0124a"
     Xcxstatus="in:656f3925f864172823764b3d"
   >
     <Credits>ESO</Credits>
@@ -1340,6 +1383,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0136a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0136a"
     Xcxstatus="in:656f3926f864172823764b3f"
   >
     <Credits>ESO</Credits>
@@ -1368,6 +1412,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0137d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0137d"
     Xcxstatus="in:656f3927f864172823764b41"
   >
     <Credits>ESO</Credits>
@@ -1396,6 +1441,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0142a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0142a"
     Xcxstatus="in:656f3928f864172823764b43"
   >
     <Credits>ESO/M.McCaughrean &amp;amp; M.Andersen (AIP)</Credits>
@@ -1424,6 +1470,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0142b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0142b"
     Xcxstatus="in:656f3929f864172823764b45"
   >
     <Credits>ESO/M.McCaughrean &amp;amp; M.Andersen (AIP)</Credits>
@@ -1452,6 +1499,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0142c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0142c"
     Xcxstatus="in:656f392af864172823764b47"
   >
     <Credits>ESO/M.McCaughrean &amp;amp; M.Andersen (AIP)</Credits>
@@ -1480,6 +1528,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0142d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0142d"
     Xcxstatus="in:656f392af864172823764b49"
   >
     <Credits>ESO/M.McCaughrean &amp;amp; M.Andersen (AIP)</Credits>
@@ -1508,6 +1557,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0142e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0142e"
     Xcxstatus="in:656f392bf864172823764b4b"
   >
     <Credits>ESO/M.McCaughrean &amp;amp; M.Andersen (AIP)</Credits>
@@ -1536,6 +1586,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0202a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0202a"
     Xcxstatus="in:656f392cf864172823764b4d"
   >
     <Credits>ESO</Credits>
@@ -1564,6 +1615,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0202b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0202b"
     Xcxstatus="in:656f392df864172823764b4f"
   >
     <Credits>ESO</Credits>
@@ -1592,6 +1644,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0209a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0209a"
     Xcxstatus="in:656f392ef864172823764b51"
   >
     <Credits>ESO</Credits>
@@ -1620,6 +1673,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0209e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0209e"
     Xcxstatus="in:6579d0f360c68ea9c726b2a5"
   >
     <Credits>ESO</Credits>
@@ -1648,6 +1702,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0209f/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0209f"
     Xcxstatus="in:6579d0f460c68ea9c726b2a8"
   >
     <Credits>ESO</Credits>
@@ -1676,6 +1731,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0209g/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0209g"
     Xcxstatus="in:6579d0f560c68ea9c726b2aa"
   >
     <Credits>ESO</Credits>
@@ -1704,6 +1760,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0209h/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0209h"
     Xcxstatus="in:6579d0f660c68ea9c726b2ac"
   >
     <Credits>ESO</Credits>
@@ -1732,6 +1789,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0209i/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0209i"
     Xcxstatus="in:6579d0f760c68ea9c726b2ae"
   >
     <Credits>ESO</Credits>
@@ -1760,6 +1818,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0209j/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0209j"
     Xcxstatus="in:6579d0f860c68ea9c726b2b0"
   >
     <Credits>ESO</Credits>
@@ -1788,6 +1847,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0214a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0214a"
     Xcxstatus="in:6579d0f960c68ea9c726b2b2"
   >
     <Credits>ESO</Credits>
@@ -1816,6 +1876,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0214b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0214b"
     Xcxstatus="in:6579d0f960c68ea9c726b2b4"
   >
     <Credits>ESO</Credits>
@@ -1844,6 +1905,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0214c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0214c"
     Xcxstatus="in:6579d0fa60c68ea9c726b2b6"
   >
     <Credits>ESO</Credits>
@@ -1872,6 +1934,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0216a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0216a"
     Xcxstatus="in:6579d0fb60c68ea9c726b2b8"
   >
     <Credits>ESO</Credits>
@@ -1900,6 +1963,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0216b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0216b"
     Xcxstatus="in:6579d0fc60c68ea9c726b2ba"
   >
     <Credits>ESO</Credits>
@@ -1928,6 +1992,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0216c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0216c"
     Xcxstatus="in:6579d0fd60c68ea9c726b2bc"
   >
     <Credits>ESO</Credits>
@@ -1956,6 +2021,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0216d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0216d"
     Xcxstatus="in:6579d0fe60c68ea9c726b2be"
   >
     <Credits>ESO</Credits>
@@ -1984,6 +2050,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0216e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0216e"
     Xcxstatus="in:6579d0fe60c68ea9c726b2c0"
   >
     <Credits>ESO</Credits>
@@ -2012,6 +2079,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0216g/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0216g"
     Xcxstatus="in:6579d0ff60c68ea9c726b2c2"
   >
     <Credits>ESO</Credits>
@@ -2040,6 +2108,7 @@
     TileLevels="7"
     Url="http://data1.wwtassets.org/feeds/eso/eso0221a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0221a"
     Xcxstatus="in:6585a23319f6c100f1f685cd"
   >
     <Credits>ESO</Credits>
@@ -2068,6 +2137,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0221b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0221b"
     Xcxstatus="in:6585a23419f6c100f1f685cf"
   >
     <Credits>ESO</Credits>
@@ -2096,6 +2166,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0221c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0221c"
     Xcxstatus="in:6585a23519f6c100f1f685d1"
   >
     <Credits>ESO</Credits>
@@ -2124,6 +2195,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0221d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0221d"
     Xcxstatus="in:6585a23619f6c100f1f685d3"
   >
     <Credits>ESO</Credits>
@@ -2152,6 +2224,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0221f/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0221f"
     Xcxstatus="in:6585a23719f6c100f1f685d5"
   >
     <Credits>ESO</Credits>
@@ -2180,6 +2253,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0221g/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0221g"
     Xcxstatus="in:6585a23719f6c100f1f685d7"
   >
     <Credits>ESO</Credits>
@@ -2208,6 +2282,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0221h/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0221h"
     Xcxstatus="in:6585a23819f6c100f1f685d9"
   >
     <Credits>ESO</Credits>
@@ -2236,6 +2311,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0223a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0223a"
     Xcxstatus="in:6585a23919f6c100f1f685db"
   >
     <Credits>ESO</Credits>
@@ -2264,6 +2340,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0226a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0226a"
     Xcxstatus="in:6585a23a19f6c100f1f685dd"
   >
     <Credits>ESO</Credits>
@@ -2292,6 +2369,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0302a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0302a"
     Xcxstatus="in:6585a23b19f6c100f1f685df"
   >
     <Credits>ESO</Credits>
@@ -2320,6 +2398,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0302c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0302c"
     Xcxstatus="in:6585a23c19f6c100f1f685e1"
   >
     <Credits>ESO</Credits>
@@ -2348,6 +2427,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0302d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0302d"
     Xcxstatus="in:6585a23c19f6c100f1f685e3"
   >
     <Credits>ESO</Credits>
@@ -2376,6 +2456,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0304a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0304a"
     Xcxstatus="in:659d64de293f0a5746370a2f"
   >
     <Credits>ESO</Credits>
@@ -2404,6 +2485,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0304b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0304b"
     Xcxstatus="in:659d64e0293f0a5746370a31"
   >
     <Credits>ESO</Credits>
@@ -2432,6 +2514,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0305b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0305b"
     Xcxstatus="in:659d64e2293f0a5746370a33"
   >
     <Credits>Reproduced from the Digital Sky Survey [STScI Digitized Sky Survey, (C) 1993, 1994, AURA, Inc. all rights reserved - cf.http://archive.eso.org/dss/dss]</Credits>
@@ -2460,6 +2543,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0310a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0310a"
     Xcxstatus="in:659d64e3293f0a5746370a35"
   >
     <Credits>ESO</Credits>
@@ -2488,6 +2572,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0310b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0310b"
     Xcxstatus="in:65bd1abe3dd4a5b0962fa324"
   >
     <Credits>ESO </Credits>
@@ -2516,6 +2601,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0310c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0310c"
     Xcxstatus="in:65bd1abf3dd4a5b0962fa326"
   >
     <Credits>ESO</Credits>
@@ -2544,6 +2630,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0310d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0310d"
     Xcxstatus="in:65bd1ac03dd4a5b0962fa328"
   >
     <Credits>ESO</Credits>
@@ -2572,6 +2659,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0311a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0311a"
     Xcxstatus="in:65bd1ac13dd4a5b0962fa32a"
   >
     <Credits>ESO</Credits>
@@ -2600,6 +2688,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0313h/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0313h"
     Xcxstatus="in:65bd1ac23dd4a5b0962fa32c"
   >
     <Credits>ESO</Credits>
@@ -2628,6 +2717,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0315a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0315a"
     Xcxstatus="in:65bd1ac33dd4a5b0962fa32e"
   >
     <Credits>ESO</Credits>
@@ -2656,6 +2746,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0315c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0315c"
     Xcxstatus="in:65d8c46faffb32cbf1d96a41"
   >
     <Credits>ESO</Credits>
@@ -2684,6 +2775,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0315d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0315d"
     Xcxstatus="in:65d8c470affb32cbf1d96a43"
   >
     <Credits>ESO</Credits>
@@ -2712,6 +2804,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0315e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0315e"
     Xcxstatus="in:65d8c471affb32cbf1d96a45"
   >
     <Credits>ESO</Credits>
@@ -2740,6 +2833,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0315f/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0315f"
     Xcxstatus="in:65d8c472affb32cbf1d96a47"
   >
     <Credits>ESO</Credits>
@@ -2768,6 +2862,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0315g/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0315g"
     Xcxstatus="in:65d8c473affb32cbf1d96a49"
   >
     <Credits>ESO</Credits>
@@ -2796,6 +2891,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0317a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0317a"
     Xcxstatus="in:65d8c474affb32cbf1d96a4b"
   >
     <Credits>ESO</Credits>
@@ -2824,6 +2920,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0322b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0322b"
     Xcxstatus="in:65d8c475affb32cbf1d96a4d"
   >
     <Credits>ESO</Credits>
@@ -2852,6 +2949,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0326a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0326a"
     Xcxstatus="in:65d8c476affb32cbf1d96a4f"
   >
     <Credits>ESO</Credits>
@@ -2880,6 +2978,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0332a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0332a"
     Xcxstatus="in:65d8c477affb32cbf1d96a51"
   >
     <Credits>ESO</Credits>
@@ -2908,6 +3007,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0332b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0332b"
     Xcxstatus="in:65d8c478affb32cbf1d96a53"
   >
     <Credits>ESO</Credits>
@@ -2936,6 +3036,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0332c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0332c"
     Xcxstatus="in:65d8c479affb32cbf1d96a55"
   >
     <Credits>ESO</Credits>
@@ -2964,6 +3065,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0332d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0332d"
     Xcxstatus="in:65d8c47aaffb32cbf1d96a57"
   >
     <Credits>ESO</Credits>
@@ -2992,6 +3094,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0332e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0332e"
     Xcxstatus="in:65d8c47baffb32cbf1d96a59"
   >
     <Credits>ESO</Credits>
@@ -3020,6 +3123,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0338a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0338a"
     Xcxstatus="in:65dccff2affb32cbf1d96fa2"
   >
     <Credits>ESO/P.D. Barthel</Credits>
@@ -3048,6 +3152,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0338b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0338b"
     Xcxstatus="in:65dccff3affb32cbf1d96fa4"
   >
     <Credits>ESO/P. Barthel</Credits>
@@ -3104,6 +3209,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0413a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0413a"
     Xcxstatus="in:65dccff5affb32cbf1d96fa8"
   >
     <Credits>ESO</Credits>
@@ -3132,6 +3238,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0415a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0415a"
     Xcxstatus="in:65dccff6affb32cbf1d96faa"
   >
     <Credits>DSS</Credits>
@@ -3188,6 +3295,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0416a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0416a"
     Xcxstatus="in:65dccff7affb32cbf1d96fae"
   >
     <Credits>ESO</Credits>
@@ -3216,6 +3324,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0416b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0416b"
     Xcxstatus="in:65dccff8affb32cbf1d96fb0"
   >
     <Credits>ESO</Credits>
@@ -3244,6 +3353,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0419b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0419b"
     Xcxstatus="in:65dccff9affb32cbf1d96fb2"
   >
     <Credits>ESO</Credits>
@@ -3272,6 +3382,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0419c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0419c"
     Xcxstatus="in:65dccffaaffb32cbf1d96fb4"
   >
     <Credits>ESO</Credits>
@@ -3300,6 +3411,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0421a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0421a"
     Xcxstatus="in:65dccffbaffb32cbf1d96fb6"
   >
     <Credits>ESO</Credits>
@@ -3328,6 +3440,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0422a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0422a"
     Xcxstatus="in:65dccffcaffb32cbf1d96fb8"
   >
     <Credits>ESO</Credits>
@@ -3356,6 +3469,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0425a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0425a"
     Xcxstatus="in:65e5f0e7affb32cbf1d97cf8"
   >
     <Credits>ESO</Credits>
@@ -3384,6 +3498,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0434a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0434a"
     Xcxstatus="in:65e5f0e8affb32cbf1d97cfa"
   >
     <Credits>ESO</Credits>
@@ -3412,6 +3527,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0434b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0434b"
     Xcxstatus="in:65e5f0e9affb32cbf1d97cfc"
   >
     <Credits>ESO</Credits>
@@ -3440,6 +3556,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0436a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0436a"
     Xcxstatus="in:65e5f0eaaffb32cbf1d97cfe"
   >
     <Credits>ESO</Credits>
@@ -3468,6 +3585,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0436b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0436b"
     Xcxstatus="in:65e5f0eaaffb32cbf1d97d00"
   >
     <Credits>ESO</Credits>
@@ -3496,6 +3614,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0437a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0437a"
     Xcxstatus="in:65e5f0ebaffb32cbf1d97d02"
   >
     <Credits>ESO</Credits>
@@ -3524,6 +3643,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0437b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0437b"
     Xcxstatus="in:65e5f0ecaffb32cbf1d97d04"
   >
     <Credits>ESO</Credits>
@@ -3552,6 +3672,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0437c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0437c"
     Xcxstatus="in:65e5f0edaffb32cbf1d97d06"
   >
     <Credits>ESO</Credits>
@@ -3580,6 +3701,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0437e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0437e"
     Xcxstatus="in:65e5f0eeaffb32cbf1d97d08"
   >
     <Credits>ESO</Credits>
@@ -3608,6 +3730,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0437f/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0437f"
     Xcxstatus="in:65e5f0efaffb32cbf1d97d0a"
   >
     <Credits>ESO</Credits>
@@ -3636,6 +3759,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0437g/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0437g"
     Xcxstatus="in:65e5f0f0affb32cbf1d97d0c"
   >
     <Credits>ESO</Credits>
@@ -3664,6 +3788,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0437h/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0437h"
     Xcxstatus="in:65e5f0f1affb32cbf1d97d0e"
   >
     <Credits>ESO</Credits>
@@ -3692,6 +3817,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0438d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0438d"
     Xcxstatus="in:65e5f0f2affb32cbf1d97d10"
   >
     <Credits>ESO</Credits>
@@ -3720,6 +3846,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0510a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0510a"
     Xcxstatus="in:66070835dc7be96c90c53467"
   >
     <Credits>ESO</Credits>
@@ -3748,6 +3875,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0513a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0513a"
     Xcxstatus="in:66070836dc7be96c90c53469"
   >
     <Credits>ESO</Credits>
@@ -3776,6 +3904,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0513b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0513b"
     Xcxstatus="in:66070837dc7be96c90c5346b"
   >
     <Credits>ESO</Credits>
@@ -3804,6 +3933,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0513e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0513e"
     Xcxstatus="in:66070838dc7be96c90c5346d"
   >
     <Credits>ESO</Credits>
@@ -3832,6 +3962,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0521a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0521a"
     Xcxstatus="in:66070839dc7be96c90c5346f"
   >
     <Credits>ESO</Credits>
@@ -3860,6 +3991,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0521b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0521b"
     Xcxstatus="in:6607083adc7be96c90c53471"
   >
     <Credits>ESO</Credits>
@@ -3888,6 +4020,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0524a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0524a"
     Xcxstatus="in:6607083bdc7be96c90c53473"
   >
     <Credits>ESO</Credits>
@@ -3916,6 +4049,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0525a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0525a"
     Xcxstatus="in:6607083cdc7be96c90c53475"
   >
     <Credits>ESO</Credits>
@@ -3944,6 +4078,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0525b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0525b"
     Xcxstatus="in:6607083ddc7be96c90c53477"
   >
     <Credits>ESO</Credits>
@@ -3972,6 +4107,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0527a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0527a"
     Xcxstatus="in:6607083ddc7be96c90c53479"
   >
     <Credits>ESO</Credits>
@@ -4000,6 +4136,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0532a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0532a"
     Xcxstatus="in:6607083edc7be96c90c5347b"
   >
     <Credits>ESO</Credits>
@@ -4028,6 +4165,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0533a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0533a"
     Xcxstatus="in:6607083fdc7be96c90c5347d"
   >
     <Credits>ESO</Credits>
@@ -4056,6 +4194,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0534a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0534a"
     Xcxstatus="in:66070840dc7be96c90c5347f"
   >
     <Credits>ESO/Prieto et al.</Credits>
@@ -4084,6 +4223,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0535a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0535a"
     Xcxstatus="in:661fef73befbe21fbdf49bbb"
   >
     <Credits>ESO</Credits>
@@ -4112,6 +4252,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0535b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0535b"
     Xcxstatus="in:661fef74befbe21fbdf49bbd"
   >
     <Credits>ESO</Credits>
@@ -4140,6 +4281,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0544a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0544a"
     Xcxstatus="in:661fef74befbe21fbdf49bbf"
   >
     <Credits>ESO</Credits>
@@ -4168,6 +4310,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0544b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0544b"
     Xcxstatus="in:661fef75befbe21fbdf49bc1"
   >
     <Credits>ESO</Credits>
@@ -4196,6 +4339,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0604a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0604a"
     Xcxstatus="in:661fef76befbe21fbdf49bc3"
   >
     <Credits>ESO</Credits>
@@ -4224,6 +4368,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0608a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0608a"
     Xcxstatus="in:661fef77befbe21fbdf49bc5"
   >
     <Credits>ESO</Credits>
@@ -4252,6 +4397,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0613a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0613a"
     Xcxstatus="in:661fef78befbe21fbdf49bc7"
   >
     <Credits>ESO</Credits>
@@ -4280,6 +4426,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0613b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0613b"
     Xcxstatus="in:661fef79befbe21fbdf49bc9"
   >
     <Credits>ESO</Credits>
@@ -4308,6 +4455,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0613c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0613c"
     Xcxstatus="in:661fef7abefbe21fbdf49bcb"
   >
     <Credits>ESO</Credits>
@@ -4336,6 +4484,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0613d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0613d"
     Xcxstatus="in:661fef7bbefbe21fbdf49bcd"
   >
     <Credits>ESO</Credits>
@@ -4364,6 +4513,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0614a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0614a"
     Xcxstatus="in:661fef7cbefbe21fbdf49bcf"
   >
     <Credits>ESO</Credits>
@@ -4392,6 +4542,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0614b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0614b"
     Xcxstatus="in:661fef7dbefbe21fbdf49bd1"
   >
     <Credits>ESO</Credits>
@@ -4420,6 +4571,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0614c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0614c"
     Xcxstatus="in:661fef7ebefbe21fbdf49bd3"
   >
     <Credits>ESO</Credits>
@@ -4448,6 +4600,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0617a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0617a"
     Xcxstatus="in:661fef7ebefbe21fbdf49bd5"
   >
     <Credits>ESO</Credits>
@@ -4476,6 +4629,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0620a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0620a"
     Xcxstatus="in:661fef7fbefbe21fbdf49bd7"
   >
     <Credits>ESO</Credits>
@@ -4504,6 +4658,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0622a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0622a"
     Xcxstatus="in:661fef80befbe21fbdf49bd9"
   >
     <Credits>ESO</Credits>
@@ -4532,6 +4687,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0622b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0622b"
     Xcxstatus="in:661fef81befbe21fbdf49bdb"
   >
     <Credits>ESO</Credits>
@@ -4560,6 +4716,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0627a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0627a"
     Xcxstatus="in:661fef82befbe21fbdf49bdd"
   >
     <Credits>ESO</Credits>
@@ -4588,6 +4745,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0627b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0627b"
     Xcxstatus="in:661fef83befbe21fbdf49bdf"
   >
     <Credits>ESO</Credits>
@@ -4616,6 +4774,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0627c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0627c"
     Xcxstatus="in:661fef84befbe21fbdf49be1"
   >
     <Credits>ESO</Credits>
@@ -4644,6 +4803,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0630a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0630a"
     Xcxstatus="in:661fef85befbe21fbdf49be3"
   >
     <Credits>ESO</Credits>
@@ -4672,6 +4832,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0643a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0643a"
     Xcxstatus="in:661fef86befbe21fbdf49be5"
   >
     <Credits>ESO</Credits>
@@ -4700,6 +4861,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0643b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0643b"
     Xcxstatus="in:661fef87befbe21fbdf49be7"
   >
     <Credits>ESO</Credits>
@@ -4728,6 +4890,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0649b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0649b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -4756,6 +4919,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0650a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0650a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/R. Fosbury (ST-ECF)</Credits>
@@ -4784,6 +4948,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0650b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0650b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -4812,6 +4977,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0708a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0708a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -4840,6 +5006,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0709a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0709a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -4868,6 +5035,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0712a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0712a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -4896,6 +5064,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0715a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0715a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey.</Credits>
@@ -4924,6 +5093,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0716a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0716a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -4952,6 +5122,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0722c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0722c"
     Xcxstatus="queue:eso"
   >
     <Credits>Digital Sky Survey</Credits>
@@ -4980,6 +5151,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0736b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0736b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -5008,6 +5180,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0736c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0736c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -5036,6 +5209,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0739a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0739a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -5064,6 +5238,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0749a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0749a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -5092,6 +5267,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0755a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0755a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -5120,6 +5296,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0755b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0755b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -5148,6 +5325,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0802a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0802a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -5176,6 +5354,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0803c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0803c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -5204,6 +5383,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0805a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0805a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -5232,6 +5412,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0806a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0806a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -5260,6 +5441,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0809a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0809a"
     Xcxstatus="queue:eso"
   >
     <Credits>Digital Sky Survey/VirGO.</Credits>
@@ -5288,6 +5470,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0823a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0823a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -5316,6 +5499,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0825a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0825a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -5344,6 +5528,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0832a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0832a"
     Xcxstatus="queue:eso"
   >
     <Credits>X-ray (NASA/CXC/Columbia/F.Bauer et al); Visible light (NASA/STScI/UMD/A.Wilson et al.)</Credits>
@@ -5372,6 +5557,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0832b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0832b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -5400,6 +5586,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0834a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0834a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/ESA/ JPL-Caltech/NASA/ D. Gouliermis (MPIA) et al.</Credits>
@@ -5428,6 +5615,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0837a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0837a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -5456,6 +5644,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0837b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0837b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -5484,6 +5673,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0839a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0839a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/ Mario Nonino, Piero Rosati and the ESO GOODS Team</Credits>
@@ -5512,6 +5702,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0840a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0840a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/APEX/DSS2/ SuperCosmos/ Deharveng(LAM)/ Zavagno(LAM)</Credits>
@@ -5540,6 +5731,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0841a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0841a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/APEX/2MASS/A. Eckart et al.</Credits>
@@ -5568,6 +5760,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0844a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0844a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -5596,6 +5789,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0846a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0846a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/S. Gillessen et al.</Credits>
@@ -5624,6 +5818,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0847a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0847a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/F. Courbin et al</Credits>
@@ -5652,6 +5847,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0848a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0848a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -5680,6 +5876,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0902a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0902a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -5708,6 +5905,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0902b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0902b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/NASA/ESA</Credits>
@@ -5736,6 +5934,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0902c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0902c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -5764,6 +5963,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0902d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0902d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin.</Credits>
@@ -5792,6 +5992,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0903a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0903a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/WFI (Optical); MPIfR/ESO/APEX/A.Weiss et al. (Submillimetre); NASA/CXC/CfA/R.Kraft et al. (X-ray)</Credits>
@@ -5820,6 +6021,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0905a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0905a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -5848,6 +6050,7 @@
     TileLevels="7"
     Url="http://data1.wwtassets.org/feeds/eso/eso0905b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0905b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin.</Credits>
@@ -5876,6 +6079,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0906e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0906e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin</Credits>
@@ -5904,6 +6108,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0907a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0907a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -5932,6 +6137,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0907b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0907b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin</Credits>
@@ -5960,6 +6166,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0911a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0911a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -5988,6 +6195,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0911b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0911b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin.</Credits>
@@ -6016,6 +6224,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0914a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0914a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -6044,6 +6253,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0915c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0915c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin</Credits>
@@ -6072,6 +6282,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0919c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0919c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2</Credits>
@@ -6100,6 +6311,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0921a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0921a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/P. Espinoza</Credits>
@@ -6128,6 +6340,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0921c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0921c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -6156,6 +6369,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0923a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0923a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/E. Helder &amp;amp; NASA/Chandra</Credits>
@@ -6184,6 +6398,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0923b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0923b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin</Credits>
@@ -6240,6 +6455,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0925a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0925a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -6268,6 +6484,7 @@
     TileLevels="7"
     Url="http://data1.wwtassets.org/feeds/eso/eso0925b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0925b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin.</Credits>
@@ -6296,6 +6513,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0926a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0926a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -6324,6 +6542,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0926b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0926b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin.</Credits>
@@ -6352,6 +6571,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0927e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0927e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin.</Credits>
@@ -6380,6 +6600,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0928a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0928a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/F. Millour et al.</Credits>
@@ -6408,6 +6629,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0928e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0928e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/F. Millour et al.</Credits>
@@ -6436,6 +6658,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0928f/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0928f"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin.</Credits>
@@ -6464,6 +6687,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0929a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0929a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -6492,6 +6716,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0929b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0929b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -6520,6 +6745,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0929c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0929c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -6548,6 +6774,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0929d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0929d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin</Credits>
@@ -6576,6 +6803,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0930a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0930a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -6604,6 +6832,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0930b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0930b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -6632,6 +6861,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0931a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0931a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -6660,6 +6890,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0931b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0931b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin</Credits>
@@ -6688,6 +6919,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0933b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0933b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey</Credits>
@@ -6744,6 +6976,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0934a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0934a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/S. Guisard (www.eso.org/~sguisard)  </Credits>
@@ -6772,6 +7005,7 @@
     TileLevels="7"
     Url="http://data1.wwtassets.org/feeds/eso/eso0936a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0936a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -6800,6 +7034,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0938a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0938a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -6828,6 +7063,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0938b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0938b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgment: Davide De Martin</Credits>
@@ -6856,6 +7092,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0940a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0940a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Y. Beletsky</Credits>
@@ -6884,6 +7121,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso0940b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0940b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -6912,6 +7150,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0940c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0940c"
     Xcxstatus="queue:eso"
   >
     <Credits>NASA/ESA and Jesús Maíz Apellániz (Instituto de Astrofísica de Andalucía, Spain)</Credits>
@@ -6940,6 +7179,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0940d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0940d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO, ESA/Hubble and Digitized Sky Survey 2. Acknowledgment: Davide De Martin (ESA/Hubble)</Credits>
@@ -6968,6 +7208,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0941c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0941c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Subaru/National Astronomical Observatory of Japan/M. Tanaka</Credits>
@@ -6996,6 +7237,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0943b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0943b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2</Credits>
@@ -7052,6 +7294,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso0944a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0944a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Y. Beletsky</Credits>
@@ -7080,6 +7323,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso0945a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0945a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/F. Ferraro</Credits>
@@ -7108,6 +7352,7 @@
     TileLevels="1"
     Url="http://data1.wwtassets.org/feeds/eso/eso0946b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0946b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -7136,6 +7381,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso0947a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0947a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/H. Sana</Credits>
@@ -7164,6 +7410,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0947b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0947b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -7192,6 +7439,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0949a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0949a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/J. Emerson/VISTA. Acknowledgment: Cambridge Astronomical Survey Unit </Credits>
@@ -7220,6 +7468,7 @@
     TileLevels="7"
     Url="http://data1.wwtassets.org/feeds/eso/eso0949b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0949b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/VISTA. Acknowledgment: Cambridge Astronomical Survey Unit </Credits>
@@ -7248,6 +7497,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0949c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0949c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/J. Emerson/VISTA. Acknowledgment: Cambridge Astronomical Survey Unit</Credits>
@@ -7276,6 +7526,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0949k/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0949k"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin </Credits>
@@ -7304,6 +7555,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0949l/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0949l"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin and S. Guisard (www.eso.org/~sguisard)</Credits>
@@ -7332,6 +7584,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0949m/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0949m"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin</Credits>
@@ -7360,6 +7613,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0949n/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0949n"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/J. Emerson/VISTA. Acknowledgment: Cambridge Astronomical Survey Unit</Credits>
@@ -7388,6 +7642,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso0950b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso0950b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2</Credits>
@@ -7416,6 +7671,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso1005a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1005a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -7444,6 +7700,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso1006a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1006a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/J. Emerson/VISTA. Acknowledgment: Cambridge Astronomical Survey Unit</Credits>
@@ -7472,6 +7729,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso1017a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1017a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/J. Emerson/VISTAAcknowledgment: Cambridge Astronomical Survey Unit</Credits>
@@ -7500,6 +7758,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso1027a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1027a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -7528,6 +7787,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso1031b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1031b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -7556,6 +7816,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso1105a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1105a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Igor Chekalin</Credits>
@@ -7584,6 +7845,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso1109a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1109a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Sergey Stepanenko</Credits>
@@ -7612,6 +7874,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso1119a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1119a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/INAF-VST/OmegaCAM. Acknowledgement: OmegaCen/Astro-WISE/Kapteyn Institute</Credits>
@@ -7640,6 +7903,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso1119b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1119b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/INAF-VST/OmegaCAM. Acknowledgement: A. Grado, L. Limatola/INAF-Capodimonte Observatory</Credits>
@@ -7668,6 +7932,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso1131a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1131a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -7724,6 +7989,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso1208a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1208a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/T. Preibisch</Credits>
@@ -7752,6 +8018,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso1221a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1221a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -7780,6 +8047,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso1233a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1233a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -7808,6 +8076,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso1236a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1236a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -7836,6 +8105,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso1238a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1238a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/B. Bailleul</Credits>
@@ -7864,6 +8134,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso1302a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1302a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/M.-R. Cioni/VISTA Magellanic Cloud survey.Acknowledgment: Cambridge Astronomical Survey Unit</Credits>
@@ -7892,6 +8163,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso1303a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1303a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/F. Comeron</Credits>
@@ -7920,6 +8192,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso1320a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1320a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/U.G. Jørgensen</Credits>
@@ -7948,6 +8221,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso1322a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1322a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -7976,6 +8250,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso1412a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1412a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -8004,6 +8279,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso1420a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1420a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -8032,6 +8308,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso1422a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1422a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/G. Beccari</Credits>
@@ -8060,6 +8337,7 @@
     TileLevels="7"
     Url="http://data1.wwtassets.org/feeds/eso/eso1424a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1424a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -8088,6 +8366,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso1436a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1436a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)</Credits>
@@ -8116,6 +8395,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso1503a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1503a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -8144,6 +8424,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso1520a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1520a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -8172,6 +8453,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso1532a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1532a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -8200,6 +8482,7 @@
     TileLevels="7"
     Url="http://data1.wwtassets.org/feeds/eso/eso1607a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1607a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -8228,6 +8511,7 @@
     TileLevels="8"
     Url="http://data1.wwtassets.org/feeds/eso/eso1607b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1607b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -8256,6 +8540,7 @@
     TileLevels="8"
     Url="http://data1.wwtassets.org/feeds/eso/eso1612a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1612a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO. Acknowledgement: Aniello Grado and Luca Limatola</Credits>
@@ -8284,6 +8569,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso1625a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1625a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/H. Drass et al.</Credits>
@@ -8312,6 +8598,7 @@
     TileLevels="7"
     Url="http://data1.wwtassets.org/feeds/eso/eso1628a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1628a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -8340,6 +8627,7 @@
     TileLevels="7"
     Url="http://data1.wwtassets.org/feeds/eso/eso1701-compa/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1701-compa"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/VISION survey</Credits>
@@ -8368,6 +8656,7 @@
     TileLevels="7"
     Url="http://data1.wwtassets.org/feeds/eso/eso1701-compb/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1701-compb"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2.</Credits>
@@ -8396,6 +8685,7 @@
     TileLevels="8"
     Url="http://data1.wwtassets.org/feeds/eso/eso1701a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1701a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/VISION survey</Credits>
@@ -8508,6 +8798,7 @@
     TileLevels="7"
     Url="http://data1.wwtassets.org/feeds/eso/eso1723a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1723a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/G. Beccari</Credits>
@@ -8564,6 +8855,7 @@
     TileLevels="7"
     Url="http://data1.wwtassets.org/feeds/eso/eso1740a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1740a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -8592,6 +8884,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso1907a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1907a"
     Xcxstatus="queue:eso"
   >
     <Credits>EHT Collaboration</Credits>
@@ -8620,6 +8913,7 @@
     TileLevels="7"
     Url="http://data1.wwtassets.org/feeds/eso/eso1914a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1914a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/VMC Survey</Credits>
@@ -8648,6 +8942,7 @@
     TileLevels="8"
     Url="http://data1.wwtassets.org/feeds/eso/eso1920a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso1920a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Nogueras-Lara et al.</Credits>
@@ -8676,6 +8971,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso2001b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2001b"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO), Rivilla et al.</Credits>
@@ -8704,6 +9000,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso2001e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2001e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin</Credits>
@@ -8732,6 +9029,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso2002a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2002a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO), Olofsson et al. Acknowledgement: Robert Cumming</Credits>
@@ -8760,6 +9058,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso2002c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2002c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin</Credits>
@@ -8788,6 +9087,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso2003a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2003a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/M. Montargès et al.</Credits>
@@ -8816,6 +9116,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso2003b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2003b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/M. Montargès et al.</Credits>
@@ -8872,6 +9173,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso2007c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2007c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin</Credits>
@@ -8900,6 +9202,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso2008a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2008a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Boccaletti et al.</Credits>
@@ -8928,6 +9231,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso2008b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2008b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Boccaletti et al.</Credits>
@@ -8956,6 +9260,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso2008f/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2008f"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin</Credits>
@@ -8984,6 +9289,7 @@
     TileLevels="1"
     Url="http://data1.wwtassets.org/feeds/eso/eso2010b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2010b"
     Xcxstatus="queue:eso"
   >
     <Credits>NASA, ESA/Hubble, J. Andrews (U. Arizona)</Credits>
@@ -9012,6 +9318,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso2010d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2010d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin</Credits>
@@ -9040,6 +9347,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso2011a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2011a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Bohn et al.</Credits>
@@ -9068,6 +9376,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso2011c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2011c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Bohn et al.</Credits>
@@ -9096,6 +9405,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso2012a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2012a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -9124,6 +9434,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso2012c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2012c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin</Credits>
@@ -9152,6 +9463,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso2013a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2013a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO), Rizzo et al.</Credits>
@@ -9180,6 +9492,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso2014c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2014c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Exeter/Kraus et al., ALMA (ESO/NAOJ/NRAO)</Credits>
@@ -9208,6 +9521,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso2103b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2103b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin</Credits>
@@ -9236,6 +9550,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso2105a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2105a"
     Xcxstatus="queue:eso"
   >
     <Credits>EHT Collaboration</Credits>
@@ -9264,6 +9579,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso2105d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2105d"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO), Goddi et al.</Credits>
@@ -9292,6 +9608,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso2107j/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2107j"
     Xcxstatus="queue:eso"
   >
     <Credits>ESA</Credits>
@@ -9320,6 +9637,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso2109c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2109c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/M. Montargès et al.</Credits>
@@ -9348,6 +9666,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso2109d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2109d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/M. Montargès et al.</Credits>
@@ -9376,6 +9695,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso2109e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2109e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/M. Montargès et al.</Credits>
@@ -9404,6 +9724,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso2109f/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2109f"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/M. Montargès et al.</Credits>
@@ -9432,6 +9753,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso2110b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2110b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/PHANGS</Credits>
@@ -9460,6 +9782,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso2110c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2110c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/PHANGS</Credits>
@@ -9488,6 +9811,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso2110d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2110d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/PHANGS</Credits>
@@ -9516,6 +9840,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso2110e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2110e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/PHANGS</Credits>
@@ -9544,6 +9869,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso2110f/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2110f"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/PHANGS</Credits>
@@ -9572,6 +9898,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso2110g/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2110g"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/ALMA (ESO/NAOJ/NRAO)/PHANGS</Credits>
@@ -9600,6 +9927,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso2110h/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2110h"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/ALMA (ESO/NAOJ/NRAO)/PHANGS</Credits>
@@ -9628,6 +9956,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso2110i/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2110i"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/ALMA (ESO/NAOJ/NRAO)/PHANGS</Credits>
@@ -9656,6 +9985,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso2110j/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2110j"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/ALMA (ESO/NAOJ/NRAO)/PHANGS</Credits>
@@ -9684,6 +10014,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso2110k/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2110k"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/ALMA (ESO/NAOJ/NRAO)/PHANGS</Credits>
@@ -9712,6 +10043,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso2111b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2111b"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)/Benisty et al.</Credits>
@@ -9740,6 +10072,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso2111c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2111c"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)/Benisty et al.</Credits>
@@ -9768,6 +10101,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso2116b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2116b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO, NASA/ESA/R. Gilmozzi/S. Casertano, J. Schmidt</Credits>
@@ -9796,6 +10130,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso2117b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2117b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Voggel et al.</Credits>
@@ -9824,6 +10159,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso2117d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2117d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin</Credits>
@@ -9852,6 +10188,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso2118a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2118a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Janson et al.</Credits>
@@ -9880,6 +10217,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso2119b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2119b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/GRAVITY collaboration</Credits>
@@ -9908,6 +10246,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso2119c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2119c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/GRAVITY collaboration</Credits>
@@ -9936,6 +10275,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso2119d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2119d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/GRAVITY collaboration</Credits>
@@ -9964,6 +10304,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso2119e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2119e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/GRAVITY collaboration</Credits>
@@ -9992,6 +10333,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso2120b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2120b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Miret-Roig et al.</Credits>
@@ -10020,6 +10362,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso2309a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2309a"
     Xcxstatus="in:6552f2c55dff7c3291e3b0ea"
   >
     <Credits>ESO/VPHAS+ team. Acknowledgement: CASU</Credits>
@@ -10048,6 +10391,7 @@
     TileLevels="8"
     Url="http://data1.wwtassets.org/feeds/eso/eso2320a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso2320a"
     Xcxstatus="in:65860314293f0a574636f246"
   >
     <Credits>ESO/VPHAS+ team. Acknowledgement: CASU</Credits>
@@ -10076,6 +10420,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso8709a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso8709a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10104,6 +10449,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso8906b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso8906b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10160,6 +10506,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso9003d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9003d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10188,6 +10535,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso9003g/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9003g"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10216,6 +10564,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso9003h/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9003h"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10244,6 +10593,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso9003i/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9003i"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10272,6 +10622,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso9003k/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9003k"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10300,6 +10651,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso9011a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9011a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10328,6 +10680,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso9532a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9532a"
     Xcxstatus="queue:eso"
   >
     <Credits>This graph accompanies ESO Press Release 16/95 (20 November 1995). It may be reproduced, if credit is given to the European Southern Observatory.</Credits>
@@ -10356,6 +10709,7 @@
     TileLevels="1"
     Url="http://data1.wwtassets.org/feeds/eso/eso9533a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9533a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10384,6 +10738,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso9720a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9720a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10412,6 +10767,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9801a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9801a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10440,6 +10796,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso9801b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9801b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10468,6 +10825,7 @@
     TileLevels="1"
     Url="http://data1.wwtassets.org/feeds/eso/eso9805a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9805a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/N. Devillard</Credits>
@@ -10496,6 +10854,7 @@
     TileLevels="1"
     Url="http://data1.wwtassets.org/feeds/eso/eso9805b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9805b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10524,6 +10883,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso9805c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9805c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO / F. Selman</Credits>
@@ -10552,6 +10912,7 @@
     TileLevels="1"
     Url="http://data1.wwtassets.org/feeds/eso/eso9805d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9805d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10580,6 +10941,7 @@
     TileLevels="1"
     Url="http://data1.wwtassets.org/feeds/eso/eso9805e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9805e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10608,6 +10970,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso9820c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9820c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10636,6 +10999,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso9820d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9820d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10664,6 +11028,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso9821a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9821a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10692,6 +11057,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9825a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9825a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10720,6 +11086,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9827a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9827a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10748,6 +11115,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9833a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9833a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10776,6 +11144,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9842c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9842c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10804,6 +11173,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9845a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9845a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10832,6 +11202,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9845b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9845b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10860,6 +11231,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9845c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9845c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10888,6 +11260,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso9845d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9845d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO </Credits>
@@ -10916,6 +11289,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9845e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9845e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -10944,6 +11318,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso9846a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9846a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/I. Appenzeller, W. Seifert, O. Stahl, M. Zamani</Credits>
@@ -10972,6 +11347,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9846b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9846b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/I. Appenzeller, W. Seifert, O. Stahl, M. Zamani</Credits>
@@ -11000,6 +11376,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9847b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9847b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11028,6 +11405,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9856d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9856d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11056,6 +11434,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9857c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9857c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11084,6 +11463,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9857d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9857d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11112,6 +11492,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9858h/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9858h"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11140,6 +11521,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9903a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9903a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11168,6 +11550,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9903b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9903b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11196,6 +11579,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso9920a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9920a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11224,6 +11608,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso9920e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9920e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11252,6 +11637,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso9920f/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9920f"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11280,6 +11666,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9920g/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9920g"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11308,6 +11695,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9920h/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9920h"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11336,6 +11724,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9920i/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9920i"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11364,6 +11753,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso9920k/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9920k"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11392,6 +11782,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9920p/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9920p"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11420,6 +11811,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9920q/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9920q"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11448,6 +11840,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9920v/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9920v"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11476,6 +11869,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9921a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9921a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11504,6 +11898,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9921b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9921b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11532,6 +11927,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso9921c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9921c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11560,6 +11956,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso9922a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9922a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11588,6 +11985,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9922b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9922b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11616,6 +12014,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso9922c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9922c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11644,6 +12043,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso9922d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9922d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11672,6 +12072,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso9923a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9923a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11756,6 +12157,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso9923d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9923d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11784,6 +12186,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso9924a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9924a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11812,6 +12215,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso9924b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9924b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11840,6 +12244,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso9924c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9924c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11868,6 +12273,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso9924d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9924d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11896,6 +12302,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9924e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9924e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11924,6 +12331,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso9924f/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9924f"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11952,6 +12360,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso9925a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9925a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -11980,6 +12389,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9925b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9925b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12008,6 +12418,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9926b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9926b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12036,6 +12447,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9926d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9926d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12064,6 +12476,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9931a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9931a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12092,6 +12505,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9931b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9931b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12120,6 +12534,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9931c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9931c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12148,6 +12563,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9931d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9931d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12176,6 +12592,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9931e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9931e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12204,6 +12621,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9931f/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9931f"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12232,6 +12650,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9934a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9934a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12260,6 +12679,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9936a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9936a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12288,6 +12708,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso9944a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9944a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12316,6 +12737,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9946a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9946a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12344,6 +12766,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso9946b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9946b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12372,6 +12795,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso9948b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9948b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12400,6 +12824,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso9948c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9948c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12428,6 +12853,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso9948d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9948d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12456,6 +12882,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso9948e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9948e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12484,6 +12911,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso9948f/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9948f"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12512,6 +12940,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso9948g/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9948g"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12540,6 +12969,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso9949a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9949a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO </Credits>
@@ -12568,6 +12998,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/eso9954a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9954a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12596,6 +13027,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/eso9954c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9954c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12624,6 +13056,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/eso9954d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9954d"
     Xcxstatus="queue:eso"
   >
     <Credits>  </Credits>
@@ -12652,6 +13085,7 @@
     TileLevels="1"
     Url="http://data1.wwtassets.org/feeds/eso/eso9954e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9954e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12680,6 +13114,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso9954f/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9954f"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12708,6 +13143,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/eso9954g/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9954g"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12736,6 +13172,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/eso9954h/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|eso9954h"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12764,6 +13201,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/helix/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|helix"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12792,6 +13230,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/hh-111/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|hh-111"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12820,6 +13259,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/j16081299-2304314-dss/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|j16081299-2304314-dss"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin</Credits>
@@ -12848,6 +13288,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/jewel-box/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|jewel-box"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12876,6 +13317,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/m4/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|m4"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12904,6 +13346,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/m55-3point6-m_copy/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|m55-3point6-m_copy"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12932,6 +13375,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/m83/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|m83"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/IDA/Danish 1.5 m/R. Gendler, S. Guisard (www.eso.org/~sguisard) and C. Thöne </Credits>
@@ -12959,6 +13403,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/mcneil/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|mcneil"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -12987,6 +13432,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/minor_planet_tunis/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|minor_planet_tunis"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13015,6 +13461,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1008a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1008a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13043,6 +13490,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1009a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1009a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13071,6 +13519,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/potw1012a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1012a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13099,6 +13548,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1015a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1015a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/IDA/Danish 1.5 m/ R. Gendler, U.G. Jørgensen, J. Skottfelt, K. Harpsøe</Credits>
@@ -13127,6 +13577,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1016a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1016a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/IDA/Danish 1.5 m/ R. Gendler, U.G. Jørgensen, K. Harpsøe</Credits>
@@ -13155,6 +13606,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1022a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1022a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13183,6 +13635,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1026a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1026a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13211,6 +13664,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/potw1030a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1030a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13239,6 +13693,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1032a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1032a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/ESA/Hubble and NASA</Credits>
@@ -13267,6 +13722,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1035a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1035a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13295,6 +13751,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1037a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1037a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/IDA/Danish 1.5 m/ R. Gendler, J-E. Ovaldsen, C. Thöne, and C. Feron.</Credits>
@@ -13323,6 +13780,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/potw1046a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1046a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13351,6 +13809,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/potw1047a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1047a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/R. Schoedel</Credits>
@@ -13379,6 +13838,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/potw1048a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1048a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13407,6 +13867,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1106a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1106a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13435,6 +13896,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/potw1107a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1107a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13463,6 +13925,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/potw1120a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1120a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13491,6 +13954,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1126a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1126a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/G. Bono &amp;amp; CTIO</Credits>
@@ -13519,6 +13983,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1128a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1128a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/R. Gendler</Credits>
@@ -13547,6 +14012,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1131a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1131a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13575,6 +14041,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1140a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1140a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/A. Milani</Credits>
@@ -13603,6 +14070,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1143a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1143a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Oleg Maliy</Credits>
@@ -13631,6 +14099,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1148a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1148a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13659,6 +14128,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/potw1202a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1202a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13687,6 +14157,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1204a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1204a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13715,6 +14186,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1212a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1212a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13743,6 +14215,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/potw1228a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1228a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/R. Gendler &amp;amp; R.M. Hannahoe</Credits>
@@ -13771,6 +14244,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/potw1231a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1231a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13799,6 +14273,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1236a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1236a"
     Xcxstatus="queue:eso"
   >
     <Credits>Optical: ESO, X-ray: NASA/CXC/U.Mich./S.Oey, IR: NASA/JPL </Credits>
@@ -13827,6 +14302,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1242a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1242a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13855,6 +14331,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/potw1304a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1304a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13883,6 +14360,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1312a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1312a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13911,6 +14389,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1330a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1330a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13939,6 +14418,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1332a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1332a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13967,6 +14447,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1334a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1334a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -13995,6 +14476,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/potw1335a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1335a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/PESSTO/S. Smartt</Credits>
@@ -14023,6 +14505,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1338a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1338a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO, and D. Minniti and J. C. Beamín (Pontificia Universidad Católica de Chile).</Credits>
@@ -14051,6 +14534,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/potw1339a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1339a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -14079,6 +14563,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/potw1341a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1341a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/VPHAS+ Survey/N. Wright</Credits>
@@ -14107,6 +14592,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/potw1428a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1428a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -14135,6 +14621,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1444a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1444a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -14163,6 +14650,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1448a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1448a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/VVV Team/A. Guzmán</Credits>
@@ -14191,6 +14679,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/potw1509a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1509a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/C. Snodgrass</Credits>
@@ -14219,6 +14708,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/potw1518a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1518a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -14247,6 +14737,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/potw1523a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1523a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO / Manu Mejias</Credits>
@@ -14275,6 +14766,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1531a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1531a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -14303,6 +14795,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1541a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1541a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/M. McCaughrean</Credits>
@@ -14331,6 +14824,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1543a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1543a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO, A. M. Lagrange (Université Grenoble Alpes)</Credits>
@@ -14359,6 +14853,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/potw1550a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1550a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -14387,6 +14882,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1605a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1605a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -14415,6 +14911,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/potw1612a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1612a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -14443,6 +14940,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1619a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1619a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO. Acknowledgements: Jean-Christophe Lambry</Credits>
@@ -14471,6 +14969,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1621a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1621a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Marino et al.</Credits>
@@ -14499,6 +14998,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/potw1624a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1624a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Schmidt et al.</Credits>
@@ -14527,6 +15027,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/potw1636a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1636a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO Acknowledgements: Flickr user jbarring</Credits>
@@ -14555,6 +15056,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1640a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1640a"
     Xcxstatus="queue:eso"
   >
     <Credits>B. Saxton (NRAO/AUI/NSF); ALMA (ESO/NAOJ/NRAO)</Credits>
@@ -14583,6 +15085,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1644a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1644a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)/J.J. Tobin (University of Oklahoma/Leiden University)</Credits>
@@ -14611,6 +15114,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1645a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1645a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)/M. Kaufman &amp;amp; the NASA/ESA Hubble Space Telescope</Credits>
@@ -14639,6 +15143,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1652a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1652a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO, ALMA (ESO/NAOJ/NRAO); A. Isella; B. Saxton (NRAO/AUI/NSF)</Credits>
@@ -14667,6 +15172,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1706a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1706a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO Acknowledgement: Flickr user Josh Barrington</Credits>
@@ -14695,6 +15201,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1708a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1708a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)/T. Kitayama (Toho University, Japan)/ESA/Hubble &amp;amp; NASA</Credits>
@@ -14723,6 +15230,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1709a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1709a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA: ESO/NAOJ/NRAO/A. Angelich Hubble: NASA, ESA, R. Kirshner (Harvard-Smithsonian Center for Astrophysics and Gordon and Betty Moore Foundation) and P. Challis (Harvard-Smithsonian Center for Astrophysics) Chandra: NASA/CXC/Penn State/K. Frank et al.</Credits>
@@ -14751,6 +15259,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/potw1710a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1710a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)/H. Kim et al.</Credits>
@@ -14779,6 +15288,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/potw1710b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1710b"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)/H. Kim et al., ESA/NASA &amp;amp; R. Sahai</Credits>
@@ -14807,6 +15317,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/potw1711b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1711b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO, ALMA (ESO/NAOJ/NRAO)/A. Schruba, VLA (NRAO)/Y. Bagetakos/Little THINGS</Credits>
@@ -14835,6 +15346,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1712a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1712a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO); C. Brogan, B. Saxton (NRAO/AUI/NSF)</Credits>
@@ -14863,6 +15375,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1714a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1714a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)/ Fedele et al.</Credits>
@@ -14891,6 +15404,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1720a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1720a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)/ Lee et al.</Credits>
@@ -14918,6 +15432,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1721a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1721a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)/L. Matrà/M. A. MacGregor</Credits>
@@ -14946,6 +15461,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1724a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1724a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)/R. Sahai</Credits>
@@ -14974,6 +15490,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1726a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1726a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)/E. O’Gorman/P. Kervella</Credits>
@@ -15002,6 +15519,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1730a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1730a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -15030,6 +15548,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/potw1731a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1731a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESOAcknowledgements: Flickr user hdahle70</Credits>
@@ -15058,6 +15577,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/potw1739a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1739a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Jean-Christophe Lambry </Credits>
@@ -15086,6 +15606,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1742a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1742a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)/S. Kraus (University of Exeter, UK)</Credits>
@@ -15114,6 +15635,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1746b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1746b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/T. Contini (IRAP, Toulouse), B. Epinat (LAM, Marseille)</Credits>
@@ -15142,6 +15664,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/potw1747a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1747a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Arrigoni Battaia et al.</Credits>
@@ -15170,6 +15693,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1752a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1752a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO, ESA/Hubble &amp;amp; NASA</Credits>
@@ -15198,6 +15722,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1752b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1752b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO &amp;amp; ESA/Hubble &amp;amp; NASA</Credits>
@@ -15226,6 +15751,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1801a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1801a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -15254,6 +15780,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/potw1805a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1805a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/M. Bellazzini et al.</Credits>
@@ -15282,6 +15809,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1806a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1806a"
     Xcxstatus="queue:eso"
   >
     <Credits>NASA &amp;amp; ESA, Acknowledgement: Judy Schmidt (Geckzilla)</Credits>
@@ -15310,6 +15838,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1806b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1806b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/ESA/Hubble &amp;amp; NASA/J. Weaver et al.</Credits>
@@ -15338,6 +15867,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1807a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1807a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/M. Wittkowski (ESO)</Credits>
@@ -15366,6 +15896,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1809a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1809a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)/ D. Fedele et al.</Credits>
@@ -15394,6 +15925,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1814a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1814a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO Acknowledgements: P. Merluzzi (INAF-Osservatorio Astronomico di Capodimonte, Italy)</Credits>
@@ -15422,6 +15954,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/potw1818a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1818a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/VVV Survey/D. Minniti Acknowledgement: Ignacio Toledo</Credits>
@@ -15450,6 +15983,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1821a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1821a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Juan Carlos Muñoz</Credits>
@@ -15478,6 +16012,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/potw1822a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1822a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/A. Alonso-Herrero et al.; ALMA (ESO/NAOJ/NRAO)  </Credits>
@@ -15505,6 +16040,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/potw1827a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1827a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/R. Dong et al.; ALMA (ESO/NAOJ/NRAO)</Credits>
@@ -15533,6 +16069,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/eso/potw1831a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1831a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -15561,6 +16098,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/potw1838a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1838a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -15589,6 +16127,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1841a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1841a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)/S. P. S. Eyres</Credits>
@@ -15617,6 +16156,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/potw1843a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1843a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)/ J. R. Goicoechea (Instituto de Física Fundamental, CSIC, Spain)</Credits>
@@ -15645,6 +16185,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1847a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1847a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -15673,6 +16214,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1849a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1849a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/D. Fenech et al.; ALMA (ESO/NAOJ/NRAO)</Credits>
@@ -15700,6 +16242,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1850a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1850a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -15728,6 +16271,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1850b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1850b"
     Xcxstatus="queue:eso"
   >
     <Credits>T. Liimets et al./ESO</Credits>
@@ -15756,6 +16300,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1901a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1901a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -15784,6 +16329,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1905a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1905a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO), S. Andrews et al.; NRAO/AUI/NSF, S. Dagnello</Credits>
@@ -15812,6 +16358,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1906a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1906a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO), S. Andrews et al.; NRAO/AUI/NSF, S. Dagnello</Credits>
@@ -15840,6 +16387,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1908a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1908a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/SPECULOOS Team/E. Jehin</Credits>
@@ -15868,6 +16416,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1909a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1909a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/SPECULOOS Team/E. Jehin</Credits>
@@ -15896,6 +16445,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1911a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1911a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -15924,6 +16474,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1917a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1917a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO); NRAO/AUI/NSF, B. Saxton</Credits>
@@ -15952,6 +16503,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1919a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1919a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -15980,6 +16532,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1927a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1927a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -16008,6 +16561,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/potw1928a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1928a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)/K. Blundell (University of Oxford, UK), R. Laing, S. Lee &amp;amp; A. Richards, Ap J Letters.</Credits>
@@ -16036,6 +16590,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1930a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1930a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/SPECULOOS Team/E. Jehin</Credits>
@@ -16064,6 +16619,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1935a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1935a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/ R. Leaman/ D. Gadotti/ K. Sandstrom/ D. Calzetti</Credits>
@@ -16092,6 +16648,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1939a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1939a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO), P. Jachym (Czech Academy of Sciences) et al.</Credits>
@@ -16120,6 +16677,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw1943a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1943a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -16148,6 +16706,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw1949a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw1949a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -16176,6 +16735,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw2003a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw2003a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -16204,6 +16764,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw2020a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw2020a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -16232,6 +16793,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw2027a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw2027a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -16260,6 +16822,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/potw2034a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw2034a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/TIMER survey</Credits>
@@ -16288,6 +16851,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw2038a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw2038a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO), Decin et al.</Credits>
@@ -16316,6 +16880,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/potw2047a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw2047a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/TIMER survey</Credits>
@@ -16344,6 +16909,7 @@
     TileLevels="1"
     Url="http://data1.wwtassets.org/feeds/eso/potw2106a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw2106a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/TIMER survey</Credits>
@@ -16372,6 +16938,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/potw2108a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw2108a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Ginski et al.</Credits>
@@ -16400,6 +16967,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw2113a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw2113a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -16428,6 +16996,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/potw2117a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw2117a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Tubín et al.</Credits>
@@ -16456,6 +17025,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw2119a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw2119a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -16484,6 +17054,7 @@
     TileLevels="1"
     Url="http://data1.wwtassets.org/feeds/eso/potw2122a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw2122a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Iodice et al.</Credits>
@@ -16512,6 +17083,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw2123a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw2123a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO</Credits>
@@ -16540,6 +17112,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/eso/potw2130a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw2130a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Ragusa, Spavone et al.</Credits>
@@ -16568,6 +17141,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/eso/potw2143a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw2143a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/TIMER survey</Credits>
@@ -16596,6 +17170,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/eso/potw2145a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw2145a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Iodice et al.</Credits>
@@ -16624,6 +17199,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/eso/potw2148a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="eso|potw2148a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/VST ATLAS team. Acknowledgement: Durham University/CASU/WFAU</Credits>
@@ -52971,6 +53547,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-cenaL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|cena"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/IDA/Danish 1.5 m/R. Gendler, J.-E. Ovaldsen &amp; S. Guisard (www.eso.org/~sguisard) (ESO); Centaurus A is our nearest giant galaxy, at a distance of about 13 million light-years in the southern constellation of Centauru...</Credits>
@@ -52997,6 +53574,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso-6302L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso-6302"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/IDA/Danish 1.5 m/R. Gendler, A. Hornstrup and J.-E. Ovaldsen; The Bug Nebula, NGC 6302, is one of the brightest and most extreme planetary nebulae known. It is located about 4,000 light-year...</Credits>
@@ -53023,6 +53601,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso-flameL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso-flame"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/IDA/Danish 1.5 m/R. Gendler, J.-E. Ovaldsen, C. Thöne and C. Féron; Sparkling at the edge of a giant cloud of gas and dust, the Flame Nebula, also referred to as NGC 2024, is in fact the hideout o...</Credits>
@@ -53049,6 +53628,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso-m100L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso-m100"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/IDA/Danish 1.5 m/R. Gendler,; Similar in appearance to our own Milky Way, Messier 100 is a grand spiral galaxy that presents an intricate structure, with a br...</Credits>
@@ -53127,6 +53707,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso0104bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso0104b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/M.McCaughrean et al. (AIP); This image shows smaller, particularly interesting areas of ESO Press Photo eso0104a. The traces of a massive outflow of gas fro...</Credits>
@@ -53153,6 +53734,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso0216fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso0216f"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; Long and bright "filaments" of luminous gas in an area SW of the centre of the Tarantula Nebula....</Credits>
@@ -53179,6 +53761,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso0417dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso0417d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; Colour composite image of the Galactic Centre at a distance of about 30,000 light-years. It was made by combining images in filt...</Credits>
@@ -53205,6 +53788,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso0430eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso0430e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; Composite, false-colour image showing asteroid (4179) Toutatis moving in front of background stars, as seen from Paranal (red tr...</Credits>
@@ -53231,6 +53815,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso0436cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso0436c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; Composite colour-coded image of another magnificent spiral galaxy, NGC 7424, at a distance of 40 million light-years. It is base...</Credits>
@@ -53257,6 +53842,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso0817bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso0817b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; Located 9,000 light-years away, NGC 3576 is a gigantic region of glowing gas about 100 light-years across, where stars are curre...</Credits>
@@ -53283,6 +53869,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso0945bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso0945b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; This wide-field image, based on data from Digitized Sky Survey 2, shows the whole region around the stellar grouping Terzan 5....</Credits>
@@ -53309,6 +53896,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1003bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1003b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; Wide view centred on the Cat’s Paw Nebula (NGC 6334)....</Credits>
@@ -53335,6 +53923,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1004cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1004c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/P. Crowther; Astronomers using ESO’s Very Large Telescope (VLT) have detected a stellar-mass black hole much further away than any other prev...</Credits>
@@ -53361,6 +53950,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1004dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1004d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; This wide field image, from the Digitized Sky Survey 2, shows the area around the spiral galaxy, NGC 300, six million light-year...</Credits>
@@ -53387,6 +53977,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1005bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1005b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; This wide-field image, based on data from Digitized Sky Survey 2, shows the whole region around the cosmic factory NGC 3603, loc...</Credits>
@@ -53413,6 +54004,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1007aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1007a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; The Fornax dwarf galaxy is one of our Milky Way’s neighbouring dwarf galaxies. The Milky Way is, like all large galaxies, though...</Credits>
@@ -53439,6 +54031,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1007bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1007b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; The Sculptor dwarf galaxy is one of our Milky Way’s neighbouring dwarf galaxies. The Milky Way is, like all large galaxies, thou...</Credits>
@@ -53465,6 +54058,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1008aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1008a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; NGC 346, the brightest star-forming region in the neighbouring Small Magellanic Cloud galaxy, some 210,000 light-years away from...</Credits>
@@ -53491,6 +54085,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1008bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1008b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgements: Davide De Martin; Wide field image, based on data from Digitized Sky Survey 2, around the star-forming region NGC 346, inside the Small Magellanic...</Credits>
@@ -53517,6 +54112,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1009aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1009a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; The delicate nebula NGC 1788, located in a dark and often neglected corner of the Orion constellation, is revealed in this finel...</Credits>
@@ -53543,6 +54139,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1009bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1009b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; The delicate nebula NGC 1788 is located in a dark and often neglected corner of the Orion constellation. Although this ghostly c...</Credits>
@@ -53569,6 +54166,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1012dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1012d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO &amp; DSS2; This image shows the wider region around the distant galaxy SMM J2135-0102, which is being gravitationally lensed by the galaxy ...</Credits>
@@ -53621,6 +54219,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1014aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1014a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This image of the Gum 19 star-forming region was obtained with SOFI, an infrared instrument mounted on ESO’s New Technology Tele...</Credits>
@@ -53647,6 +54246,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1014bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1014b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; This image shows the area around the star-forming region Gum 19, in the direction of the constellation of Vela (the Sail), as se...</Credits>
@@ -53673,6 +54273,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1019aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1019a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/J. Dietrich; This wide-field, deep image reveals thousands of galaxies crowding an area on the sky roughly as large as the full Moon. These g...</Credits>
@@ -53699,6 +54300,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1019bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1019b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/ Digitized Sky Survey 2; This image, based on data from the Digitized Sky Survey 2, shows a wide area (2.6 x 2.9 degrees) around the cluster of galaxies ...</Credits>
@@ -53725,6 +54327,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1020aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1020a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/M. Gieles.Acknowledgement: Mischa Schirmer; This image of the nearby galaxy Messier 83 was taken in the infrared part of the spectrum with the HAWK-I instrument on ESO’s Ve...</Credits>
@@ -53751,6 +54354,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1020dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1020d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO, Digitized Sky Survey 2. Acknowledgement: Davide De Martin; This wide-field view shows the field around the spiral galaxy Messier 83. The image was created from photographs in red and blue...</Credits>
@@ -53777,6 +54381,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1021aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1021a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This spectacular new image from the Wide Field Imager on the MPG/ESO 2.2-metre telescope at ESO’s La Silla Observatory in Chile ...</Credits>
@@ -53803,6 +54408,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1021cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1021c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO, Digitized Sky Survey 2. Acknowledgement: Davide De Martin; This wide-field view shows a section of the Large Magellanic Cloud, centred on the unusual globular cluster NGC 1978. The image ...</Credits>
@@ -53829,6 +54435,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1023aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1023a"
     Xcxstatus="queue:eso"
   >
     <Credits>TRAPPIST/E. Jehin/ESO; This first light image of the TRAPPIST national telescope at La Silla shows the Tarantula Nebula, located in the Large Magellani...</Credits>
@@ -53855,6 +54462,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1023cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1023c"
     Xcxstatus="queue:eso"
   >
     <Credits>TRAPPIST/E. Jehin/ESO; The globular cluster Omega Centauri was one of the targets observed for first light of the TRAPPIST national telescope at La Sil...</Credits>
@@ -53881,6 +54489,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1023dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1023d"
     Xcxstatus="queue:eso"
   >
     <Credits>TRAPPIST/E. Jehin/ESO; One of the TRAPPIST first light images shows the spiral galaxy Messier 83. Messier 83 lies roughly 15 million light-years away i...</Credits>
@@ -53907,6 +54516,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1024dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1024d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; Beta Pictoris is located about 60 light-years away towards the constellation of Pictor (the Painter's Easel) and is one of the b...</Credits>
@@ -53933,6 +54543,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1025aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1025a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/J. Emerson/VISTA. Acknowledgment: Cambridge Astronomical Survey Unit; NGC 253 is one of the closest galaxies to our own. It is a bright spiral that lies about 13 million light-years from Earth in th...</Credits>
@@ -53959,6 +54570,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1027bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1027b"
     Xcxstatus="queue:eso"
   >
     <Credits>Loke Kun Tan (StarryScapes.com); This spectacular wide field image shows the area around the star R Coronae Australis. A huge dust cloud, about eight light-years...</Credits>
@@ -53985,6 +54597,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1029dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1029d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; The object IRAS 13481-6124, which consists of a young central star, about 20 times the mass of our Sun and 5 times its radius, s...</Credits>
@@ -54011,6 +54624,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1030dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1030d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/P. Crowther/C.J. Evans; A new near-infrared image of the R136 cluster, obtained at high resolution with the MAD adaptive optics instrument at ESO’s Very...</Credits>
@@ -54037,6 +54651,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1031aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1031a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This image of part of the Carina Nebula was created from images taken through red, green and blue filters with the Wide Field Im...</Credits>
@@ -54063,6 +54678,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1033aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1033a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/M.-R. Cioni/VISTA Magellanic; This VISTA image shows the spectacular 30 Doradus star-forming region, also called the Tarantula Nebula. At its core is a large ...</Credits>
@@ -54089,6 +54705,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1033cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1033c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/M.-R. Cioni/VISTA Magellanic; This VISTA image shows the spectacular 30 Doradus star-forming region, also called the Tarantula Nebula. At its core is a large ...</Credits>
@@ -54115,6 +54732,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1034bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1034b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This image of the young star cluster Westerlund 1 was taken with the Wide Field Imager on the MPG/ESO 2.2-metre telescope at ESO...</Credits>
@@ -54141,6 +54759,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1034cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1034c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This image of the young star cluster Westerlund 1 was taken with the Wide Field Imager on the MPG/ESO 2.2-metre telescope at ESO...</Credits>
@@ -54167,6 +54786,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1035bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1035b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO, Digitized Sky Survey 2. Acknowledgement: Davide De Martin; This wide-field image shows the sky around the star HD 10180, which appears as a fairly bright star just below the centre. The p...</Credits>
@@ -54193,6 +54813,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1035cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1035c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin; This image shows a close-up of the sky around the star HD 10180. The picture was created from photographs taken through red and ...</Credits>
@@ -54219,6 +54840,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1036aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1036a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/J. Dietrich; This visible light image, made with the Wide Field Imager on the MPG/ESO 2.2-metre telescope at the La Silla Observatory in Chil...</Credits>
@@ -54245,6 +54867,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1036bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1036b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin; This visible light wide-field image of the region around NGC 4666 was created from photographs taken through red and blue filter...</Credits>
@@ -54271,6 +54894,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1037aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1037a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This picture of the spectacular southern spiral galaxy NGC 300 was taken using the Wide Field Imager (WFI) at ESO’s La Silla Obs...</Credits>
@@ -54297,6 +54921,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1038aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1038a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/P. Grosbøl; This striking new image, taken with the powerful HAWK-I infrared camera on ESO’s Very Large Telescope at Paranal Observatory in ...</Credits>
@@ -54323,6 +54948,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1039aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1039a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/J. Emerson/VISTA. Acknowledg; This dramatic infrared image shows the nearby star formation region Monoceros R2, located some 2700 light-years away in the cons...</Credits>
@@ -54349,6 +54975,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1039eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1039e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin; This visible light wide-field image of the region around Monoceros R2 was created from photographs taken through red and blue fi...</Credits>
@@ -54375,6 +55002,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1042bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1042b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/P. Grosbøl; This image shows NGC 5247, a grand design barred spiral galaxy, located 60–70 million light-years away. The galaxy lies face-on ...</Credits>
@@ -54401,6 +55029,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1042cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1042c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/P. Grosbøl; This galaxy is Messier 100, also known as NGC 4321, which was discovered in the 18th century. About 55 million light-years from ...</Credits>
@@ -54427,6 +55056,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1042dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1042d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/P. Grosbøl; This image is of NGC 1300, a spiral galaxy with arms extending from the ends of a spectacularly prominent central bar. It is con...</Credits>
@@ -54453,6 +55083,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1042eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1042e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/P. Grosbøl; This spiral galaxy, NGC 4030, lies about 75 million light-years from Earth, in the constellation of Virgo. In 2007 Takao Doi, a ...</Credits>
@@ -54479,6 +55110,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1042fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1042f"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/P. Grosbøl; This image, NGC 2997, is a spiral galaxy roughly 30 million light-years away in the constellation of Antlia (the Air Pump). NGC ...</Credits>
@@ -54505,6 +55137,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1042gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1042g"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/P. Grosbøl; NGC 1232 is a spiral galaxy some 65 million light-years away in the constellation of Eridanus (the River). The galaxy is classif...</Credits>
@@ -54531,6 +55164,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1044aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1044a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This new image shows the results of a vast collision between two galaxies. This strange object is known as NGC 7252, or Arp 226,...</Credits>
@@ -54557,6 +55191,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1044cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1044c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin; This visible light wide-field image of the region around NGC 7252 was created from photographs taken through red and blue filter...</Credits>
@@ -54583,6 +55218,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1045cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1045c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin; This visible light wide-field image of the region around the exoplanet HIP 13044 b was created from photographs forming part of ...</Credits>
@@ -54609,6 +55245,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1046bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1046b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This wide field view of part of our neighbouring galaxy, the Large Magellanic Cloud, was created from photographs taken in red a...</Credits>
@@ -54635,6 +55272,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1048aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1048a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/ESO Imaging Survey; The globular cluster Messier 107, also known as NGC 6171, is located about 21 000 light-years away in the constellation of Ophiu...</Credits>
@@ -54661,6 +55299,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1101aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1101a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/VVVAcknowledgment: Cambridge; This new infrared view of the star formation region Messier 8, often called the Lagoon Nebula, was captured by the VISTA telesco...</Credits>
@@ -54687,6 +55326,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1101dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1101d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/VVVAcknowledgment: Cambridge; This new infrared view of the star formation region Messier 8, often called the Lagoon Nebula, was captured by the VISTA telesco...</Credits>
@@ -54713,6 +55353,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1103aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1103a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Igor Chekalin; This new image of the Orion Nebula was captured using the Wide Field Imager camera on the MPG/ESO 2.2-metre telescope at the La ...</Credits>
@@ -54739,6 +55380,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1104aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1104a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Joe DePasquale; This picture of the spiral galaxy NGC 3621 was taken using the Wide Field Imager (WFI) at ESO’s La Silla Observatory in Chile. N...</Credits>
@@ -54765,6 +55407,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1106cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1106c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin; This visible-light wide-field image of the region around the young star T Cha was created from photographs taken through red and...</Credits>
@@ -54791,6 +55434,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1106dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1106d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin; This visible-light wide-field image of the region around the young star T Cha was created from photographs taken through red and...</Credits>
@@ -54817,6 +55461,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1107aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1107a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This picture of the spiral galaxy NGC 247 was taken using the Wide Field Imager (WFI) at ESO’s La Silla Observatory in Chile. NG...</Credits>
@@ -54843,6 +55488,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1107cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1107c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin; This visible light wide-field image of the region around NGC 247 was created from photographs taken through red and blue filters...</Credits>
@@ -54869,6 +55515,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1108aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1108a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/NOAJ/Subaru/R. Gobat; This image is a composite of very long exposures taken with ESO’s Very Large Telescope in Chile and the NAOJ’s Subaru telescope ...</Credits>
@@ -54895,6 +55542,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1108cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1108c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin; This visible light wide-field image of the region around the most remote mature galaxy cluster yet found was created from photog...</Credits>
@@ -54921,6 +55569,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1109cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1109c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Sergey Stepanenko; This very detailed image of the star-forming region NGC 6729 from ESO’s Very Large Telescope shows the dramatic effects of very ...</Credits>
@@ -54947,6 +55596,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1110cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1110c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgement: Davide de Martin; This visible light wide-field image of the region around the brown dwarf binary CFBDSIR 1458+10 was created from photographs tak...</Credits>
@@ -54973,6 +55623,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1111aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1111a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Manu Mejias; This picture of the star cluster and surrounding nebula NGC 371 was taken using the FORS1 instrument on ESO’s Very Large Telesco...</Credits>
@@ -54999,6 +55650,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1113aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1113a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO, Digitized Sky Survey 2 and Joe DePasquale ; This picture of the star formation region NGC 3582 was taken using the Wide Field Imager at ESO's La Silla Observatory in Chile....</Credits>
@@ -55025,6 +55677,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1113cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1113c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2.Acknowledgment: Davide De Martin ; This visible light wide-field image of the region around NGC 3582 was created from photographs taken through red and blue filter...</Credits>
@@ -55051,6 +55704,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1114aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1114a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Igor Chekalin; This image from the Wide Field Imager on the MPG/ESO 2.2-metre telescope at the La Silla Observatory in Chile captures the pair ...</Credits>
@@ -55077,6 +55731,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1114cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1114c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2. Acknowledgement: Davide De Martin; This visible-light wide-field image of the region around NGC 3169 and NGC 3166 was created from photographs taken through red an...</Credits>
@@ -55103,6 +55758,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1114dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1114d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Igor Chekalin; This section of a picture from the Wide Field Imager on the MPG/ESO 2.2-metre telescope at the La Silla Observatory in Chile sho...</Credits>
@@ -55129,6 +55785,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1115aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1115a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This picture of the Meathook Galaxy (NGC 2442) was taken by the Wide Field Imager on the MPG/ESO 2.2-metre telescope at La Silla...</Credits>
@@ -55155,6 +55812,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1115bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1115b"
     Xcxstatus="queue:eso"
   >
     <Credits>NASA/ESA and ESO; This close-up Hubble view of the Meathook Galaxy (NGC 2442) focuses on the more compact of its two asymmetric spiral arms as wel...</Credits>
@@ -55181,6 +55839,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1115cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1115c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin; This visible-light wide-field image of the region around the deformed spiral galaxy NGC 2442 was created from photographs taken ...</Credits>
@@ -55207,6 +55866,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1117aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1117a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/M.-R. Cioni/VISTA Magellanic Cloud survey. Acknowledgment: Cambridge Astronomical Survey Unit; This view shows part of the very active star-forming region around the Tarantula Nebula in the Large Magellanic Cloud, a small n...</Credits>
@@ -55259,6 +55919,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1118aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1118a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This picture of the nearby galaxy NGC 6744 was taken with the Wide Field Imager on the MPG/ESO 2.2-metre telescope at La Silla. ...</Credits>
@@ -55285,6 +55946,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1118cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1118c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2; This visible-light wide-field image of the region around NGC 6744 was created from photographs taken through blue, red and infra...</Credits>
@@ -55311,6 +55973,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1123aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1123a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/S. Guisard (www.eso.org/~sgu; The  colourful Rho Ophiuchi star formation region, about 400 light-years  from Earth, contains very cold (around -250 degrees Ce...</Credits>
@@ -55337,6 +56000,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1124aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1124a"
     Xcxstatus="queue:eso"
   >
     <Credits>CFHT/IAP/Terapix/CNRS/ESO; This  very deep image shows the COSMOS field imaged by the Canada France  Hawaii Telescope (CFHT). Huge numbers of very faint ga...</Credits>
@@ -55363,6 +56027,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1124cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1124c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2. Acknowledgement: Davide De Martin.; This  visible-light wide-field image of the region around the COSMOS field  was created from photographs taken through red and b...</Credits>
@@ -55389,6 +56054,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1124dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1124d"
     Xcxstatus="queue:eso"
   >
     <Credits>CFHT/IAP/Terapix/CNRS/ESO; This  very deep image shows the COSMOS field imaged by the Canada France  Hawaii Telescope (CFHT). Huge numbers of very faint ga...</Credits>
@@ -55415,6 +56081,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1126cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1126c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2; This  visible-light wide-field image of the region around the Leo Triplet of  galaxies was created from photographs taken throug...</Credits>
@@ -55441,6 +56108,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1129aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1129a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/O. Maliy; This picture of the nearby galaxy NGC 3521 was taken using the FORS1 instrument on ESO’s Very Large Telescope, at the Paranal Ob...</Credits>
@@ -55467,6 +56135,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1129cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1129c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2; This visible light wide-field image of the region around NGC 3521 was created from photographs taken through blue, red and infra...</Credits>
@@ -55493,6 +56162,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1130cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1130c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2 ; This  visible-light wide-field image of the region around the giant  Lyman-alpha blob LAB1 was created from photographs taken th...</Credits>
@@ -55519,6 +56189,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1132aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1132a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; At  the centre of this picture is a very unremarkable looking faint star,  too faint to be seen through all but the largest amat...</Credits>
@@ -55545,6 +56216,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1132eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1132e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2; This visible light wide-field image of the region around SDSS J102915+172927  was created from photographs taken through blue, r...</Credits>
@@ -55571,6 +56243,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1141bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1141b"
     Xcxstatus="queue:eso"
   >
     <Credits>Ê ESO/D. Minniti/VVV Team;   This image from VISTA is a tiny part of the VISTA Variables in the Via Lactea (VVV) survey that is systematically studying the...</Credits>
@@ -55597,6 +56270,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1141cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1141c"
     Xcxstatus="queue:eso"
   >
     <Credits>Ê ESO/D. Minniti/VVV Team;   This image from VISTA is a tiny part of the VISTA Variables in the Via Lactea (VVV) survey that is systematically studying the...</Credits>
@@ -55623,6 +56297,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1147dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1147d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This view shows part of the stellar nursery called the Tarantula Nebula in the Large Magellanic Cloud, a small neighbour of the ...</Credits>
@@ -55649,6 +56324,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1148cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1148c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2.  Acknowledgment: Davide De Martin.; This wide-field image of the sky around the unusual double star SS Leporis is a colour composite made from exposures from the Di...</Credits>
@@ -55675,6 +56351,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1201aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1201a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO;  This image of the Omega Nebula (Messier 17), captured by ESO's Very Large Telescope (VLT), is one of the sharpest of this objec...</Credits>
@@ -55701,6 +56378,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1205aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1205a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/VISTA/J. Emerson. Acknowledgment: Cambridge Astronomical Survey Unit; ESO's Visible and Infrared Survey Telescope for Astronomy (VISTA) has captured this unusual view of the Helix Nebula (NGC 7293),...</Credits>
@@ -55727,6 +56405,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1206aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1206a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO, APEX (MPIfR/ESO/OSO), A. We; The LABOCA camera on the ESO-operated 12-metre Atacama Pathfinder Experiment (APEX) telescope reveals distant galaxies undergoin...</Credits>
@@ -55753,6 +56432,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1208dbL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1208db"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/T. Preibisch; Colour-composite image of the Carina Nebula, revealing exquisite details in the stars and dust of the region. Several well known...</Credits>
@@ -55779,6 +56459,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1208dcL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1208dc"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; Colour-composite image of the Carina Nebula, revealing exquisite details in the stars and dust of the region. Several well known...</Credits>
@@ -55805,6 +56486,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1209aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1209a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/APEX (MPIfR/ESO/OSO)/A. Haca; This image from the APEX telescope, of part of the Taurus Molecular Cloud, shows a sinuous filament of cosmic dust more than ten...</Credits>
@@ -55831,6 +56513,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1211dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1211d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2. Acknowledgment: Davide De Martin.; This visible-light wide-field image of the region around the Hercules cluster of galaxies was created from photographs taken thr...</Credits>
@@ -55857,6 +56540,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1212dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1212d"
     Xcxstatus="queue:eso"
   >
     <Credits>Digitized Sky Survey 2. Acknowle; This image shows a photographic view created from the Digitized Sky Survey 2 of part of the constellation of Cetus (The Sea Mons...</Credits>
@@ -55883,6 +56567,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1213aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1213a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/UltraVISTA team. Acknowledge; This view shows a section of the widest deep view of the sky ever taken using infrared light, with a total effective exposure ti...</Credits>
@@ -55961,6 +56646,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1218cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1218c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2; This visible-light wide-field image of the region around the star cluster NGC 6604 was created from photographs taken through bl...</Credits>
@@ -55987,6 +56673,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1219aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1219a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/APEX (MPIfR/ESO/OSO)/T. Stanke et al./Igor Chekalin/Digitized Sky Survey 2; This image of the region surrounding the reflection nebula Messier 78, just to the north of Orion’s belt, shows clouds of cosmic...</Credits>
@@ -56013,6 +56700,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1220aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1220a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/J. Emerson/VISTA. Acknowledgment: Cambridge Astronomical Survey Unit; This striking view of the globular star cluster Messier 55 in the constellation of Sagittarius (The Archer) was obtained in infr...</Credits>
@@ -56039,6 +56727,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1220cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1220c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2; This visible light wide-field image of the region around Messier 55 was created from photographs taken through blue and red filt...</Credits>
@@ -56065,6 +56754,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1222cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1222c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This is part of the image comparison The radio galaxy Centaurus A, as seen by ALMA....</Credits>
@@ -56091,6 +56781,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1227cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1227c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; This image of the sky around the star Tau Boötis was created from the Digitized Sky Survey 2 images. The star itself, which is b...</Credits>
@@ -56117,6 +56808,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1228aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1228a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO, Digitized Sky Survey 2 and S. Cantalupo (UCSC); This deep image shows the region of the sky around the quasar HE0109-3518. The quasar is near the centre of the image. The energ...</Credits>
@@ -56143,6 +56835,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1236cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1236c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2Acknowledgment: Davide De Martin. ; This  image of the region of sky around the Pencil Nebula shows a spectacular  celestial landscape featuring the blue filaments ...</Credits>
@@ -56169,6 +56862,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1248cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1248c"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)/Digitized S; This image shows the brown dwarf ISO-Oph 102, or Rho-Oph 102, in the Rho Ophiuchi star-forming region. Its position is marked by...</Credits>
@@ -56195,6 +56889,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1249aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1249a"
     Xcxstatus="queue:eso"
   >
     <Credits>CFHT/ESO/M. Schirmer; This view from the Canada-France-Hawaii Telescope shows thousands of galaxies in the distant Universe. But the one close to the ...</Credits>
@@ -56221,6 +56916,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1249bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1249b"
     Xcxstatus="queue:eso"
   >
     <Credits>CFHT/ESO/M. Schirmer; This view from the Canada-France-Hawaii Telescope shows a close-up of the sky around a very unusual green object called J224024....</Credits>
@@ -56247,6 +56943,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="7"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1250aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1250a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO. Acknowledgement: VPHAS+ Consortium/Cambridge Astronomical Survey Unit; The spectacular star-forming Carina Nebula has been captured in great detail by the VLT Survey Telescope at ESO’s Paranal Observ...</Credits>
@@ -56273,6 +56970,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1302cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1302c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2Acknowledgment: Davide De Martin.; This view of 47 Tucanae covers a field of view of 2.4 x 2.8 degrees, and shows the landscape around the cluster. It is a colour ...</Credits>
@@ -56299,6 +56997,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1307aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1307a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This image from the Wide Field Imager on the MPG/ESO 2.2-metre telescope at ESO’s La Silla Observatory in Chile, shows the brigh...</Credits>
@@ -56325,6 +57024,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1307cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1307c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin; This wide-field view shows the very rich star fields of the Large Sagittarius Star Cloud and the cluster NGC 6520 and the neighb...</Credits>
@@ -56351,6 +57051,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1308bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1308b"
     Xcxstatus="queue:eso"
   >
     <Credits>Radio: NRAO/AUI/NSF/GBT/VLA/Dyer; This remarkable image was created from pictures taken by different telescopes in space and on the ground. It shows the thousand-...</Credits>
@@ -56377,6 +57078,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1308cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1308c"
     Xcxstatus="queue:eso"
   >
     <Credits>NASA, ESA, and the Hubble Herita; This image is a composite of hydrogen-light observations taken with Hubble's Advanced Camera for Surveys in February 2006 and Wi...</Credits>
@@ -56403,6 +57105,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1309aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1309a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/VVV Survey/D. Minniti. Acknowledgement: Ignacio Toledo; This image from ESO’s VISTA telescope captures a celestial landscape of vast, glowing clouds of gas and tendrils of dust surroun...</Credits>
@@ -56429,6 +57132,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1310fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1310f"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This  picture shows the sky around the young star HD 100546 in the southern  constellation of Musca (The Fly). It was created fr...</Credits>
@@ -56455,6 +57159,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1315aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1315a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This image from ESO’s Very Large Telescope at the Paranal Observatory in Chile shows NGC 1637, a spiral galaxy located about 35 ...</Credits>
@@ -56481,6 +57186,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1315bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1315b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This image from ESO’s Very Large Telescope at the Paranal Observatory in Chile shows NGC 1637, a spiral galaxy located about 35 ...</Credits>
@@ -56507,6 +57213,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1315dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1315d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin; This image shows the sky around the spiral galaxy NGC 1637 in the constellation of Eridanus (The River). It was created from ima...</Credits>
@@ -56533,6 +57240,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1323aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1323a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This  image from the Wide Field Imager on the MPG/ESO 2.2-metre telescope at  the La Silla Observatory in Chile shows the globul...</Credits>
@@ -56559,6 +57267,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1324cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1324c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin; This picture shows the sky around the young star HD 95086 in the southern constellation of Carina (The Keel). It was created fro...</Credits>
@@ -56585,6 +57294,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1326aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1326a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This spectacular group of young stars is the open star cluster NGC 3766 in the constellation of Centaurus (The Centaur). Very ca...</Credits>
@@ -56611,6 +57321,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1327bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1327b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This picture was created from images forming part of the Digitized Sky Survey 2. It shows the region of sky around the active ga...</Credits>
@@ -56637,6 +57348,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1328cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1328c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin; This picture shows the sky around multiple star Gliese 667. The bright star at the centre is Gliese 667 A and B, the two main co...</Credits>
@@ -56663,6 +57375,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1330bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1330b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This wide-field view shows the sky around a very rare galaxy and quasar pair in the southern constellation of Tucana (The Toucan...</Credits>
@@ -56689,6 +57402,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1331aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1331a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NRAJ/NRAO)/NASA/Spitze; Observations of the dark cloud SDC 335.579-0.292 using the Atacama Large Millimeter/submillimeter array (ALMA) have given astron...</Credits>
@@ -56715,6 +57429,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1331cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1331c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This wide-field view shows a region of sky in the southern constellation of Norma (The Carpenter's Square). At the centre lies t...</Credits>
@@ -56741,6 +57456,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1336bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1336b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/ALMA (ESO/NAOJ/NRAO)/H. Arce; Astronomers using the Atacama Large Millimeter/submillimeter Array (ALMA) have obtained a vivid close-up view of material stream...</Credits>
@@ -56767,6 +57483,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1336cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1336c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Bo Reipurth; This image from ESO's New Technology Telescope at the La Silla Observatory in Chile shows the Herbig-Haro object HH 46/47 as jet...</Credits>
@@ -56793,6 +57510,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1337cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1337c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin; This wide-field view captures the solar twin HIP 102152 in the constellation of Capricornus (The Sea Goat). Located 250 light-ye...</Credits>
@@ -56819,6 +57537,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1338aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1338a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This image shows an example of a bipolar planetary nebula known as NGC 6537 taken with the New Technology Telescope at ESO’s La ...</Credits>
@@ -56845,6 +57564,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1339dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1339d"
     Xcxstatus="queue:eso"
   >
     <Credits>NASA &amp; ESA; This image from the NASA/ESA Hubble Space Telescope shows edge-on galaxy NGC 4710. When staring directly at the centre of the ga...</Credits>
@@ -56871,6 +57591,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1340aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1340a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO. Acknowledgement: Martin Pug; The glowing jumble of gas clouds visible in new image make up a huge stellar nursery nicknamed the Prawn Nebula. Taken using the...</Credits>
@@ -56897,6 +57618,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1344bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1344b"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)/NASA/ESA/I.; This image from the NASA/ESA Hubble Space Telescope shows the distant active galaxy PKG 1830-211. It shows up as an unremarkable...</Credits>
@@ -56923,6 +57645,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1347aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1347a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/G. Beccari; The Wide Field Imager on the MPG/ESO 2.2-metre telescope at ESO’s La Silla Observatory in Chile has captured the best image so f...</Credits>
@@ -56949,6 +57672,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1347cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1347c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Acknowledgement: Davide De Martin; This wide-field image shows the patch of sky around the star cluster NGC 3572 and its associated gas clouds. This view was creat...</Credits>
@@ -56975,6 +57699,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1403aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1403a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/VPHAS+ team; The VLT Survey Telescope (VST) at ESO's Paranal Observatory in Chile has captured this richly detailed new image of the Lagoon N...</Credits>
@@ -57001,6 +57726,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1406aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1406a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This new image from the Wide Field Imager on the MPG/ESO 2.2-metre telescope at ESO’s La Silla Observatory in Chile, shows the b...</Credits>
@@ -57027,6 +57753,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1407cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1407c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/MUSE consortium/R. Bacon; This colour composite of the unusual polar ring galaxy NGC 4650A was created from data from the new MUSE instrument on ESO’s Ver...</Credits>
@@ -57053,6 +57780,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1409aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1409a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; HR 5171, the brightest star just below the centre of this wide-field image, is a yellow hypergiant, a very rare type of stars wi...</Credits>
@@ -57079,6 +57807,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1411cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1411c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; This picture shows the sky around the pair of galaxies NGC 1316 and 1317. It was created from images forming part of the Digitiz...</Credits>
@@ -57105,6 +57834,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1412cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1412c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This wide-field view shows the sky around the planetary nebula Abell 33, which appears as the ghostly blue circle near the centr...</Credits>
@@ -57131,6 +57861,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1413aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1413a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This new image from the Wide Field Imager (WFI) on the MPG/ESO 2.2-metre telescope at the La Silla Observatory in Chile reveals ...</Credits>
@@ -57157,6 +57888,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1415dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1415d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2 Ackno; This wide-field view from the Digitized Sky Survey 2 is centred on the star cluster Westerlund 1 in the constellation of Ara (Th...</Credits>
@@ -57183,6 +57915,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1420cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1420c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This wide-field view captures the spectacular celestial landscape around the central object Gum 15. Among many other objects the...</Credits>
@@ -57209,6 +57942,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1421bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1421b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESA/Hubble &amp; NASA; This image from the NASA/ESA Hubble Space Telescope shows the irregular dwarf galaxy UGC 5189A. This star-forming galaxy was the...</Credits>
@@ -57235,6 +57969,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1423cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1423c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This wide field image shows extensive dust and small clumps of star formation in part of the Taurus star formation region. A fai...</Credits>
@@ -57261,6 +57996,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1423dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1423d"
     Xcxstatus="queue:eso"
   >
     <Credits>B. Saxton (NRAO/AUI/NSF); K. Sta; This image of the binary system HK Tauri combines visible light and infrared data from the NASA/ESA Hubble Space Telescope with ...</Credits>
@@ -57287,6 +58023,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1423eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1423e"
     Xcxstatus="queue:eso"
   >
     <Credits>NASA/JPL-Caltech/R. Hurt (IPAC); This picture shows the key velocity data taken with ALMA that helped the astronomers determine that the discs in HK Tauri were m...</Credits>
@@ -57313,6 +58050,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1424cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1424c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This wide field view of the sky around the nearby galaxy Messier 33 was assembled from images forming part of the Digitized Sky ...</Credits>
@@ -57339,6 +58077,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1425aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1425a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/G. Beccari; This mosaic of images from the Wide Field Imager on the MPG/ESO 2.2-metre telescope at ESO’s La Silla Observatory in Chile shows...</Credits>
@@ -57365,6 +58104,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1426aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1426a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/NASA/ESA/W. M. Keck Observat; The Atacama Large Millimeter/submillimeter Array (ALMA) and many other telescopes on the ground and in space have been used to o...</Credits>
@@ -57391,6 +58131,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1426cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1426c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This wide-field view of the sky around the gravitationally lensed galaxy merger H-ATLAS J142935.3-002836 was created from images...</Credits>
@@ -57417,6 +58158,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1426dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1426d"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)/NASA/ESA/W.; The Atacama Large Millimeter/submillimeter Array (ALMA) and many other telescopes on the ground and in space have been used to o...</Credits>
@@ -57443,6 +58185,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1427aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1427a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; The Wide Field Imager (WFI) on the MPG/ESO 2.2-metre telescope at the La Silla Observatory in Chile captured this view of dark c...</Credits>
@@ -57469,6 +58212,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1427cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1427c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; This view of the sky around the dark cloud Lupus 4 was created from the images forming part of the Digitized Sky Survey 2. Lupus...</Credits>
@@ -57495,6 +58239,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1428cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1428c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2; This visible-light wide-field image of the region around the globular star cluster Messier 54 was created from photographs formi...</Credits>
@@ -57521,6 +58266,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1430aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1430a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; The Wide Field Imager (WFI) on the MPG/ESO 2.2-metre telescope at the La Silla Observatory in Chile has taken this beautiful ima...</Credits>
@@ -57547,6 +58293,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1431bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1431b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This image shows the APEX view in sub-millimetre light of the region around the Spiderweb Galaxy — a protocluster of galaxies in...</Credits>
@@ -57573,6 +58320,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1431cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1431c"
     Xcxstatus="queue:eso"
   >
     <Credits>NASA, ESA, G. Miley and R. Overz; This image, taken by the NASA/ESA Hubble Space Telescope, shows the full ACS overview of the region around the Spiderweb Galaxy ...</Credits>
@@ -57599,6 +58347,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1431dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1431d"
     Xcxstatus="queue:eso"
   >
     <Credits>Digitized Sky Survey 2 and ESA/H; This image is a colour composite made from exposures from the Digitized Sky Survey 2 (DSS2). The field of view is 2.8 x 2.9 degr...</Credits>
@@ -57625,6 +58374,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1434bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1434b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This wide-field view shows the sky around the young multiple star system GG Tauri, which appears very close to the centre of thi...</Credits>
@@ -57651,6 +58401,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1436dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1436d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESA/Hubble and NASA Acknowledgem; This image was taken by the NASA/ESA Hubble Space Telescope and shows the tumultuous region around HL Tauri, a young star surrou...</Credits>
@@ -57677,6 +58428,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1436gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1436g"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; This image shows the region in which HL Tauri is situated. HL Tauri is part of one of the closest star-forming regions to Earth ...</Credits>
@@ -57703,6 +58455,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1437aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1437a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/M. Fumagalli; The MUSE instrument on ESO’s Very Large Telescope has provided researchers with the best view yet of a spectacular cosmic crash....</Credits>
@@ -57729,6 +58482,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1437bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1437b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/M. Fumagalli; The MUSE instrument on ESO’s Very Large Telescope has provided researchers with the best view yet of a spectacular cosmic crash....</Credits>
@@ -57755,6 +58509,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1437dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1437d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; This wide-field view shows the sky around the galaxy ESO 137-001, which appears near the bottom-right of this picture. This part...</Credits>
@@ -57781,6 +58536,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1437eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1437e"
     Xcxstatus="queue:eso"
   >
     <Credits>NASA, ESA, CXC; This image combines NASA/ESA Hubble Space Telescope observations with data from the Chandra X-ray Observatory. As well as the el...</Credits>
@@ -57807,6 +58563,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1439aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1439a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/G. Beccari; The MPG/ESO 2.2-metre telescope at ESO’s La Silla Observatory in Chile captured this richly colourful view of the bright star cl...</Credits>
@@ -57833,6 +58590,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1439cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1439c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This wide-field view of the sky around the cluster NGC 3532 was created from photographic material forming part of the Digitized...</Credits>
@@ -57859,6 +58617,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1441aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1441a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This spectacular image of the star cluster Messier 47 was taken using the Wide Field Imager camera, installed on the MPG/ESO 2.2...</Credits>
@@ -57885,6 +58644,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1441cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1441c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This wide-field image shows part of the constellation of Puppis (The Poop). This region of the sky includes some bright star clu...</Credits>
@@ -57911,6 +58671,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1501aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1501a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; The Wide Field Imager (WFI) on the MPG/ESO 2.2-metre telescope at the La Silla Observatory in Chile snapped this image of the da...</Credits>
@@ -57937,6 +58698,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1501cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1501c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2; This visible-light wide-field image of the region around the dark nebula LDN 483 was created from photographs forming part of th...</Credits>
@@ -57963,6 +58725,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1503cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1503c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2; This wide-field image shows a rich region of the sky in the constellation of Puppis (The Poop). At the centre lies the strange c...</Credits>
@@ -57989,6 +58752,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1504aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1504a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/VVV consortium/D. Minniti; This small extract from the VISTA VVV survey of the central parts of the Milky Way shows the famous Trifid Nebula to the right o...</Credits>
@@ -58015,6 +58779,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1504eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1504e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/VVV consortium/D. Minniti; This extract from the VISTA VVV survey of the central parts of the Milky Way shows the famous Trifid Nebula at the bottom. It ap...</Credits>
@@ -58041,6 +58806,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1504fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1504f"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/VVV consortium/D. Minniti; This small extract from the VISTA VVV survey of the central parts of the Milky Way shows the famous Trifid Nebula to the right o...</Credits>
@@ -58067,6 +58833,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1504gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1504g"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Gábor Tóth; This picture shows a familiar visible-light view of the Trifid Nebula from a small telescope on the ground....</Credits>
@@ -58093,6 +58860,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1505bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1505b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This image of the unusual planetary nebula was obtained using ESO’s Very Large Telescope at the Paranal Observatory in Chile. In...</Credits>
@@ -58119,6 +58887,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1505dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1505d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; This picture shows the sky around the planetary nebula Henize 2-428. The object itself is visible as a small curving nebula at t...</Credits>
@@ -58145,6 +58914,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1506cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1506c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; This picture shows the sky around the unusual double star V471 Tauri. The object itself is visible as an unremarkable looking st...</Credits>
@@ -58171,6 +58941,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1508cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1508c"
     Xcxstatus="queue:eso"
   >
     <Credits>NASA; ESA; L. Bradley (Johns Hop; This spectacular view from the NASA/ESA Hubble Space Telescope shows the rich galaxy cluster Abell 1689. The huge concentration ...</Credits>
@@ -58197,6 +58968,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1508dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1508d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; This view from the Digitized Sky Survey 2 shows the region of sky in the constellation of Virgo (The Virgin) around the rich gal...</Credits>
@@ -58223,6 +58995,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1511bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1511b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/T. Kamiński; This picture shows the remains of the new star that was seen in the year 1670. It was created from a combination of visible-ligh...</Credits>
@@ -58249,6 +59022,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1511dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1511d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This wide-field view shows the sky around the location of the historical exploding star Nova Vul 1670. The remains of the nova a...</Credits>
@@ -58275,6 +59049,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1513bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1513b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; This image shows the sky around the young star MWC 480 in the constellation of Taurus (The Bull). This picture was assembled fro...</Credits>
@@ -58301,6 +59076,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1514aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1514a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This image from the NASA/ESA Hubble Space Telescope shows the rich galaxy cluster Abell 3827. The strange blue structures surrou...</Credits>
@@ -58327,6 +59103,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1516bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1516b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESA/Hubble &amp; NASA Image acknowle; This NASA/ESA Hubble Space Telescope image shows an elliptical galaxy known as IC 2006. Massive elliptical galaxies like these a...</Credits>
@@ -58353,6 +59130,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1517cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1517c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; This image shows the sky around the star 51 Pegasi in the northern constellation of Pegasus (The Winged Horse).  In 1995 the fir...</Credits>
@@ -58379,6 +59157,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1518bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1518b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This colour view was created from observations of the Pillars of Creation made with the MUSE instrument on ESO’s Very Large Tele...</Credits>
@@ -58405,6 +59184,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1518eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1518e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This image is a colour composite of the Eagle Nebula (M 16)  made from exposures from the Digitized Sky Survey 2 (DSS2). The fie...</Credits>
@@ -58431,6 +59211,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1519aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1519a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey. Ackno; This huge elliptical galaxy NGC 5128 (also known as Centaurus A) is the closest such galaxy to the Earth, at a distance of about...</Credits>
@@ -58457,6 +59238,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1519cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1519c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO,ESA/Hubble, NASA. Digitized ; This huge elliptical galaxy NGC 5128 (also known as Centaurus A) is the closest such galaxy to the Earth, at a distance of about...</Credits>
@@ -58483,6 +59265,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1520cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1520c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; This wide-field view shows the sky around the large but faint planetary nebula known as the Medusa Nebula. The full extent of th...</Credits>
@@ -58509,6 +59292,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1521aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1521a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This richly coloured cloud of gas called RCW 34 is a site of star formation in the southern constellation of Vela (The Sails). T...</Credits>
@@ -58535,6 +59319,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1522bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1522b"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (NRAO/ESO/NAOJ)/Mark Swinba; ALMA’s Long Baseline Campaign has produced a spectacularly detailed image of a distant galaxy being gravitationally lensed, reve...</Credits>
@@ -58561,6 +59346,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1522cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1522c"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (NRAO/ESO/NAOJ)/Y. Tamura (; ALMA’s Long Baseline Campaign has produced a spectacularly detailed image of a distant galaxy being gravitationally lensed, reve...</Credits>
@@ -58587,6 +59373,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1522dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1522d"
     Xcxstatus="queue:eso"
   >
     <Credits>The NASA/ESA Hubble Space Telesc; ALMA’s Long Baseline Campaign has produced a spectacularly detailed image of a distant galaxy being gravitationally lensed, reve...</Credits>
@@ -58613,6 +59400,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1523aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1523a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/P. Kervella; Some of the sharpest images ever made with ESO’s Very Large Telescope have for the first time revealed what appears to be an age...</Credits>
@@ -58639,6 +59427,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1523bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1523b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/P. Kervella; Some of the sharpest images ever made with ESO’s Very Large Telescope have for the first time revealed what appears to be an age...</Credits>
@@ -58665,6 +59454,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1523dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1523d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; This image shows the region of sky in the southern constellation of Puppis surrounding the red giant star L2 Puppis. This rich a...</Credits>
@@ -58691,6 +59481,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1525aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1525a"
     Xcxstatus="queue:eso"
   >
     <Credits>Chris Mihos (Case Western Reserv; The huge halo around giant elliptical galaxy Messier 87 appears on this very deep image. An excess of light in the top-right par...</Credits>
@@ -58717,6 +59508,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1525bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1525b"
     Xcxstatus="queue:eso"
   >
     <Credits>A. Longobardi (Max-Planck-Instit; The red and blue dots mark the position of the planetary nebulae whose motion revealed that Messier 87 has recently been struck ...</Credits>
@@ -58743,6 +59535,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1526aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1526a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/G. Beccari; This rich view of an array of colourful stars and gas was captured by the Wide Field Imager (WFI) camera, on the MPG/ESO 2.2-met...</Credits>
@@ -58769,6 +59562,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1526cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1526c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This wide-field view of the sky around the cluster NGC 2367 was created from photographic material forming part of the Digitized...</Credits>
@@ -58795,6 +59589,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1528bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1528b"
     Xcxstatus="queue:eso"
   >
     <Credits>Kilo-Degree Survey Collaboration; The first results have been released from a major new dark matter survey of the southern skies using ESO’s  VLT Survey Telescope...</Credits>
@@ -58821,6 +59616,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1528cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1528c"
     Xcxstatus="queue:eso"
   >
     <Credits>Kilo-Degree Survey Collaboration; The first results have been released from a major new dark matter survey of the southern skies using ESO’s  VLT Survey Telescope...</Credits>
@@ -58847,6 +59643,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1530bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1530b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/R. Maiolino; This view is a combination of images from ALMA and the Very Large Telescope. The central object is a very distant galaxy, labell...</Credits>
@@ -58873,6 +59670,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1531aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1531a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This image from the New Technology Telescope at ESO’s La Silla Observatory shows Nova Centauri 2013 in July 2015 as the brightes...</Credits>
@@ -58899,6 +59697,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1531dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1531d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This image shows the sky around the location of Nova Centauri 2013. The nova itself appears, in its pre-outburst state, as a fai...</Credits>
@@ -58925,6 +59724,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1532cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1532c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This image shows the sky around the location of ESO 378-1. This planetary nebula shows up clearly as a blue disc at the centre o...</Credits>
@@ -58951,6 +59751,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1534aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1534a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This rich view of a tapestry of colourful stars was captured by the Wide Field Imager (WFI) camera, on the MPG/ESO 2.2-metre tel...</Credits>
@@ -58977,6 +59778,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1534cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1534c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This wide-field view of the sky around the cluster IC 4651 was created from photographic material forming part of the Digitized ...</Credits>
@@ -59003,6 +59805,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1535aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1535a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; The rich patchwork of gas clouds in this new image make up part of a huge stellar nursery nicknamed the Prawn Nebula (also known...</Credits>
@@ -59029,6 +59832,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1536aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1536a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; The Sculptor Dwarf Galaxy, pictured in a new image from the Wide Field Imager camera, installed on the 2.2-metre MPG/ESO telesco...</Credits>
@@ -59055,6 +59859,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1536cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1536c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; This image of the sky around the Sculptor Dwarf Galaxy was created from pictures from the Digitized Sky Survey 2. The galaxy app...</Credits>
@@ -59081,6 +59886,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1537aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1537a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This image of the rose-coloured star forming region Messier 17 was captured by the Wide Field Imager on the MPG/ESO 2.2-metre te...</Credits>
@@ -59107,6 +59913,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1538cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1538c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; This image shows the sky around the nearby young star AU Microscopii. It was created from images forming part of the Digitized S...</Credits>
@@ -59133,6 +59940,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1539aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1539a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This image from the Wide Field Imager on the MPG/ESO 2.2-metre telescope shows part of the huge cloud of dust and gas known as t...</Credits>
@@ -59159,6 +59967,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1539cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1539c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This rich landscape is part of the small constellation of Crux (The Southern Cross). The very bright star is Alpha Crucis, also ...</Credits>
@@ -59185,6 +59994,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1546aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1546a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; The star VY Canis Majoris is a red hypergiant, one of the largest known stars in the Milky Way. It is 30–40 times the mass of th...</Credits>
@@ -59211,6 +60021,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1546cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1546c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This wide-field view shows the sky around the very brilliant red hypergiant star VY Canis Majoris, one of the largest stars know...</Credits>
@@ -59237,6 +60048,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1547aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1547a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; The spectacular aftermath of a 360 million year old cosmic collision is revealed in great detail in this image from ESO’s Very L...</Credits>
@@ -59263,6 +60075,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1547cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1547c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This wide-field view shows the sky around the galaxy NGC 5291. This system has interacted with other galaxies and is surrounded ...</Credits>
@@ -59289,6 +60102,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1548bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1548b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESA/XXL consortium/Canada France; This image superimposes an X-ray image of a distant cluster (the blue pixellated image, from ESA's XMM-Newton satellite) on top ...</Credits>
@@ -59315,6 +60129,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1548cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1548c"
     Xcxstatus="queue:eso"
   >
     <Credits>XXL consortium/Canada France Haw; This distant cluster of galaxies was discovered by the XXL survey. It was found by its telltale X-ray emission coming from hot g...</Credits>
@@ -59341,6 +60156,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1548dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1548d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESA/XXL consortium/Canada France; This image superimposes an X-ray image of a distant cluster (the blue image, from ESA's XMM-Newton satellite) on top of a ground...</Credits>
@@ -59367,6 +60183,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1603aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1603a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO Acknowledgement: VST/Omegaca; This image, captured with the OmegaCAM camera on ESO’s VLT Survey Telescope in Chile, shows an unusually clean small galaxy. IC ...</Credits>
@@ -59393,6 +60210,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1603cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1603c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This wide-field view shows the sky around the dwarf galaxy IC 1613 in the constellation of Cetus (The Sea Monster). This picture...</Credits>
@@ -59419,6 +60237,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1604bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1604b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/NASA/ESA; The young star 2MASS J16281370-2431391 lies in the spectacular Rho Ophiuchi star formation region, about 400 light-years from Ea...</Credits>
@@ -59445,6 +60264,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1604dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1604d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2 Ackno; This wide-field view shows a spectacular region of dark and bright clouds, forming part of a region of star formation in the con...</Credits>
@@ -59471,6 +60291,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1605aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1605a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; A newly formed star lights up the surrounding cosmic clouds in this image from ESO’s La Silla Observatory in Chile. Dust particl...</Credits>
@@ -59497,6 +60318,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1605cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1605c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2 Ackno; A newly formed star lights up the surrounding cosmic clouds to create the blue reflection nebula IC 2631 at the centre of this s...</Credits>
@@ -59523,6 +60345,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1606fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1606f"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/ATLASGAL consortium/NASA/GLI; This picture shows the more familiar view in visible light, where most of the more distant structures are hidden from view. This...</Credits>
@@ -59549,6 +60372,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1606gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1606g"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/ATLASGAL consortium/NASA/GLI; The top panel shows compact sources of submillimetre radiation detected by APEX as part of the ATLASGAL survey, combined with co...</Credits>
@@ -59575,6 +60399,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1606hL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1606h"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/ATLASGAL consortium/NASA/GLI; This image shows the same region as seen in shorter, infrared, wavelengths by the NASA Spitzer Space Telescope.This image is par...</Credits>
@@ -59601,6 +60426,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1606iL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1606i"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/ATLASGAL consortium/NASA/GLI; This image shows the same part of sky again at even shorter wavelengths, the near-infrared, as seen by ESO’s VISTA infrared surv...</Credits>
@@ -59627,6 +60453,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1608bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1608b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; The Very Large Telescope Interferometer at ESO’s Paranal Observatory in Chile has obtained the sharpest view ever of the dusty d...</Credits>
@@ -59653,6 +60480,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1608dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1608d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2 Ackno; This colourful image shows the rich celestial landscape in the constellation of Vela (The Sails) around the aging double star IR...</Credits>
@@ -59679,6 +60507,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1610aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1610a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO Acknowledgement: VST/Omegaca; This image, captured by ESO’s OmegaCAM on the VLT Survey Telescope, shows a lonely galaxy known as Wolf-Lundmark-Melotte, or WLM...</Credits>
@@ -59705,6 +60534,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1610cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1610c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This wide-field view shows the sky around the dwarf galaxy WLM in the constellation of Cetus (The Sea Monster). This picture was...</Credits>
@@ -59731,6 +60561,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1611aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1611a"
     Xcxstatus="queue:eso"
   >
     <Credits>S. Andrews (Harvard-Smithsonian ; ALMA’s best image of a protoplanetary disc to date. This picture of the nearby young star TW Hydrae reveals the classic rings an...</Credits>
@@ -59757,6 +60588,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1611cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1611c"
     Xcxstatus="queue:eso"
   >
     <Credits>S. Andrews (Harvard-Smithsonian ; This ALMA image of the young nearby star TW Hydrae has a resolution of 1 AU (Astronomical Unit, the distance from the Earth to t...</Credits>
@@ -59783,6 +60615,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1616aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1616a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; In this image from ESO’s Very Large Telescope (VLT), light from blazing blue stars energises the gas left over from the stars’ r...</Credits>
@@ -59809,6 +60642,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1620cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1620c"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO), NAOJ; Light from ionised oxygen detected by ALMA is shown in green. Light from ionised hydrogen detected by the Subaru Telescope and u...</Credits>
@@ -59835,6 +60669,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1624eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1624e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2; This wide-field image shows a piece of the constellation of Centaurus (The Centaur) centred on the position of the triple star H...</Credits>
@@ -59861,6 +60696,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1624gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1624g"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/K. Wagner et al.; This composite image shows the newly discovered exoplanet HD 131399Ab in the triple-star system HD 131399. The image of the plan...</Credits>
@@ -59887,6 +60723,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1626bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1626b"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)/L. Cieza; This image of the planet-forming disc around the young star V883 Orionis was obtained by ALMA in long-baseline mode. This star i...</Credits>
@@ -59913,6 +60750,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1627cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1627c"
     Xcxstatus="queue:eso"
   >
     <Credits>Digitized Sky Survey 2. Acknowle; This wide-field image from the Digitized Sky Survey 2 shows the rich starfields surrounding the exotic binary star system AR Sco...</Credits>
@@ -59939,6 +60777,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1628cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1628c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; The small smattering of bright stars at the centre of this wide-field view is Messier 18, an open star cluster containing stars ...</Credits>
@@ -59965,6 +60804,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1630aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1630a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/F. Ferraro; Peering through the thick dust clouds of the galactic bulge an international team of astronomers has revealed the unusual mix of...</Credits>
@@ -59991,6 +60831,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1630bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1630b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/F. Ferraro; Peering through the thick dust clouds of the galactic bulge an international team of astronomers has revealed the unusual mix of...</Credits>
@@ -60017,6 +60858,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1631aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1631a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/CARS survey; This image from the MUSE instrument on ESO’s Very Large Telescope shows the active galaxy Markarian 1018, which has a supermassi...</Credits>
@@ -60043,6 +60885,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1631bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1631b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This wide-field image shows the sky around the faint active galaxy Markarian 1018. The picture was assembled from images forming...</Credits>
@@ -60069,6 +60912,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1633cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1633c"
     Xcxstatus="queue:eso"
   >
     <Credits>NASA, ESA, G. Illingworth, D. Ma; This image, called the Hubble eXtreme Deep Field (XDF), combines Hubble observations taken over the past decade of a small patch...</Credits>
@@ -60095,6 +60939,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1633dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1633d"
     Xcxstatus="queue:eso"
   >
     <Credits>B. Saxton (NRAO/AUI/NSF); ALMA (; ALMA surveyed the Hubble Ultra Deep Field, uncovering new details of the star-forming history of the Universe. This close-up ima...</Credits>
@@ -60121,6 +60966,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1633eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1633e"
     Xcxstatus="queue:eso"
   >
     <Credits>B. Saxton (NRAO/AUI/NSF); ALMA (; A trove of galaxies, rich in carbon monoxide (indicating star-forming potential) were imaged by ALMA (orange) in the Hubble Ultr...</Credits>
@@ -60147,6 +60993,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1635aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1635a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This richly detailed view of the star formation region Messier 78, in the constellation of Orion (The Hunter), was taken with th...</Credits>
@@ -60173,6 +61020,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1636aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1636a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/VVV Survey/D. Minniti; This image, captured with the VISTA infrared survey telescope, as part of the Variables in the Via Lactea (VVV) ESO public surve...</Credits>
@@ -60199,6 +61047,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1639aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1639a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/A. McLeod; This image was taken by the MUSE instrument, mounted on ESO’s Very Large Telescope and shows the region R44 within the Carina Ne...</Credits>
@@ -60225,6 +61074,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1639cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1639c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/A. McLeod; This image was taken by the MUSE instrument, mounted on ESO’s Very Large Telescope and shows the region R18 within the Carina Ne...</Credits>
@@ -60251,6 +61101,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1639dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1639d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/A. McLeod; This image was taken by the MUSE instrument, mounted on ESO’s Very Large Telescope and shows the region R37 within the Carina Ne...</Credits>
@@ -60277,6 +61128,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1639eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1639e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/A. McLeod; This image was taken by the MUSE instrument, mounted on ESO’s Very Large Telescope and shows the region R45 within the Carina Ne...</Credits>
@@ -60303,6 +61155,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1639fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1639f"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/A. McLeod; This pillar is part of the massive star cluster Trumpler 14, within the Carina Nebula, 7500 light-years away. The image was take...</Credits>
@@ -60329,6 +61182,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1639gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1639g"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/A. McLeod; The prominent dark patches, in the central region and to the right of the image are a so called Bok globule: these are isolated ...</Credits>
@@ -60355,6 +61209,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1639hL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1639h"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/A. McLeod; This craggy fantasy mountaintop enshrouded by wispy clouds looks like a bizarre landscape. But it is indeed a pillar of gas and ...</Credits>
@@ -60381,6 +61236,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1640cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1640c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO, C. Ginski et al.; Using the ESO’s SPHERE instrument at the Very Large Telescope, a team of astronomer observed the planetary disc surrounding the ...</Credits>
@@ -60407,6 +61263,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1640dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1640d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO, T. Stolker et al.; Using ESO’s SPHERE instrument at the Very Large Telescope, a team of astronomers observed the planetary disc surrounding the sta...</Credits>
@@ -60433,6 +61290,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1641bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1641b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2 Ackno; This wide field image shows the sky around the very faint neutron star RX J1856.5-3754 in the southern constellation of Corona A...</Credits>
@@ -60459,6 +61317,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1641cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1641c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; Colour composite photo of the sky field around the lonely neutron star RX J1856.5-3754 and the related cone-shaped nebula. It is...</Credits>
@@ -60485,6 +61344,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1645aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1645a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA(ESO/NAOJ/NRAO)/NASA/ESA and; The compound view shows a new ALMA Band 5 image of the colliding galaxy system Arp 220 (in red) on top of an image from the NASA...</Credits>
@@ -60511,6 +61371,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1707aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1707a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This colourful image from ESO’s Very Large Telescope shows NGC 1055 in the constellation of Cetus (The Sea Monster).  This large...</Credits>
@@ -60537,6 +61398,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1711aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1711a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO), J. Bally/H;    Stellar explosions are most often associated with supernovae, the spectacular deaths of stars. But new ALMA observations of t...</Credits>
@@ -60563,6 +61425,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1711bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1711b"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO), J. Bally; Stellar explosions are most often associated with supernovae, the spectacular deaths of stars. But new ALMA observations of the ...</Credits>
@@ -60589,6 +61452,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1720aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1720a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; ESO’s Very Large Telescope (VLT) has captured a magnificent face-on view of the barred spiral galaxy Messier 77. The image does ...</Credits>
@@ -60615,6 +61479,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1720cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1720c"
     Xcxstatus="queue:eso"
   >
     <Credits>NASA/ESA, Digitized Sky Survey 2; This image from the Digitized Sky Survey shows spiral galaxy Messier 77 and its surroundings. Messier 77 appears at the centre a...</Credits>
@@ -60641,6 +61506,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1724aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1724a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/J. Richard (CRAL); The coupling of the AOF with MUSE gives access to both greater sharpness and a wide dynamic range when observing celestial objec...</Credits>
@@ -60667,6 +61533,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1724aaL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1724aa"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/P. Weilbacher; The image is how NGC 6369 is seen in natural sky conditions. This image is part of an image comparison....</Credits>
@@ -60693,6 +61560,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1724abL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1724ab"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/P. Weilbacher; The image depicts the true power of the Adaptive Optics Facility (AOF), revealing much finer details in the faint planetary nebu...</Credits>
@@ -60743,6 +61611,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1724caL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1724c,eso|eso1724ca"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/P. Weilbacher; The planetary nebula NGC 6563 resides in a crowded starry region of the sky. In natural sky conditions many of these stars remai...</Credits>
@@ -60769,6 +61638,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1724cbL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1724cb"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/P. Weilbacher; The planetary nebula NGC 6563 resides in a crowded starry region of the sky. In natural sky conditions many of these stars remai...</Credits>
@@ -60795,6 +61665,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1724hL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1724h"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/P. Weilbacher (AIP); Known as the Little Ghost Nebula, NGC 6369 is a planetary nebula in the constellation Ophiuchus, the serpent-bearer. The nebula ...</Credits>
@@ -60821,6 +61692,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1724iL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1724i"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/P. Weilbacher (AIP); ESO 338-4 is a starburst galaxy located in Sagittarius, the Archer. It is currently in the process of merging, with several smal...</Credits>
@@ -60847,6 +61719,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1725bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1725b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/GASP collaboration; Observations of “Jellyfish galaxies” with ESO’s Very Large Telescope have revealed a previously unknown way to fuel supermassive...</Credits>
@@ -60873,6 +61746,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1725dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1725d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/GASP collaboration; Observations of “Jellyfish galaxies” with ESO’s Very Large Telescope have revealed a previously unknown way to fuel supermassive...</Credits>
@@ -60899,6 +61773,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1726aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1726a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/K. Ohnaka; Using ESO’s Very Large Telescope Interferometer astronomers have constructed this remarkable image of the red supergiant star An...</Credits>
@@ -60925,6 +61800,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1727bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1727b"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)/E. Falgaron; This ALMA image shows the Cosmic Eyelash, a remote starburst galaxy that appears double and brightened by gravitational lensing....</Credits>
@@ -60951,6 +61827,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1730aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1730a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO)/F. Kerschba; This ALMA image reveals much finer structure in the U Antliae shell than has previously been possible. Around 2700 years ago, U ...</Credits>
@@ -60977,6 +61854,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1730cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1730c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO, Digitized Sky Survey 2. Ack; This image from the Digitized Sky Survey 2 shows the very red carbon star U Antliae and its surroundings....</Credits>
@@ -61003,6 +61881,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1730dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1730d"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO), F. Kerschb; This image was created from ALMA data on the unusual red carbon star U Antliae and its surrounding shell of material. The colour...</Credits>
@@ -61029,6 +61908,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1731aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1731a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/J. Walsh; The spectacular planetary nebula NGC 7009, or the Saturn Nebula, emerges from the darkness like a series of oddly-shaped bubbles...</Credits>
@@ -61055,6 +61935,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1731eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1731e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO, Digitized Sky Survey 2. Ack; This image from the Digitized Sky Survey 2 shows the sky around the bright planetary nebula NGC 7009, often called the Saturn Ne...</Credits>
@@ -61081,6 +61962,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1733bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1733b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/A.J. Levan, N.R. Tanvir; This image from the VIMOS instrument on ESO’s Very Large Telescope at the Paranal Observatory in Chile shows the galaxy NGC 4993...</Credits>
@@ -61107,6 +61989,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1733dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1733d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/J.D. Lyman, A.J. Levan, N.R.; This image from the MUSE instrument on ESO’s Very Large Telescope at the Paranal Observatory in Chile shows the galaxy NGC 4993,...</Credits>
@@ -61133,6 +62016,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1733hL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1733h"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/S. Smartt &amp; T.-W. Chen; Image obtained by ESO's Gamma-ray Burst Optical/Near-infrared Detector (GROND) attached to the MPG/ESO 2.2-metre telescope at La...</Credits>
@@ -61159,6 +62043,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1733iL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1733i"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO and Digitized Sky Survey 2; This wide-field image generated from the Digitized Sky Survey 2 shows the sky around the galaxy NGC 4993. This galaxy was the ho...</Credits>
@@ -61185,6 +62070,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1736bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1736b"
     Xcxstatus="queue:eso"
   >
     <Credits>Digitized Sky Survey 2. Acknowle; This image shows the sky around the red dwarf star Ross 128 in the constellation of Virgo (The Virgin). It was created from imag...</Credits>
@@ -61211,6 +62097,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1738aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1738a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/MUSE HUDF collaboration; This colour image shows the Hubble Ultra Deep Field region, a tiny but much-studied region in the constellation of Fornax, as ob...</Credits>
@@ -61237,6 +62124,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1738cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1738c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/MUSE HUDF team.; This compound image shows the Hubble Ultra Deep Field region and highlights in blue the glowing haloes of gas around many distan...</Credits>
@@ -61263,6 +62151,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1741aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1741a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; Astronomers using ESO’s Very Large Telescope have directly observed granulation patterns on the surface of a star outside the So...</Credits>
@@ -61289,6 +62178,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1741bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1741b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This colourful image shows the sky around the bright pair of stars π1 Gruis (centre-right, very red) and π2 Gruis (centre-left, ...</Credits>
@@ -61315,6 +62205,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1802eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1802e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESA/NASA; This image from the NASA/ESA Hubble Space Telescope shows the central region of the rich globular star cluster NGC 3201 in the s...</Credits>
@@ -61341,6 +62232,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1809aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1809a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/H. Drass/ALMA (ESO/NAOJ/NRAO; This spectacular and unusual image shows part of the famous Orion Nebula, a star formation region lying about 1350 light-years f...</Credits>
@@ -61367,6 +62259,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1810aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1810a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/NASA, ESA and the Hubble Her; This new picture created from images from telescopes on the ground and in space tells the story of the hunt for an elusive missi...</Credits>
@@ -61393,6 +62286,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1810bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1810b"
     Xcxstatus="queue:eso"
   >
     <Credits>NASA, ESA and the Hubble Heritag; This picture from the NASA/ESA Hubble Space Telescope sets the scene for the story of the hunt for an elusive missing object hid...</Credits>
@@ -61419,6 +62313,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1810cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1810c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/F. Vogt et al.; This new picture from the MUSE instrument on ESO’s Very Large Telescope in Chile shows how an elusive missing object was found a...</Credits>
@@ -61445,6 +62340,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1810dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1810d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/NASA; This archival image from the NASA Chandra X-Ray Observatory shows how an elusive missing object was found amid a complex tangle ...</Credits>
@@ -61471,6 +62367,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1815bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1815b"
     Xcxstatus="queue:eso"
   >
     <Credits>NASA, ESA, S. Rodney (John Hopki; This image shows the huge galaxy cluster MACS J1149.5+223, whose light took over 5 billion years to reach us. The huge mass of t...</Credits>
@@ -61497,6 +62394,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1817bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1817b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This gigantic star-forming region in the Milky Way’s neighbour galaxy the Large Magellanic Cloud is the birthplace of an astonis...</Credits>
@@ -61523,6 +62421,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1818aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1818a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO, ALMA (ESO/NAOJ/NRAO); Pinte; ALMA has uncovered convincing evidence that three young planets are in orbit around the infant star HD 163296. Using a novel pla...</Credits>
@@ -61549,6 +62448,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1818dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1818d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2 Ackno; This wide-field image shows the surroundings of the young star HD 163296 in the rich constellation of Sagittarius (The Archer). ...</Credits>
@@ -61575,6 +62475,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1821aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1821a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/A. Müller et al.; This spectacular image from the SPHERE instrument on ESO's Very Large Telescope is the first clear image of a planet caught in t...</Credits>
@@ -61601,6 +62502,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1821bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1821b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This colourful image shows the sky around the faint orange dwarf star PDS 70 (in the middle of the image). The bright blue star ...</Credits>
@@ -61627,6 +62529,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1823aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1823a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/K. Muzic; New observations with ESO’s Very Large Telescope show the star cluster RCW 38 in all its glory. This image was taken during test...</Credits>
@@ -61653,6 +62556,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1826aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1826a"
     Xcxstatus="queue:eso"
   >
     <Credits>ALMA (ESO/NAOJ/NRAO), T. Kamińs; Composite image of CK Vulpeculae, the remains of a double-star collision. This impact launched radioactive molecules into space,...</Credits>
@@ -61679,6 +62583,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1827aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1827a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Spavone et al.; This deep image of the area of sky around the elliptical galaxy NGC 5018 offers a spectacular view of its tenuous streams of sta...</Credits>
@@ -61705,6 +62610,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1827eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1827e"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This image is a colour composite made from exposures from the Digitized Sky Survey 2 (DSS2)....</Credits>
@@ -61731,6 +62637,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1828aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1828a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/J. Emerson/M. Irwin/J. Lewis; This spectacular image of the Carina nebula reveals the dynamic cloud of interstellar matter and thinly spread gas and dust as n...</Credits>
@@ -61757,6 +62664,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1828bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1828b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/J. Emerson/M. Irwin/J. Lewis; This wider coverage area reveals even more stars from the crowded neighbourhood surrounding the Carina nebula. Captured by VISTA...</Credits>
@@ -61783,6 +62691,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1828cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1828c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This image is a colour composite made from exposures from the Digitized Sky Survey 2 (DSS2). The field of view is approximately ...</Credits>
@@ -61809,6 +62718,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1830aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1830a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; FORS2, an instrument mounted on ESO’s Very Large Telescope captured the spiral galaxy NGC 3981 in all its glory. The image, capt...</Credits>
@@ -61835,6 +62745,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1830bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1830b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This image is a colour composite made from exposures from the Digitized Sky Survey 2 (DSS2). The field of view is approximately ...</Credits>
@@ -61861,6 +62772,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1832aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1832a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESA/Hubble &amp; NASA, ESO/ Lutz Wis; Deep observations made with the MUSE spectrograph on ESO’s Very Large Telescope have uncovered vast cosmic reservoirs of atomic ...</Credits>
@@ -61887,6 +62799,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1832bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1832b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This image is a colour composite made from exposures from the Digitized Sky Survey 2 (DSS2). The field of view is approximately ...</Credits>
@@ -61913,6 +62826,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1834aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1834a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This vivid picture of an active star forming region — NGC 2467, otherwise known as the Skull and Crossbones nebula — is as sinis...</Credits>
@@ -61939,6 +62853,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1836bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1836b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; Observations by ALMA and data from the MUSE spectrograph on ESO’s VLT have revealed a colossal fountain of molecular gas powered...</Credits>
@@ -61965,6 +62880,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1837dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1837d"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2 Ackno; This wide-field image shows the surroundings of the red dwarf known as Barnard’s Star in the constellation of Ophiuchus (the Ser...</Credits>
@@ -61991,6 +62907,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1838aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1838a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Callingham et al.; The VISIR instrument on ESO’s VLT captured this stunning image of a newly-discovered massive binary star system. Nicknamed Apep ...</Credits>
@@ -62017,6 +62934,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1838cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1838c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; The image is a colour composite made from exposures from the Digitized Sky Survey 2 (DSS2), and shows the region surrounding  2X...</Credits>
@@ -62043,6 +62961,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1839bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1839b"
     Xcxstatus="queue:eso"
   >
     <Credits>SPECULOOS Team/E. Jehin/ESO; This first light image from the Europa telescope at the SPECULOOS Southern Observatory (SSO) shows the heart of the Carina Nebul...</Credits>
@@ -62069,6 +62988,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1839hL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1839h"
     Xcxstatus="queue:eso"
   >
     <Credits>SPECULOOS Team/E. Jehin/ESO; This first light image from the Europa telescope at the  SPECULOOS Southern Observatory  (SSO) shows M83,  the Southern Pinwheel...</Credits>
@@ -62095,6 +63015,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1839iL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1839i"
     Xcxstatus="queue:eso"
   >
     <Credits>SPECULOOS Team/E. Jehin/ESO; This first light image from the Callisto telescope at the  SPECULOOS Southern Observatory  (SSO) shows the famous  Horsehead Neb...</Credits>
@@ -62121,6 +63042,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1840aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1840a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Schmid et al.; While testing a new subsystem on the SPHERE planet-hunting instrument on ESO’s Very Large telescope, astronomers were able to ca...</Credits>
@@ -62147,6 +63069,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1902aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1902a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; The faint, ephemeral glow emanating from the planetary nebula ESO 577-24 persists for only a short time  — around 10,000 years, ...</Credits>
@@ -62173,6 +63096,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1903aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1903a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO, A McLeod et al.; This dazzling region of newly-forming stars in the Large Magellanic Cloud (LMC) was captured by the Multi Unit Spectroscopic Exp...</Credits>
@@ -62199,6 +63123,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1903bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1903b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO, A McLeod et al.; Deep within the glowing cloud of the HII region LHA 120-N 180B, MUSE has spotted a jet emitted by a fledgling star — a massive  ...</Credits>
@@ -62225,6 +63150,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1903cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1903c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This dazzling region of newly-forming stars in the Large Magellanic Cloud (LMC) was captured by the Multi Unit Spectroscopic Exp...</Credits>
@@ -62251,6 +63177,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1904aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1904a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; Hidden in one of the darkest corners of the Orion constellation, this Cosmic Bat is spreading its hazy wings through interstella...</Credits>
@@ -62277,6 +63204,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1905cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1905c"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This wide-field image shows the surroundings of the young star HR8799 in the constellation of Pegasus. This picture was created ...</Credits>
@@ -62303,6 +63231,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1907bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1907b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; Messier 87 (M87) is an enormous elliptical galaxy located about 55 million light years from Earth, visible in the constellation ...</Credits>
@@ -62329,6 +63258,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso1908aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso1908a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This image, a composite of several observations captured by ESO’s VLT Survey Telescope (VST), shows the space observatory Gaia a...</Credits>
@@ -62484,6 +63414,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso9856bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso9856b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This image displays a spectacular three-colour composite image of RCW38, obtained through three near-infrared filters. This is a...</Credits>
@@ -62536,6 +63467,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-eso9920uL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eso9920u"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; Colour composite image of the galaxy cluster 1ES 0657-558, based on data taken in the B (blue; exposure 900 sec), V (green; 600 ...</Credits>
@@ -62612,6 +63544,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-etamosaicnm2L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|eta,eso|etamosaicnm2"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/IDA/Danish 1.5 m/R.Gendler, ; The Carina Nebula is a large bright nebula that surrounds several clusters of stars. It contains two of the most massive and lum...</Credits>
@@ -62638,6 +63571,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-galactic_center_hiL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|galactic_center_hi"
     Xcxstatus="queue:eso"
   >
     <Credits>NRAO/AUI/NSF; The view of the centre of our galaxy with a closer view of the object known as Sagittarius A*, the bright radio source that corr...</Credits>
@@ -62664,6 +63598,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-n70L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|n70"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; The N70 superbubble nebula in the Large Magellanic Cloud (LMC), imaged with the ESO Schmidt Telescope on La Silla....</Credits>
@@ -62690,6 +63625,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-naco_ccL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|naco_cc"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; A raw image straight from the NACO instrument on the VLT....</Credits>
@@ -62716,6 +63652,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc104-47-schmidtL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|ngc104-47-schmidt"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; A colour-corrected image of the the second largest and second brightest globular cluster, or tight grouping of stars, seen in Ea...</Credits>
@@ -62742,6 +63679,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc1068-sercL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|ngc1068-serc"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; A survey of the sky captured on film by ESO's 1-m Schmidt Telescope. In the left-centre, the galaxy NGC 1068 is visible, among o...</Credits>
@@ -62768,6 +63706,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc1232bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|ngc1232b"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/IDA/Danish 1.5 m/R.Gendler and A. Hornstrup.; The striking, large spiral galaxy NGC 1232, and its distorted companion shaped like the greek letter "theta". The pair is locate...</Credits>
@@ -62794,6 +63733,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc1448-potwL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|ngc1448-potw"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; Portrayed in this beautiful image is the spiral galaxy NGC 1448, with a prominent disc of young and very bright stars surroundin...</Credits>
@@ -62820,6 +63760,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc1532L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|ngc1532"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/IDA/Danish 1.5 m/R.Gendler and J.-E. Ovaldsen; The pair of galaxies NGC 1531/2, engaged in a spirited waltz, is located about 70 million light-years away towards the southern ...</Credits>
@@ -62846,6 +63787,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc2060-ccL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|ngc2060-cc"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; Located in the direction of the constellation Dorado in the Large Magellanic Cloud, the resplendent object known as NGC 2060 is ...</Credits>
@@ -62872,6 +63814,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc2207L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|ngc2207"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; In this image, two spiral galaxies, similar in looks to the Milky Way, are participating in a cosmic ballet, which, in a few bil...</Credits>
@@ -62898,6 +63841,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc2280-potwL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|ngc2280-potw"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This new image of the galaxy NGC 2280 shows the extent of its massive spiral arms that reach far into the surrounding space. The...</Credits>
@@ -62924,6 +63868,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc2442L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|ngc2442"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/IDA/Danish 1.5 m/R. Gendler, J.-E. Ovaldsen, C. C. Thöne and C. Féron; The distorted galaxy NGC 2442, also known as the Meathook Galaxy, is located some 50 million light-years away in the constellati...</Credits>
@@ -62950,6 +63895,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc3132-ccL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|ngc3132-cc"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; NGC 3132, also referred to as the Eight-Burst or the Southern Ring Nebula, glows at a distance of about 2,000 light years in the...</Credits>
@@ -62976,6 +63922,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc3201L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|ngc3201"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; Colour-composite image of the globular cluster NGC 3201, obtained with the WFI instrument on the ESO/MPG 2.2-m telescope at La S...</Credits>
@@ -63002,6 +63949,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc6781-potwL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|ngc6781-potw"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; Stars such as our Sun do not contain enough mass to finish their lives in the glorious explosions known as supernovae. However, ...</Credits>
@@ -63052,6 +64000,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc_2997L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|ngc_2997"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This is one of the first CCD images taken at ESO. It was obtained in the V filter, with the CCD camera at the 1.5-metre Danish T...</Credits>
@@ -63078,6 +64027,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-ngc_6188_paranalL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|ngc_6188_paranal"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/J. Pérez; Impressive image of the NGC 6188 nebula, located some 4000 light-years away, in the southern constellation of Ara (the Altar). T...</Credits>
@@ -63104,6 +64054,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-omega-nebulaL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|omega-nebula"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; The Omega Nebula, also known as the Swan Nebula, Messier 17 (M17), or NGC 6618, as imaged by the ESO 3.6-metre telescope on La S...</Credits>
@@ -63130,6 +64081,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-opo0708aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|opo0708a"
     Xcxstatus="queue:eso"
   >
     <Credits>NASA, ESA, and The Hubble Herita; This image from the NASA/ESA Hubble Space Telescope shows the diverse collection of galaxies in the cluster Abell S0740 that is ...</Credits>
@@ -63156,6 +64108,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-orion-hawk-iL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|orion-hawk-i"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; The central region of the Orion Nebula (M42, NGC 1976) as seen in the near-infrared by the High Acuity Wide field K-band Imager ...</Credits>
@@ -63182,6 +64135,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-potw1007aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|potw1007a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/IDA/Danish 1.5 m/R. Gendler and C. Thöne; Portrayed in this image is the spiral galaxy NGC 4945, a close neighbour of the Milky Way. Belonging to the Centaurus A group of...</Credits>
@@ -63208,6 +64162,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-potw1017aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|potw1017a"
     Xcxstatus="queue:eso"
   >
     <Credits>Credit: ESO/IDA/Danish 1.5 m/ R. Gendler, U. G. Jørgensen, J. Skottfelt, K. Harpsøe; NGC 253, also known as the Sculptor Galaxy, is the brightest of the Sculptor Group of galaxies, found in the constellation of th...</Credits>
@@ -63234,6 +64189,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-potw1044aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|potw1044a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/R. Chini; Astronomers using data from ESO's Very Large Telescope (VLT), at the Paranal Observatory in Chile, have made an impressive compo...</Credits>
@@ -63260,6 +64216,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-potw1447aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|potw1447a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/S. Ramstedt (Uppsala Univers; Studying red giant stars tells astronomers about the future of the Sun — and about how previous generations of stars spread the ...</Credits>
@@ -63286,6 +64243,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-raqr-nttL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|raqr-ntt"
     Xcxstatus="queue:eso"
   >
     <Credits>Romano Corradi; R Aquarii observed using the New Technology Telescope in 1991. The white vertical line in the middle is caused by light from the...</Credits>
@@ -63312,6 +64270,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-sn1992c_aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|sn1992c_a"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; This photo shows the newly discovered Supernova 1992C in the barred spiral galaxy NGC 3367. The supernova is the bright, star-li...</Credits>
@@ -63338,6 +64297,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-sombreroL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|sombrero"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/IDA/Danish 1.5 m/R. Gendler and J.-E. Ovaldsen; One of most famous spiral galaxies is Messier 104, widely known as the "Sombrero" (the Mexican hat) because of its particular sh...</Credits>
@@ -63364,6 +64324,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-tarantulaL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|tarantula"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO/IDA/Danish 1.5 m/R. Gendler, C. C. Thöne, C. Féron, and J.-E. Ovaldsen; Located inside the Large Magellanic Cloud (LMC) – one of our closest galaxies – in what some describe as a frightening sight, th...</Credits>
@@ -63416,6 +64377,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-vela-snr-schmidtourcompL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|vela-snr-schmidtourcomp"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; A so-called Supernova Remnant (SNR) in the Vela constellation, captured by ESO's 1 m Schmidt Telescope at La Silla in Chile. The...</Credits>
@@ -63442,6 +64404,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/ESO-wr124L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="eso|wr124"
     Xcxstatus="queue:eso"
   >
     <Credits>ESO; M1-67 is the youngest wind-nebula around a Wolf-Rayet star, called WR124, in our Galaxy. These Wolf-Rayet stars start their live...</Credits>

--- a/imagesets/sky__visible.xml
+++ b/imagesets/sky__visible.xml
@@ -29776,6 +29776,7 @@
     TileLevels="7"
     Url="http://data1.wwtassets.org/packages/2020/07_hubble30/heic0707a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|heic0707a"
     Xcxstatus="in:6537c3d6b493728d11b82ba2"
   >
     <Credits>NASA, ESA, N. Smith (University of California, Berkeley), and The Hubble Heritage Team (STScI/AURA)</Credits>
@@ -29912,6 +29913,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/packages/2020/07_hubble30/heic0910h/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|heic0910h"
     Xcxstatus="in:6537c3dbb493728d11b82bac"
   >
     <Credits>NASA, ESA and the Hubble SM4 ERO Team</Credits>
@@ -29940,6 +29942,7 @@
     TileLevels="7"
     Url="http://data1.wwtassets.org/packages/2020/07_hubble30/heic1206a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|heic1206a"
     Xcxstatus="in:6537c3dcb493728d11b82bae"
   >
     <Credits>NASA, ESA, ESO, D. Lennon and E. Sabbi (ESA/STScI), J. Anderson, S. E. de Mink, R. van der Marel, T. Sohn, and N. Walborn (STScI), N. Bastian (Excellence Cluster, Munich), L. Bedin (INAF, Padua), E. Bressert (ESO), P. Crowther (Sheffield), A. de Koter (Amsterdam), C. Evans (UKATC/STFC, Edinburgh), A. Herrero (IAC, Tenerife), N. Langer (AifA, Bonn), I. Platais (JHU) and H. Sana (Amsterdam)</Credits>
@@ -30025,6 +30028,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/packages/2020/07_hubble30/heic1307a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|heic1307a"
     Xcxstatus="in:6548efd75dff7c3291e39e0f"
   >
     <Credits>NASA, ESA, and the Hubble Heritage Team (AURA/STScI)</Credits>
@@ -30053,6 +30057,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/packages/2020/07_hubble30/heic1501a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|heic1501a"
     Xcxstatus="in:6548efd85dff7c3291e39e11"
   >
     <Credits>NASA, ESA/Hubble  and the Hubble Heritage Team</Credits>
@@ -30081,6 +30086,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/packages/2020/07_hubble30/heic1501b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|heic1501b"
     Xcxstatus="in:6548efd95dff7c3291e39e13"
   >
     <Credits>NASA, ESA/Hubble and the Hubble Heritage Team</Credits>
@@ -30109,6 +30115,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/packages/2020/07_hubble30/heic1509a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|heic1509a"
     Xcxstatus="in:6548efda5dff7c3291e39e15"
   >
     <Credits>NASA, ESA, the Hubble Heritage Team (STScI/AURA), A. Nota (ESA/STScI), and the Westerlund 2 Science Team The original observations of Westerlund 2 were obtained by the science team: Antonella Nota (ESA/STScI), Elena Sabbi (STScI), Eva Grebel and Peter Zeidler (Astronomisches Rechen-Institut Heidelberg), Monica Tosi (INAF, Osservatorio Astronomico di Bologna), Alceste Bonanos (National Observatory of Athens, Astronomical Institute), Carol Christian (STScI/AURA) and Selma de Mink (University of Amsterdam). Follow-up observations were made by the Hubble Heritage team: Zoltan Levay (STScI), Max Mutchler, Jennifer Mack, Lisa Frattare, Shelly Meyett, Mario Livio, Carol Christian (STScI/AURA), and Keith Noll (NASA/GSFC).</Credits>
@@ -30137,6 +30144,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/packages/2020/07_hubble30/heic1510a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|heic1510a"
     Xcxstatus="in:6548efdb5dff7c3291e39e17"
   >
     <Credits>NASA, ESA, and the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration  Acknowledgment: J. Mack (STScI) and G. Piotto (University of Padova, Italy)</Credits>
@@ -30165,6 +30173,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/packages/2020/07_hubble30/heic1520a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|heic1520a"
     Xcxstatus="in:655407a85dff7c3291e3b295"
   >
     <Credits>NASA, ESA, Hubble Heritage Team</Credits>
@@ -30193,6 +30202,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/packages/2020/07_hubble30/heic1608a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|heic1608a"
     Xcxstatus="in:655407a95dff7c3291e3b297"
   >
     <Credits>NASA, ESA, Hubble Heritage Team</Credits>
@@ -30221,6 +30231,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/packages/2020/07_hubble30/heic1704a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|heic1704a"
     Xcxstatus="in:655407aa5dff7c3291e3b299"
   >
     <Credits>NASA, ESA, and R. Kirshner (Harvard-Smithsonian Center for Astrophysics and Gordon and Betty Moore Foundation) and P. Challis (Harvard-Smithsonian Center for Astrophysics)</Credits>
@@ -30249,6 +30260,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/packages/2020/07_hubble30/heic1709a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|heic1709a"
     Xcxstatus="in:655407ab5dff7c3291e3b29b"
   >
     <Credits>NASA, ESA, and M. Mutchler (STScI)</Credits>
@@ -30277,6 +30289,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/packages/2020/07_hubble30/heic1712a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|heic1712a"
     Xcxstatus="in:655407ac5dff7c3291e3b29d"
   >
     <Credits>ESA/Hubble, NASA</Credits>
@@ -30305,6 +30318,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/packages/2020/07_hubble30/heic1818a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|heic1818a"
     Xcxstatus="in:654106a6a5946236dee82e11"
   >
     <Credits>ESA/Hubble, NASA</Credits>
@@ -30333,6 +30347,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/packages/2020/07_hubble30/heic1820b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|heic1820b"
     Xcxstatus="in:655407ad5dff7c3291e3b29f"
   >
     <Credits>NASA, ESA, and M. Montes (University of New South Wales, Sydney, Australia)</Credits>
@@ -30361,6 +30376,7 @@
     TileLevels="7"
     Url="http://data1.wwtassets.org/packages/2020/07_hubble30/heic1909a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|heic1909a"
     Xcxstatus="in:655407ad5dff7c3291e3b2a1"
   >
     <Credits>NASA, ESA, G. Illingworth and D. Magee (University of California, Santa Cruz), K. Whitaker (University of Connecticut), R. Bouwens (Leiden University), P. Oesch (University of Geneva), and the Hubble Legacy Field team.</Credits>
@@ -30389,6 +30405,7 @@
     TileLevels="0"
     Url="http://data1.wwtassets.org/packages/2020/07_hubble30/heic1919a/image.jpg"
     WidthFactor="2"
+    Xastropix_ids="esahubble|heic1919a"
     Xcxstatus="in:655407ae5dff7c3291e3b2a3"
   >
     <Credits>NASA, ESA, J. Dalcanton, B.F. Williams, and M. Durbin (University of Washington)</Credits>
@@ -30417,6 +30434,7 @@
     TileLevels="7"
     Url="http://data1.wwtassets.org/packages/2020/07_hubble30/heic2007a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|heic2007a"
     Xcxstatus="in:655407af5dff7c3291e3b2a5"
   >
     <Credits>NASA, ESA, and STScI</Credits>
@@ -30446,6 +30464,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/packages/2020/07_hubble30/heic2011b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|heic2011b"
     Xcxstatus="in:655407b05dff7c3291e3b2a7"
   >
     <Credits>NASA, ESA, and J. Kastner (RIT)</Credits>
@@ -30472,6 +30491,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/packages/2020/07_hubble30/ngc602/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|ngc602"
     Xcxstatus="in:655407b15dff7c3291e3b2a9"
   >
     <Credits>Credit:X-ray: NASA/CXC/Univ.Potsdam/L.Oskinova et al; Optical: ESA, NASA/STScI; Infrared: NASA/JPL-Caltech</Credits>
@@ -30500,6 +30520,7 @@
     TileLevels="0"
     Url="http://data1.wwtassets.org/packages/2020/07_hubble30/opo9402b/image.jpg"
     WidthFactor="2"
+    Xastropix_ids="esahubble|opo9402b"
     Xcxstatus="in:655407b25dff7c3291e3b2ab"
   >
     <Credits>NASA &amp; ESA</Credits>
@@ -30528,6 +30549,7 @@
     TileLevels="0"
     Url="http://data1.wwtassets.org/packages/2020/07_hubble30/potw1203a/image.jpg"
     WidthFactor="2"
+    Xastropix_ids="esahubble|potw1203a"
     Xcxstatus="in:655407b35dff7c3291e3b2ad"
   >
     <Credits>ESA/Hubble &amp; NASA </Credits>
@@ -30582,6 +30604,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/packages/2020/07_hubble30/potw1850a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|potw1850a"
     Xcxstatus="in:655407b55dff7c3291e3b2b1"
   >
     <Credits>NASA, ESA</Credits>
@@ -31067,6 +31090,7 @@
     TileLevels="8"
     Url="http://data1.wwtassets.org/packages/2020/07_phat_m33/{1}/{3}/{3}_{2}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|heic1901a"
     Xcxstatus="in:649ba2b71e6961df10c19448"
   >
     <Credits>NASA, ESA, and M. Durbin, J. Dalcanton, and B. F. Williams (University of Washington)</Credits>
@@ -32489,6 +32513,7 @@ The smaller spiral galaxy to the upper left of Cartwheel displays much of the sa
     TileLevels="5"
     Url="http://data1.wwtassets.org/packages/2022/12_jwst/hudf/{1}/{3}/{3}_{2}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|heic0611b"
     Xcxstatus="in:6564c45cf864172823763c19"
   >
     <Credits>NASA, ESA, and S. Beckwith (STScI) and the HUDF Team</Credits>
@@ -32544,6 +32569,7 @@ SCIENCE: Brant Robertson (UC Santa Cruz), S. Tacchella (Cambridge), E. Curtis-La
     TileLevels="5"
     Url="http://data1.wwtassets.org/packages/2022/12_jwst/pillarsofcreation_composite/{1}/{3}/{3}_{2}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|pillarsofcreation_composite"
     Xcxstatus="in:642761e1975014bc743f1594"
   >
     <Credits>NASA, ESA, CSA, STScI, J. DePasquale (STScI), A. Pagan (STScI), A. M. Koekemoer (STScI)</Credits>
@@ -33650,6 +33676,7 @@ These belts are most likely shaped by the gravitational forces produced by unsee
     TileLevels="6"
     Url="http://data1.wwtassets.org/packages/2023/07_jwst/weic2316a/{1}/{3}/{3}_{2}.png"
     WidthFactor="2"
+    Xastropix_ids="esahubble|weic2316a"
     Xcxstatus="in:64ae8c1ba15b29de42b30448"
   >
     <Credits>NASA, ESA, CSA, STScI, K. Pontoppidan (STScI), A. Pagan (STScI)</Credits>
@@ -63441,6 +63468,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann0820L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|ann0820"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA; Science operations with the NASA/ESA Hubble Space Telescope resumed over the weekend, four weeks after a problem with the scienc...</Credits>
@@ -63467,6 +63495,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann0901aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|ann0901a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; The unique planetary nebula NGC 2818 is nested inside the open star cluster NGC 2818A. Both the cluster and the nebula reside ov...</Credits>
@@ -63493,6 +63522,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann0904aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|ann0904a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA; In celebration of the International Year of Astronomy 2009, the NASA/ESA Hubble Space Telescope photographed the winning target ...</Credits>
@@ -63519,6 +63549,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann0906aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|ann0906a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA; The Hubble community bids farewell to the soon-to-be decommissioned Wide Field Planetary Camera 2 (WFPC2) onboard the Hubble Spa...</Credits>
@@ -63545,6 +63576,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann0909aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|ann0909a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA; After more than three months of calibration and testing, the NASA/ESA Hubble Space Telescope is reopening its rejuvenated eyes t...</Credits>
@@ -63571,6 +63603,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann0910aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|ann0910a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA; A bright and bizarre galaxy called NGC 2623 is the focus of this Hubblecast.  The single galaxy is the product of the merger of ...</Credits>
@@ -63597,6 +63630,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann0912aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|ann0912a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA; A never-before-seen view of the turbulent heart of our Milky Way galaxy provided by the NASA/ESA Hubble Space Telescope and its ...</Credits>
@@ -63623,6 +63657,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann1006aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|ann1006a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and Jesús Maíz Apell; This image is a screen shot from Hubblecast 37 featuring a spectacular new NASA/ESA Hubble Space Telescope image — one of the la...</Credits>
@@ -63649,6 +63684,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann1105aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|ann1105a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, R. Gobat (Laboratoire; This image from the Near Infrared Camera and Multi-Object Spectrometer (NICMOS) onboard the NASA/ESA Hubble Space Telescope show...</Credits>
@@ -63675,6 +63711,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann1108aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|ann1108a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and A. Fruchter (STScI; The NASA/ESA Hubble Space Telescope has pinpointed the source of one of the most puzzling blast of high-energy radiation ever ob...</Credits>
@@ -63701,6 +63738,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann1110aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|ann1110a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; The Hubble Space Telescope has imaged the star field around the Cepheid variable V1 in M31. This image shows individually resolv...</Credits>
@@ -63727,6 +63765,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann1111aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|ann1111a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and Pete Challis (Harv; This  Hubble image of Supernova 1987A shows the brightening ring of supernova  debris. The closest supernova seen in almost 400 ...</Credits>
@@ -63753,6 +63792,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann1121aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|ann1121a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, J. Kriss (STScI) and ; This  image from the NASA/ESA Hubble Space Telescope shows the galaxy  Markarian 509. The bright object at the centre of the gal...</Credits>
@@ -63779,6 +63819,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann1409aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|ann1409a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA; Screenshot of Hubblecast 76: Merging galaxies and droplets of starbirth....</Credits>
@@ -63805,6 +63846,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-ann1802aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|ann1802a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble; This is a still from Hubblecast 107, which explains the meaning of the colours in the spiral galaxy NGC 3344....</Credits>
@@ -63831,6 +63873,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-eso1631aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|eso1631a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESO/CARS survey; The mystery of a rare change in the behaviour of the supermassive black hole at the centre of the distant galaxy Markarian 1018 ...</Credits>
@@ -63857,6 +63900,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0309dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0309d"
     Xcxstatus="queue:hubble"
   >
     <Credits>European Space Agency, NASA, Jea; This is a 2.5-degree field around galaxy cluster CL0024+1654. The cluster galaxies are visible in the centre of the image in yel...</Credits>
@@ -63883,6 +63927,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0407bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0407b"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/NASA &amp; Romano Corradi (ING); The Bug Nebula, NGC 6302, here imaged with the 3.6 metre telescope at ESO's La Silla Observatory by astronomer Romano L.M. Corra...</Credits>
@@ -63909,6 +63954,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0414dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0414d"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA and Digitized Sky Survey 2; The image of the area around the Cat's Eye Nebula was composed from three Digitized Sky Survey 2 images taken through blue, red ...</Credits>
@@ -63935,6 +63981,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0506cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0506c"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and Digitized Sky S; The Whirlpool Galaxy (M51a) with it's sparkling arms is the first galaxy found to have a spiral structure....</Credits>
@@ -63961,6 +64008,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0510aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0510a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Davide De Martin (ESA/Hubble), t; This image is a composite from black and white images taken with the Palomar Observatory's 48-inch (1.2 meter) Samuel Oschin Tel...</Credits>
@@ -63987,6 +64035,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0512dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0512d"
     Xcxstatus="queue:hubble"
   >
     <Credits>÷ 2002 R. Gendler, Photo by R. ; Image of M31 taken with a 12.5-inch Ritchey-Chrétien telescope by amateur astronomer Robert Gendler....</Credits>
@@ -64013,6 +64062,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0513bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0513b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, B. Mobasher ( Space T; This image demonstrates how data from two space observatories, the Spitzer and Hubble Space Telescopes, are used to identify one...</Credits>
@@ -64039,6 +64089,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0513cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0513c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, B. Mobasher ( Space T; This image demonstrates how data from two space observatories, the Spitzer and Hubble Space Telescopes, are used to identify one...</Credits>
@@ -64065,6 +64116,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0513dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0513d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, B. Mobasher ( Space T; This image demonstrates how data from two space observatories, the Spitzer and Hubble Space Telescopes, are used to identify one...</Credits>
@@ -64091,6 +64143,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0513eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0513e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, B. Mobasher ( Space T; This image demonstrates how data from two space observatories, the Spitzer and Hubble Space Telescopes, are used to identify one...</Credits>
@@ -64117,6 +64170,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0514aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0514a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and A. Nota (ESA/STScI; This Hubble Space Telescope view shows one of the most dynamic and intricately detailed star-forming regions in space, located 2...</Credits>
@@ -64143,6 +64197,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0514bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0514b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and A. Nota (ESA/STScI; Contained within the most massive and active star-forming region in the nearby galaxy, the Small Magellanic Cloud, star cluster ...</Credits>
@@ -64169,6 +64224,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0514cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0514c"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and Digitized Sky Sur; The two-colour image shows an overview of the full Small Magellanic Cloud (SMC) and was composed from two images from the Digiti...</Credits>
@@ -64195,6 +64251,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0515aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0515a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and Allison Loll/Jeff ; This new Hubble image - One among the largest ever produced with the Earth-orbiting observatory - shows gives the most detailed ...</Credits>
@@ -64221,6 +64278,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0515dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0515d"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and Digitized Sky Sur; This two-colour image shows 2.7 x 2.7 degrees of the surroundings around the Crab Nebula. It was composed from Digitized Sky Sur...</Credits>
@@ -64247,6 +64305,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0516eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0516e"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and Digitized Sky Sur; The image shows an overview of Sirius B's surroundings and was composed from images from the Digitized Sky Survey 2. The field o...</Credits>
@@ -64273,6 +64332,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0516fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0516f"
     Xcxstatus="queue:hubble"
   >
     <Credits>Akira Fujii; This ground-based image was taken by Japanese amateur astronomer Akira Fujii and shows a close-up of Sirius....</Credits>
@@ -64299,6 +64359,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0601cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0601c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, M. Robberto ( Space T; A massive star is illuminating this small region, called M43, and sculpting the landscape of dust and gas. Astronomers call the ...</Credits>
@@ -64325,6 +64386,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0601dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0601d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, M. Robberto ( Space T; Packed into the centre of this region are bright lights of the Trapezium stars, the four heftiest stars in the Orion Nebula. Ult...</Credits>
@@ -64351,6 +64413,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0601eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0601e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, M. Robberto ( Space T; This dark red column shows an illuminated edge of the cavity wall....</Credits>
@@ -64377,6 +64440,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0601fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0601f"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, M. Robberto ( Space T; The faint red stars in this close-up image are the myriad brown dwarfs that Hubble spied for the first time in the Orion Nebula ...</Credits>
@@ -64403,6 +64467,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0601gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0601g"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, M. Robberto ( Space T; This glowing region reveals arcs and bubbles formed when stellar winds - streams of charged particles ejected by the Trapezium s...</Credits>
@@ -64429,6 +64494,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0601hL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0601h"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, M. Robberto ( Space T; These dense, dark pillars of dust and gas are resisting erosion from intense ultraviolet light released by the Orion Nebula's bi...</Credits>
@@ -64455,6 +64521,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0602aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0602a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image: European Space Agency &amp; N; This new Hubble image reveals the gigantic Pinwheel galaxy, one of the best known examples of "grand design spirals", and its su...</Credits>
@@ -64481,6 +64548,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0602cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0602c"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image: European Space Agency &amp; N; Background galaxies far behind the Pinwheel Galaxy. The galaxies are clearly "reddened" by the dust in the Pinwheel....</Credits>
@@ -64507,6 +64575,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0602dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0602d"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image: European Space Agency &amp; N; Dust lanes in the Pinwheel galaxy. The dust particles scatter blue light the most and therefore colour the light from background...</Credits>
@@ -64533,6 +64602,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0602eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0602e"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image: European Space Agency &amp; N; A selection of some of the millions of individual stars visible in Messier 101 with Hubble's sharp vision. In total it is estima...</Credits>
@@ -64559,6 +64629,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0602fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0602f"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image: European Space Agency &amp; N; An example of some of the 3000 bright clusters of sizzling newborn blue stars in the Pinwheel galaxy....</Credits>
@@ -64585,6 +64656,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0602gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0602g"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image: European Space Agency &amp; N; Another "grand design" spiral lies behind the Pinwheel Galaxy itself and is visible through its disk. Hubble's incredible resolu...</Credits>
@@ -64611,6 +64683,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0602hL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0602h"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image: European Space Agency &amp; N; Two distant galaxies behind Messier 101 and a collection of individual foreground stars from one of its spiral arms....</Credits>
@@ -64637,6 +64710,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0602iL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0602i"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and Digitized Sky Sur; This two-colour image shows 3.7 x 2.7 degrees of the surroundings around the Pinwheel Galaxy. It was composed from Digitized Sky...</Credits>
@@ -64663,6 +64737,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0603bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0603b"
     Xcxstatus="queue:hubble"
   >
     <Credits>European Space Agency &amp; NASA Ack; Hubble has captured the most detailed image to date of the open star cluster NGC 265 in the Small Magellanic Cloud. The image ta...</Credits>
@@ -64689,6 +64764,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0603cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0603c"
     Xcxstatus="queue:hubble"
   >
     <Credits>European Space Agency &amp; NASA Ack; Hubble has captured the most detailed image to date of the open star cluster NGC 290 in the Small Magellanic Cloud. The image ta...</Credits>
@@ -64715,6 +64791,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0603dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0603d"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and Digitized Sky Sur; The two-colour image shows an overview of the full Small Magellanic Cloud (SMC) and was composed from two images from the Digiti...</Credits>
@@ -64741,6 +64818,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0604aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0604a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; This mosaic image of the magnificent starburst galaxy, Messier 82 (M82) is the sharpest wide-angle view ever obtained of M82. It...</Credits>
@@ -64767,6 +64845,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0604dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0604d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, CXC, and JPL-Caltech; Composite of images of the active galaxy Messier 82 from the three Great Observatories: Hubble Space Telescope, Chandra X-Ray Ob...</Credits>
@@ -64793,6 +64872,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0604eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0604e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA/CXC/JHU/D.Strickland; Composite image of the active galaxy Messier 82 from x-ray observations by Chandra X-Ray Observatory in three energy bands coded...</Credits>
@@ -64819,6 +64899,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0604fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0604f"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA/JPL-Caltech/C. Engelbracht ; Composite image of the active galaxy Messier 82 from infrared observations by Spitzer Space Telescope in three wavelength bands ...</Credits>
@@ -64845,6 +64926,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0604hL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0604h"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and Digitized Sky Sur; The spiral galaxy M81 and the neighbour galaxy M82 are forming a physical pair. A few tens of million years ago, the smaller M82...</Credits>
@@ -64871,6 +64953,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0606aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0606a"
     Xcxstatus="queue:hubble"
   >
     <Credits>European Space Agency, NASA, Ker; This NASA/ESA Hubble Space Telescope image is the first-ever picture of a distant quasar lensed into five images. The group of f...</Credits>
@@ -64897,6 +64980,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0606bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0606b"
     Xcxstatus="queue:hubble"
   >
     <Credits>European Space Agency, NASA, Ker; This full-size Hubble image shows galaxy cluster SDSS J1004+4112 that was discovered as part of the  Sloan Digital Sky Survey. I...</Credits>
@@ -64923,6 +65007,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0606cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0606c"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and Digitized Sky Sur; This two-colour image shows an overview of region of sky where galaxy cluster SDSS J1004+4112 is located. It is composed from tw...</Credits>
@@ -64949,6 +65034,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0607aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0607a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA; The latest photo from the Hubble Space Telescope, presented at the 2006 General Assembly of the International Astronomical Union...</Credits>
@@ -64975,6 +65061,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0607bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0607b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA; The latest photo from the Hubble Space Telescope, presented at the 2006 General Assembly of the International Astronomical Union...</Credits>
@@ -65001,6 +65088,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0607dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0607d"
     Xcxstatus="queue:hubble"
   >
     <Credits>Davide De Martin (ESA/Hubble), t; Part of the LMC centered on LH 95. This image is a colour composite taken by the Digitized Sky Survey (DSS), the field of view i...</Credits>
@@ -65027,6 +65115,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0609aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0609a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; A new image taken with the NASA/ESA Hubble Space Telescope provides a detailed look at the tattered remains of a supernova explo...</Credits>
@@ -65053,6 +65142,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0609bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0609b"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and Digitized Sky Sur; The two-colour image shows an overview of area of Cas A and was composed from two images from the Digitized Sky Survey 2. The fi...</Credits>
@@ -65079,6 +65169,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0612dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0612d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, K. Sahu (STScI) and t; This is an image of one-half of the Hubble Space Telescope field of view in the Sagittarius Window Eclipsing Extrasolar Planet S...</Credits>
@@ -65105,6 +65196,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0612eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0612e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, K. Sahu (STScI) and t; This is an excerpt of the Hubble Space Telescope field of view in the Sagittarius Window Eclipsing Extrasolar Planet Search (SWE...</Credits>
@@ -65131,6 +65223,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0614aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0614a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image credit: NASA, ESA, G. Mile; This image is a composite of many separate exposures made by the ACS instrument on the Hubble Space Telescope using several diff...</Credits>
@@ -65157,6 +65250,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0614bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0614b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image credit: NASA, ESA, G. Mile; This image shows the full ACS overview of the region around the Spiderweb Galaxy (just to the right of the center). The  galaxy ...</Credits>
@@ -65183,6 +65277,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0614cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0614c"
     Xcxstatus="queue:hubble"
   >
     <Credits>Digitized Sky Survey 2 and ESA/H; This image is a colour composite made from exposures from the Digitized Sky Survey 2 (DSS2). The field of view is 2.8 x 2.9 degr...</Credits>
@@ -65209,6 +65304,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0615aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0615a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and the Hubbl; This Hubble image of the Antennae galaxies is the sharpest yet of this merging pair of galaxies. As the two galaxies smash toget...</Credits>
@@ -65235,6 +65331,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0615cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0615c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NOAO/AURA/NSF, B. Twardy, B. Twa; This photo of the Antennae galaxies was taken with one of the NOAO telescopes from the ground....</Credits>
@@ -65261,6 +65358,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0615dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0615d"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and Digitized Sky Sur; This image is a colour composite made from exposures from the Digitized Sky Survey 2 (DSS2). The field of view is 2.8 x 2.8 degr...</Credits>
@@ -65287,6 +65385,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0616bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0616b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and G. Meylan (École; A seven year study with the NASA/ESA Hubble Space Telescope has provided astronomers with the best observational evidence yet th...</Credits>
@@ -65313,6 +65412,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0616cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0616c"
     Xcxstatus="queue:hubble"
   >
     <Credits>Very Large Telescope/European So; A photo of the globular star cluster 47 Tucanae taken with the Very Large Telescope, in Chile. It is one of the densest globular...</Credits>
@@ -65339,6 +65439,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0616dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0616d"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble (Davide De Martin), t; This image of 47 Tucanae is a colour composite taken by the Digitized Sky Survey (DSS), the field of view is 2.4x2.8 degrees....</Credits>
@@ -65365,6 +65466,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0617bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0617b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and H. Bond (STScI ); The light echo around the star V838 Monocerotis as seen by the Hubble Space Telescope in November 2005....</Credits>
@@ -65391,6 +65493,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0617cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0617c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and H. Bond (STScI ); The light echo around the star V838 Monocerotis as seen by the Hubble Space Telescope in September 2006....</Credits>
@@ -65417,6 +65520,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0619aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0619a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and Jesús Maíz Apell; The star cluster Pismis 24 lies in the core of the large emission nebula NGC 6357 that extends one degree on the sky in the dire...</Credits>
@@ -65443,6 +65547,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0619cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0619c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and Jesœs Ma­z Apell; Looking closer at Pismis 24-1 with Hubble's ACS High Resolution Channel: it becomes clear that it is in reality two stars....</Credits>
@@ -65469,6 +65574,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0619dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0619d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and Jesœs Ma­z Apell; ACS HRC image close-up showing the two stars of Pismis 24-1. It  was thought to have an incredibly large mass of 200 to 300 sola...</Credits>
@@ -65495,6 +65601,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0619eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0619e"
     Xcxstatus="queue:hubble"
   >
     <Credits>Davide De Martin (ESA/Hubble), t; Part of the constellation Scorpius centred on NGC 6357 which has star cluster Pismis 24 in its centre.  This image is a colour c...</Credits>
@@ -65521,6 +65628,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0701gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0701g"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and A. Koekemoer (STSc; This image shows the full COSMOS field at one tenth resolution. COSMOS - the Cosmic Evolution Survey - is the Hubble Space Teles...</Credits>
@@ -65547,6 +65655,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0701hL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0701h"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and A. Koekemoer (STSc; This image shows an excerpt of the COSMOS survey in full resolution. COSMOS - the Cosmic Evolution Survey - is the Hubble Space ...</Credits>
@@ -65573,6 +65682,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0701iL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0701i"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and A. Koekemoer (STSc; This image shows an excerpt of the COSMOS survey in full resolution. COSMOS - the Cosmic Evolution Survey - is the Hubble Space ...</Credits>
@@ -65599,6 +65709,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0701jL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0701j"
     Xcxstatus="queue:hubble"
   >
     <Credits>Davide De Martin (ESA/Hubble), t; This image shows the COSMOS field and is a colour composite made from Digitized Sky Survey 2 (DSS2) exposure. The field of view ...</Credits>
@@ -65625,6 +65736,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0701kL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0701k"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and R. Massey (Califor; This composite shows three different components of the COSMOS survey: The normal matter (in red) determined mainly by the Europe...</Credits>
@@ -65651,6 +65763,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0702aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0702a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; This image depicts bright blue newly formed stars that are blowing a cavity in the centre of a fascinating star-forming region k...</Credits>
@@ -65677,6 +65790,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0702bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0702b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Davide De Martin (ESA/Hubble), t; This image shows the area around N90 and is a colour composite made from Digitized Sky Survey 2 (DSS2) exposure. The field of vi...</Credits>
@@ -65703,6 +65817,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0703aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0703a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and K. Noll (STScI); This image of NGC 2440 shows the colourful "last hurrah" of a star like our Sun. The star is ending its life by casting off its ...</Credits>
@@ -65729,6 +65844,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0704aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0704a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and R. Kirshner (Harv; Two decades ago, astronomers spotted one of the brightest exploding stars in more than 400 years. Since that first sighting, the...</Credits>
@@ -65755,6 +65871,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0704cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0704c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and R. Kirshner (Harv; This photo album of images from NASA/ESA Hubble Space Telescope shows a ring of gas beginning to glow around an exploded star. T...</Credits>
@@ -65781,6 +65898,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0705aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0705a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Jean-Paul Kneib (Labo; While looking at the galaxy cluster Abell 2667, astronomers found an odd-looking spiral galaxy (shown here in the upper left han...</Credits>
@@ -65807,6 +65925,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0705bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0705b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, Spitzer Space Telescope; This infrared image was taken by NASA's Spitzer Space Telescope.and shows a part of the galaxy cluster Abell 2667. The "Comet Ga...</Credits>
@@ -65833,6 +65952,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0705cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0705c"
     Xcxstatus="queue:hubble"
   >
     <Credits>Davide De Martin (ESA/Hubble), t; Part of the constellation Sculptor centred on galaxy cluster. This image is a colour composite taken by the Digitized Sky Survey...</Credits>
@@ -65859,6 +65979,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0706aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0706a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA; The barred spiral galaxy NGC 1672, showing up clusters of hot young blue stars along its spiral arms, and clouds of hydrogen gas...</Credits>
@@ -65885,6 +66006,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0706bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0706b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Davide De Martin (ESA/Hubble), t; A 2.7 x 2.9 degree wide field ground-based image of NGC 1672's region in the Southern constellation of Dorado. This image is a c...</Credits>
@@ -65911,6 +66033,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0707gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0707g"
     Xcxstatus="queue:hubble"
   >
     <Credits>N. Smith and NOAO/AURA/NSF; This image shows a ground-based view of the giant star-forming region in the southern sky known as the Carina Nebula, combining ...</Credits>
@@ -65937,6 +66060,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0708aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0708a"
     Xcxstatus="queue:hubble"
   >
     <Credits>European Space Agency, NASA, G. ; This NASA/ESA Hubble Space Telescope image of a dense swarm of stars shows the central region of the globular cluster NGC 2808. ...</Credits>
@@ -65963,6 +66087,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0708cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0708c"
     Xcxstatus="queue:hubble"
   >
     <Credits>Davide De Martin (ESA/Hubble), t; The globular cluster NGC 2808 as seen in the Digitized Sky Survey 2 (DSS2). The image is a colour composite from DSS2 images, th...</Credits>
@@ -65989,6 +66114,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0709bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0709b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, M.J. Jee and H. Ford ; An international team of astronomers using the NASA/ESA Hubble Space Telescope has discovered a ghostly ring of dark matter that...</Credits>
@@ -66015,6 +66141,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0709dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0709d"
     Xcxstatus="queue:hubble"
   >
     <Credits>Davide De Martin (ESA/Hubble), t; ZwCl0024+1652 as seen in the Digitized Sky Survey 2 (DSS2). The image is a colour composite from DSS2 images. The field of view ...</Credits>
@@ -66041,6 +66168,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0710bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0710b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and A. Zezas (Harvard-; This image combines data from the Hubble Space Telescope, the Spitzer Space Telescope and the Galaxy Evolution Explorer (GALEX) ...</Credits>
@@ -66067,6 +66195,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0710dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0710d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; Inner bulge and nucleus of M81....</Credits>
@@ -66093,6 +66222,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0710eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0710e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; Southern arm of M81 including a chain of HII regions....</Credits>
@@ -66119,6 +66249,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0710fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0710f"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; OB Associations in outer northern arm of M81....</Credits>
@@ -66145,6 +66276,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0710gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0710g"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; Bulge-disk transition in M81 and chain of HII regions....</Credits>
@@ -66171,6 +66303,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0710hL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0710h"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; HII shell of M81 and background galaxies....</Credits>
@@ -66197,6 +66330,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0710iL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0710i"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; Southern extremity of the galaxy M81....</Credits>
@@ -66223,6 +66357,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0710jL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0710j"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; Background group of galaxies....</Credits>
@@ -66249,6 +66384,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0711aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0711a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, A. Aloisi (STScI/ESA); Hundreds of thousands of vibrant blue and red stars are visible in this new image of galaxy NGC 4449 taken by the NASA/ESA Hubbl...</Credits>
@@ -66275,6 +66411,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0712aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0712a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; This image shows a small portion of the Veil Nebula - the shattered remains of a supernova that exploded some 5-10,000 years ago...</Credits>
@@ -66301,6 +66438,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0712bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0712b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; This image is a stunning close-up of the Veil Nebula - the shattered remains of a supernova that exploded some 5-10,000 years ag...</Credits>
@@ -66327,6 +66465,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0712cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0712c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; This image shows a beautiful portion of the Veil Nebula - the shattered remains of a supernova that exploded some 5-10,000 years...</Credits>
@@ -66353,6 +66492,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0712gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0712g"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage (; A wide-field image of the Veil Nebula, made as a colour composite from individual exposures from the Digitized Sky Survey 2. The...</Credits>
@@ -66379,6 +66519,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0714bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0714b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and N. Pirzkal (Europ; Building block galaxy at redshift of 4.00 from Hubble Ultra Deep Field image....</Credits>
@@ -66405,6 +66546,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0714cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0714c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and N. Pirzkal (Europ; Building block galaxy at redshift of 4.88 from Hubble Ultra Deep Field image....</Credits>
@@ -66431,6 +66573,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0714dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0714d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and N. Pirzkal (Europ; Building block galaxy at redshift of 4.90 from Hubble Ultra Deep Field image....</Credits>
@@ -66457,6 +66600,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0714eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0714e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and N. Pirzkal (Europ; Building block galaxy at redshift of 5.42 from Hubble Ultra Deep Field image....</Credits>
@@ -66483,6 +66627,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0714fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0714f"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and N. Pirzkal (Europ; Building block galaxy at redshift of 5.76 from Hubble Ultra Deep Field image....</Credits>
@@ -66509,6 +66654,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0714gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0714g"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and N. Pirzkal (Europ; The Hubble Ultra Deep Field Image....</Credits>
@@ -66535,6 +66681,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0715cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0715c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Digitized Sky; A wide-field image in the region of NGC 3603 taken on the ground by the Digitized Sky Survey 2. The glowing clouds of hydrogen g...</Credits>
@@ -66561,6 +66708,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0716aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0716a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and A. Aloisi (Europe; The NASA/ESA Hubble Space Telescope quashed the possibility that what was previously believed to be a toddler galaxy in the near...</Credits>
@@ -66587,6 +66735,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0716cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0716c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Digitized Sky; A wide field image of the sky around the galaxy I Zwicky 18 taken on the ground by the Digitized Sky Survey 2. The field of view...</Credits>
@@ -66613,6 +66762,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0717aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0717a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and The Hubble Herita; Arp 87 is a stunning pair of interacting galaxies. Stars, gas, and dust flow from the large spiral galaxy, NGC 3808, forming an ...</Credits>
@@ -66639,6 +66789,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0717bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0717b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Digitized Sky; An image of the region of sky around Arp 87. The interacting galaxies can just be seen towards the centre of the frame. The fiel...</Credits>
@@ -66665,6 +66816,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0719aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0719a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and The Hubble Herita; In the new Hubble image of the galaxy M74 we can also see a smattering of bright pink regions decorating the spiral arms. These ...</Credits>
@@ -66691,6 +66843,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0719bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0719b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Digitized Sky; An image of the region of sky around M74, the "Phantom Galaxy", from the Digitized Sky Survey 2. The field-of-view is approximat...</Credits>
@@ -66717,6 +66870,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0720dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0720d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Digitized Sky; A wide star field image of the region around HD 189733b. In the centre is the star HD 189733 and just to the right is the planet...</Credits>
@@ -66743,6 +66897,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0801bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0801b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and D. de Mello (Cath; A GALEX ultraviolet image of the interacting galaxies M81 and M82, which lie 12 million light-years away in the constellation Ur...</Credits>
@@ -66769,6 +66924,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0801cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0801c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and D. de Mello (Cath; A Hubble Space Telescope visible light image of bright blue star clusters found along a wispy bridge of gas that was tidally str...</Credits>
@@ -66795,6 +66951,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0801dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0801d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and D. de Mello (Cath; A Hubble Space Telescope visible light close-up of bright blue star clusters in Arp's Loop in the M81-M82 galaxy group....</Credits>
@@ -66821,6 +66978,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0801eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0801e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and D. de Mello (Cath; A Hubble Space Telescope visible light close-up of bright blue star clusters in Arp's Loop in the M81-M82 galaxy group....</Credits>
@@ -66847,6 +67005,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0801fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0801f"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and D. de Mello (Cath; A Hubble Space Telescope visible light close-up of bright blue star clusters in Arp's Loop in the M81-M82 galaxy group....</Credits>
@@ -66873,6 +67032,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0801gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0801g"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; This loose collection of stars is actually a dwarf irregular galaxy, called Holmberg IX. It resides just off the outer edge of M...</Credits>
@@ -66899,6 +67059,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0802bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0802b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit for the Hubble images: NA; This image reveals the distribution of dark matter in the supercluster Abell 901/902, composed of hundreds of galaxies./p&gt; The i...</Credits>
@@ -66925,6 +67086,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0802cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0802c"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit for the Hubble images: NA; A Hubble study pinpointed four main areas in the supercluster where dark matter has pooled into dense clumps. These areas match ...</Credits>
@@ -66951,6 +67113,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0802dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0802d"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit for the Hubble images: NA; A Hubble study pinpointed four main areas in the supercluster where dark matter has pooled into dense clumps. These areas match ...</Credits>
@@ -66977,6 +67140,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0802eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0802e"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit for the Hubble images: NA; A Hubble study pinpointed four main areas in the supercluster where dark matter has pooled into dense clumps. These areas match ...</Credits>
@@ -67003,6 +67167,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0802fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0802f"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit for the Hubble images: NA; A Hubble study pinpointed four main areas in the supercluster where dark matter has pooled into dense clumps. These areas match ...</Credits>
@@ -67029,6 +67194,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0803bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0803b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and R. Gavazzi and T.; This is an image of gravitational lens system SDSSJ0946+1006 as photographed by Hubble Space Telescope's Advanced Camera for Sur...</Credits>
@@ -67055,6 +67221,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0803cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0803c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and R. Gavazzi and T.; This is a close-up of a gravitational lens showing two concentric partial ring-like structures after subtracting the glare of th...</Credits>
@@ -67081,6 +67248,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0804aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0804a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; The NASA/ESA Hubble Space Telescope has captured a new image of the galaxy NGC 1132 which is, most likely, a cosmic fossil - the...</Credits>
@@ -67107,6 +67275,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0804bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0804b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, M. West (ESO, Chile),; This image of the elliptical galaxy NGC 1132 combines an image from NASA's Chandra X-Ray Observatory obtained in 2004 with image...</Credits>
@@ -67133,6 +67302,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0804dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0804d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and Digitized Sky Sur; This is a wide-field view of the region around NGC 1132, in the constellation of Eridanus, the River. The field-of-view is appro...</Credits>
@@ -67159,6 +67329,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0805eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0805e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA; ESA; L. Bradley (Johns Hop; The gravity of the cluster's trillion stars acts as a cosmic "zoom lens", bending and magnifying the light of the galaxies locat...</Credits>
@@ -67185,6 +67356,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0805fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0805f"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA; ESA; L. Bradley (Johns Hop; The distant galaxy, dubbed A1689-zD1, appears as a greyish-white smudge in the close-up view taken with Hubble's NICMOS. The gal...</Credits>
@@ -67211,6 +67383,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0805gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0805g"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA; ESA; L. Bradley (Johns Hop; The distant galaxy, dubbed A1689-zD1, appears as a whitish blob in the Spitzer IRAC close-up view. The galaxy is brimming with s...</Credits>
@@ -67237,6 +67410,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0806dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0806d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, C. Faure (Zentrum fü; An Einstein ring can be seen in this image from the COSMOS project. An Einstein ring is a complete circle image of a background ...</Credits>
@@ -67263,6 +67437,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0806eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0806e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, C. Faure (Zentrum fü; This lens is an example of the rich diversity of 67 strong gravitational lenses found in the COSMOS survey. The lenses were disc...</Credits>
@@ -67289,6 +67464,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0806fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0806f"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, C. Faure (Zentrum fü; An Einstein ring can be seen in this image of the gravitational lens 5921+0638 from the COSMOS survey. An Einstein ring is a com...</Credits>
@@ -67315,6 +67491,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0806gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0806g"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, C. Faure (Zentrum fü; This is a triple gravitational lens, an example of the rich diversity of the 67 strong gravitational lenses found in the COSMOS ...</Credits>
@@ -67341,6 +67518,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0806hL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0806h"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, C. Faure (Zentrum fü; This lens is an example of the rich diversity of 67 strong gravitational lenses found in the COSMOS survey. The lenses were disc...</Credits>
@@ -67367,6 +67545,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0806iL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0806i"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, C. Faure (Zentrum fü; This lens is an example of the rich diversity of 67 strong gravitational lenses found in the COSMOS survey. It shows one triple ...</Credits>
@@ -67393,6 +67572,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0807bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0807b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Digitized Sky; A wide star field image of the region around HD 189733b. The star HD 189733 is located in the centre, just to the left of the pl...</Credits>
@@ -67419,6 +67599,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0808aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0808a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA &amp; Stephen Smartt (Quee; NGC 2397, pictured in this image from Hubble, is a classic spiral galaxy with long prominent dust lanes along the edges of its a...</Credits>
@@ -67445,6 +67626,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0809aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0809a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; A new discovery has resolved some of the mystery surrounding Omega Centauri, the largest and brightest globular cluster in the s...</Credits>
@@ -67471,6 +67653,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="7"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0809bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0809b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Digitized Sky; A wide star field image of the region around Omega Centauri (NGC 5139). The field-of-view is approximately 4.6 x 4.1 degrees....</Credits>
@@ -67497,6 +67680,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810afL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0810af"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; Arp 302 consists of a pair of very gas-rich spiral galaxies in their early stages of interaction: VV 340A is seen edge-on to the...</Credits>
@@ -67523,6 +67707,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810agL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0810ag"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; Arp 256 is a stunning system of two spiral galaxies in an early stage of merging. The Hubble image displays two galaxies with st...</Credits>
@@ -67549,6 +67734,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810ahL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0810ah"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; NGC 6670 is a gorgeous pair of overlapping edge-on galaxies. Scientists believe that NGC 6670 has already experienced at least o...</Credits>
@@ -67575,6 +67761,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810ajL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0810aj"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; ESO 593-8 is an impressive pair of interacting galaxies with a feather-like galaxy crossing a companion galaxy. The two componen...</Credits>
@@ -67601,6 +67788,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810akL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0810ak"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; NGC 454 is galaxy pair comprising a large red elliptical galaxy and an irregular gas-rich blue galaxy. The system is in the earl...</Credits>
@@ -67627,6 +67815,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810alL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0810al"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; UGC 8335 is a strongly interacting pair of spiral galaxies resembling two ice skaters. The interaction has united the galaxies v...</Credits>
@@ -67653,6 +67842,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810amL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0810am"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; This Hubble image displays a beautiful pair of interacting spiral galaxies with swirling arms. The smaller of the two, dubbed LE...</Credits>
@@ -67679,6 +67869,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810anL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0810an"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; This galaxy features a single nucleus, a containing a blue central disc with delicate fine structure in the outer parts and tida...</Credits>
@@ -67705,6 +67896,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810aoL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0810ao"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; This Hubble image of ESO 77-14 is a stunning snapshot of a celestial dance performed by a pair of similar-sized galaxies. Two cl...</Credits>
@@ -67731,6 +67923,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810apL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0810ap"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; Arp 272 is a remarkable collision between two spiral galaxies, NGC 6050 and IC 1179, and is part of the Hercules Galaxy Cluster,...</Credits>
@@ -67757,6 +67950,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810aqL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0810aq"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; NGC 520 is the product of a collision between two disc galaxies that started 300 million years ago. It exemplifies the middle st...</Credits>
@@ -67783,6 +67977,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810arL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0810ar"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; NGC 3256 is an impressive example of a peculiar galaxy that is actually the relict of a collision of two separate galaxies that ...</Credits>
@@ -67809,6 +68004,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810asL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0810as"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; This system consists of a pair of galaxies, dubbed IC 694 and NGC 3690, which made a close pass some 700 million years ago. As a...</Credits>
@@ -67835,6 +68031,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810atL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0810at"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; Arp 240 is an astonishing galaxy pair, composed of spiral galaxies of similar mass and size, NGC 5257 and NGC 5258. The galaxies...</Credits>
@@ -67861,6 +68058,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810auL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0810au"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; IC 883 displays a very disturbed, complex central region with two tidal tails of approximately the same length emerging at nearl...</Credits>
@@ -67887,6 +68085,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810avL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0810av"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; Markarian 273 is a galaxy with a bizarre structure that somewhat resembles a toothbrush. The Hubble image shows an intricate cen...</Credits>
@@ -67913,6 +68112,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810awL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0810aw"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; ESO 99-4 is a galaxy with a highly peculiar shape that is probably the remnant of an earlier merger process that has deformed it...</Credits>
@@ -67939,6 +68139,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810axL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0810ax"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; The galaxy system NGC 1614 has a bright optical centre and two clear inner spiral arms that are fairly symmetrical. It also has ...</Credits>
@@ -67965,6 +68166,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810ayL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0810ay"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; NGC 6090 is a beautiful pair of spiral galaxies with an overlapping central region and two long tidal tails formed from material...</Credits>
@@ -67991,6 +68193,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0810azL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0810az"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; This is a beautiful face-on spiral galaxy with two long arms extending from the central bulge and curving back amongst the scatt...</Credits>
@@ -68017,6 +68220,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0812bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0812b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA &amp; Ivo Saviane (Europea; The Hubble ACS image shows a portion of the southern tidal tail of the Antennae galaxies. The main visible component consists of...</Credits>
@@ -68043,6 +68247,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0812cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0812c"
     Xcxstatus="queue:hubble"
   >
     <Credits>Robert Gendler; This ground-based image was taken by Robert Gendler and shows the two merging Antennae Galaxies (NGC 4038 and NGC 4039) and thei...</Credits>
@@ -68069,6 +68274,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0812dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0812d"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and Digitized Sky Sur; This image is a colour composite made from exposures from the Digitized Sky Survey 2 (DSS2). The field of view is 2.8 x 2.8 degr...</Credits>
@@ -68095,6 +68301,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0813aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0813a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; Hubble's Advanced Camera for Surveys has viewed a large portion of the Coma Cluster, stretching across several million light-yea...</Credits>
@@ -68121,6 +68328,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0813bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0813b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; On the right, a spiral galaxy in the Coma Cluster....</Credits>
@@ -68147,6 +68355,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0813cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0813c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; Varied galaxy types in the Coma Cluster....</Credits>
@@ -68173,6 +68382,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0813dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0813d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; Lenticular galaxy in the Coma Cluster with numerous background galaxies....</Credits>
@@ -68199,6 +68409,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0813eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0813e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Digitized Sky; A wide star field image of the region around the Coma Cluster (Abell 1656). The field-of-view is approximately 2.7 x 2.85 degree...</Credits>
@@ -68225,6 +68436,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0814aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0814a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and Johan Richard (Ca; The picture shows Abell 2218, a rich galaxy cluster composed of thousands of individual galaxies. It sits about 2.1 billion ligh...</Credits>
@@ -68251,6 +68463,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0814bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0814b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and Johan Richard (Ca; Located in the northern celestial hemisphere, Abell 1703 is composed of over one hundred different galaxies that act as a powerf...</Credits>
@@ -68277,6 +68490,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0814cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0814c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and Johan Richard (Ca; ZwCl 1358+62 is located 3.7 billion light-years from Earth (z=0.33) and is made up of at least 150 individual galaxies. This ima...</Credits>
@@ -68303,6 +68517,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0814dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0814d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and Johan Richard (Ca; Located 2.7 billion light-years from the Earth (redshift 0.23), Abell 2390 is located in the constellation Pegasus. The large ar...</Credits>
@@ -68329,6 +68544,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0815bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0815b"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA, NASA and E. Peng (Peking Un; Virgo cluster galaxy NGC 4660, na elliptical located about 50 million light-years from Earth. Hubble's "eye" is so sharp that it...</Credits>
@@ -68355,6 +68571,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0815cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0815c"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA, NASA and E. Peng (Peking Un; Virgo cluster galaxy NGC 4458. Hubble's "eye" is so sharp that it was able to pick out the fuzzy globular clusters, which, at th...</Credits>
@@ -68381,6 +68598,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0815dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0815d"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA, NASA and E. Peng (Peking Un; Virgo cluster galaxy IC 3506. Hubble's "eye" is so sharp that it was able to pick out the fuzzy globular clusters, which, at tha...</Credits>
@@ -68407,6 +68625,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0815eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0815e"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA, NASA and E. Peng (Peking Un; Virgo cluster galaxy VCC 1993. Hubble's "eye" is so sharp that it was able to pick out the fuzzy globular clusters, which, at th...</Credits>
@@ -68433,6 +68652,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0815fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0815f"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; The monstrous elliptical galaxy M87 is the home of several trillion stars, a supermassive black hole, and family of 13,000 globu...</Credits>
@@ -68459,6 +68679,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0815iL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0815i"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Digitized Sky; Virgo cluster of galaxies image taken with the Palomar Observatory 48-inch Schmidt telescope as part of the Digitized Sky Survey...</Credits>
@@ -68485,6 +68706,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0815jL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0815j"
     Xcxstatus="queue:hubble"
   >
     <Credits>Photo Credit: NASA, ESA, and Z. ; This image is a composite of visible (or optical), radio, and X-ray  data of the giant elliptical galaxy, M87. M87 lies at a dis...</Credits>
@@ -68511,6 +68733,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0816aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0816a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and M. Livio (STScI); In commemoration of the NASA/ESA Hubble Space Telescope completing its 100 000th orbit around the Earth in its 18th year of expl...</Credits>
@@ -68537,6 +68760,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0817bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0817b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, NRAO and L. Frattare ; The behemoth galaxy NGC 1275, also known as Perseus A, lies at the centre of Perseus Galaxy Cluster. By combining multi-waveleng...</Credits>
@@ -68563,6 +68787,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0817cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0817c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Digitized Sky; Located around 235 million light-years away from Earth, The Perseus Galaxy Cluster is one of the closest to us but is difficult ...</Credits>
@@ -68589,6 +68814,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0818aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0818a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, CXC, M. Bradac (Unive; This astounding view of galaxy cluster MACSJ0025 demonstrates how ordinary matter and mysterious dark matter interact. The blue ...</Credits>
@@ -68615,6 +68841,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0819bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0819b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, J. Dalcanton and B. W; NGC 253 is one of brightest spiral galaxies in the night sky, easily visible with small telescopes, and it is composed of thousa...</Credits>
@@ -68641,6 +68868,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0819cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0819c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, J. Dalcanton and B. W; In this view of the spiral galaxy NGC 300, young, blue stars are concentrated in spiral arms that sweep diagonally through the i...</Credits>
@@ -68667,6 +68895,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0819dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0819d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, J. Dalcanton and B. W; The dark clumps of material scattered around the bright nucleus of NGC 3077 are pieces of wreckage from the galaxy's interaction...</Credits>
@@ -68693,6 +68922,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0819eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0819e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, J. Dalcanton and B. W; This image shows a swarm of young, blue stars in the diffuse dwarf irregular galaxy NGC 4163. It is a member of a group of dwarf...</Credits>
@@ -68719,6 +68949,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0819fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0819f"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, J. Dalcanton and B. W; Hubble's Advanced Camera for Surveys shows individual as well as clusters of stars in the spiral galaxy NGC 300, located approxi...</Credits>
@@ -68745,6 +68976,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0819gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0819g"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, J. Dalcanton and B. W; Hubble's Advanced Camera for Surveys shows individual stars, clusters of stars and nebulae in the spiral galaxy NGC 300, located...</Credits>
@@ -68771,6 +69003,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0819hL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0819h"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, J. Dalcanton and B. W; Hubble's Advanced Camera for Surveys shows individual stars and clusters of stars in the spiral galaxy NGC 300, located approxim...</Credits>
@@ -68797,6 +69030,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0820aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0820a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and M. Livio (STScI); The NASA/ESA Hubble Space Telescope is back in business. Just a couple of days after the orbiting observatory was brought back o...</Credits>
@@ -68823,6 +69057,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0821fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0821f"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Digitized Sky; This image shows Fomalhaut, the star around which the newly discovered planet orbits. Fomalhaut is much hotter than our Sun, 15 ...</Credits>
@@ -68849,6 +69084,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0822aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0822a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and Jesús Maíz Apell; The image shows a pair of colossal stars, WR 25 and Tr16-244, located within the open cluster Trumpler 16. This cluster is embed...</Credits>
@@ -68875,6 +69111,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0822bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0822b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and Jesús Maíz Apell; WR 25 and Tr16-244, at the bottom of the image, are located within the open cluster Trumpler 16. This cluster is embedded within...</Credits>
@@ -68901,6 +69138,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0822cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0822c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and Jesús Maíz Apell; In WR 25 two of the stars are so close to each other that they look like a single object, but Hubble's Advanced Camera for Surve...</Credits>
@@ -68927,6 +69165,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0901aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0901a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and K. Cook (Lawrence ; This very deep image taken with the NASA/ESA Hubble Space Telescope shows the spiral galaxy NGC 4921 along with a spectacular ba...</Credits>
@@ -68953,6 +69192,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0901cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0901c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Digitized Sky; A wide-field image of the region around the Coma Galaxy Cluster (Abell 1656) constructed from the images in the Digitized Sky Su...</Credits>
@@ -68979,6 +69219,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0902aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0902a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and R. Sharples (Unive; The three pictured galaxies - NGC 7173 (middle left), NCG 7174 (middle right) and NGC 7176 (lower right) - are part of the Hicks...</Credits>
@@ -69005,6 +69246,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0903bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0903b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and C. Conselice (Univ; This object, [CGW2003] J031931.7+4131, is one of four dwarf galaxies that is part of a census of small galaxies in the tumultuou...</Credits>
@@ -69031,6 +69273,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0903cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0903c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and C. Conselice (Univ; This object, [CGW2003] J031910.4+4129, is one of four dwarf galaxies that is part of a census of small galaxies in the tumultuou...</Credits>
@@ -69057,6 +69300,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0903dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0903d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and C. Conselice (Univ; This object, [CGW2003] J031900.4+4129, is one of four dwarf galaxies that is part of a census of small galaxies in the tumultuou...</Credits>
@@ -69083,6 +69327,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0903eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0903e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and C. Conselice (Univ; This object, [CGW2003] J031905.2+4134, is one of four dwarf galaxies that is part of a census of small galaxies in the tumultuou...</Credits>
@@ -69109,6 +69354,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0905bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0905b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Digitized Sky; A wide-field image of the region around NGC 7049 constructed from the images in the Digitized Sky Survey. The field-of-view is a...</Credits>
@@ -69135,6 +69381,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0906aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0906a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; This brilliant image, courtesy of NASA/ESA's Hubble Space Telescope, is a fitting 19th anniversary tribute to the workhorse spac...</Credits>
@@ -69161,6 +69408,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0910bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0910b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble SM4 ERO Te; The NASA/ESA Hubble Space Telescope's newly repaired Advanced Camera for Surveys (ACS) has peered across almost five billion lig...</Credits>
@@ -69187,6 +69435,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0910eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0910e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble SM4 ERO; Composed of gas and dust, the pictured pillar resides in a tempestuous stellar nursery called the Carina Nebula, located 7500 li...</Credits>
@@ -69213,6 +69462,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0910fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0910f"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble SM4 ERO; Composed of gas and dust, the pictured pillar resides in a tempestuous stellar nursery called the Carina Nebula, located 7500 li...</Credits>
@@ -69239,6 +69489,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0910gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0910g"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble SM4 ERO; The NASA/ESA Hubble Space Telescope snapped this panoramic view of a colourful assortment of 100 000 stars residing in the crowd...</Credits>
@@ -69265,6 +69516,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0910jL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0910j"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble SM4 ERO; The wispy, glowing, magenta structures in this NASA/ESA Hubble Space Telescope image are the remains of a star 10 to 15 times th...</Credits>
@@ -69291,6 +69543,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0910mL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0910m"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble SM4 ERO Te; This image is a colour composite made from exposures from the Digitized Sky Survey 2 (DSS2). The field of view is slightly more ...</Credits>
@@ -69317,6 +69570,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0910nL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0910n"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble SM4 ERO; Rings of brilliant blue stars encircle the bright, active core of this spiral galaxy, whose monster black hole is blasting mater...</Credits>
@@ -69343,6 +69597,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0910tL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0910t"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and Digitized Sky Surv; This image is a colour composite made from exposures from the Digitized Sky Survey 2 (DSS2). The field of view is approximately ...</Credits>
@@ -69369,6 +69624,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0911bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0911b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA; Hubble's Advanced Camera for Surveys (ACS) allows astronomers to study an interesting and important phenomenon called ram pressu...</Credits>
@@ -69395,6 +69651,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0911cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0911c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA; The image of NGC 4402 highlights some telltale signs of ram pressure stripping such as the curved, or convex, appearance of the ...</Credits>
@@ -69421,6 +69678,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0911dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0911d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Digitized Sky ; A wide-field image of the region around NGC 4522 constructed from the images in the Digitized Sky Survey. The field-of-view is a...</Credits>
@@ -69447,6 +69705,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0911fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0911f"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Digitized Sky ; A wide-field image of the region around NGC 4402 constructed from the images in the Digitized Sky Survey. The field-of-view is a...</Credits>
@@ -69473,6 +69732,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0912aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0912a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and A. Evans (Stony Br; Not surprisingly, interacting galaxies have a dramatic effect on each other. Studies have revealed that as galaxies approach one...</Credits>
@@ -69499,6 +69759,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0912bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0912b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Digitized Sky ; A wide-field image of the region around NGC 2623 constructed from Digitized Sky Survey 2 images. The field of view is approximat...</Credits>
@@ -69525,6 +69786,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0913aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0913a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA/ESA and Jesús Maíz Apell; This image is a "close-up' view from the NASA/ESA Hubble Space Telescope of NGC 4755, or the Jewel Box cluster. Several very bri...</Credits>
@@ -69551,6 +69813,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0913bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0913b"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESO; The FORS1 instrument on the ESO Very Large Telescope (VLT) at ESO's Paranal Observatory was used to take this exquisitely sharp ...</Credits>
@@ -69577,6 +69840,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0913cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0913c"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESO; This image of the well-known NGC 4755 cluster or Jewel Box was taken with the Wide Field Imager (WFI) on the MPG/ESO 2.2-metre t...</Credits>
@@ -69603,6 +69867,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0913dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0913d"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESO, ESA/Hubble and Digitized Sk; A wide-field image of the region around NGC 4755 constructed from the data from Digitized Sky Survey 2. The bright star is Mimos...</Credits>
@@ -69629,6 +69894,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0914aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0914a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA; Still an astrophysical mystery, the evolution of the bulges in spiral galaxies led astronomers to the edge-on galaxy NGC 4710. W...</Credits>
@@ -69655,6 +69921,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0914bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0914b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA; Still an astrophysical mystery, the evolution of the bulges in spiral galaxies led astronomers to the edge-on galaxy NGC 4710. W...</Credits>
@@ -69681,6 +69948,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0914cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0914c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and Digitized Sky Surv; A wide-field image of the region around NGC 4710 constructed from Digitized Sky Survey 2 data. The field of view is approximatel...</Credits>
@@ -69707,6 +69975,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0915aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0915a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA; This close-up of an area in the northwest region of the large Iris Nebula seems to be clogged with cosmic dust. With bright ligh...</Credits>
@@ -69733,6 +70002,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0915bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0915b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and Digitized Sky Surv; A wide-field image of the region around NGC 7023 constructed from Digitized Sky Survey 2 data. The field of view is approximatel...</Credits>
@@ -69759,6 +70029,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0916aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0916a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, G. Illingworth (UCO/L; In 2004, Hubble created the deepest visible-light image of the Universe and now, with its brand-new camera, Hubble is seeing eve...</Credits>
@@ -69785,6 +70056,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0918aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0918a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA/ ESA; This brilliant image of Messier 30 (M 30) was taken by Hubble's Advanced Camera for Surveys (ACS). Messier 30 formed 13 billion ...</Credits>
@@ -69811,6 +70083,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic0918cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic0918c"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESO and Digitized Sky Survey 2Ac; This wide-field image of the sky around the globular cluster Messier 30 was created from photographs forming part of the Digitiz...</Credits>
@@ -69837,6 +70110,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1001bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1001b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, G. Illingworth (UCO/L; This Hubble image taken by the observatory’s new Wide Field Camera 3 in Infrared highlights some of the oldest galaxies ever see...</Credits>
@@ -69863,6 +70137,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1001cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1001c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, G. Illingworth (UCO/L; This Hubble image taken by the observatory's new Wide Field Camera 3 in infrared light highlights some of the oldest galaxies ev...</Credits>
@@ -69889,6 +70164,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1004aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1004a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and Michael West (ESO); This image from the Advanced Camera for Surveys aboard the NASA/ESA Hubble Space Telescope highlights the large and bright ellip...</Credits>
@@ -69915,6 +70191,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1005aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1005a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, P. Simon (University ; This image shows a smoothed reconstruction of the total (mostly dark) matter distribution in the COSMOS field, created from data...</Credits>
@@ -69941,6 +70218,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1005dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1005d"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; Digitized Sky Surve; This image shows the COSMOS field and is a colour composite made from Digitized Sky Survey 2 (DSS2) exposure. The field of view ...</Credits>
@@ -69967,6 +70245,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1006aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1006a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; Hubble has snapped a spectacular view of M 66, the largest "player" of the Leo Triplet, and a galaxy with an unusual anatomy: it...</Credits>
@@ -69993,6 +70272,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1006bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1006b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and and Digitized Sky ; This wide-field image of the sky around the spiral galaxy Messier 66 was created from photographs forming part of the Digitized ...</Credits>
@@ -70019,6 +70299,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1007aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1007a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, M. Livio and the Hubb; This craggy fantasy mountaintop enshrouded by wispy clouds looks like a bizarre landscape from Tolkien’s The Lord of the Rings. ...</Credits>
@@ -70045,6 +70326,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1007cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1007c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and M. Livio and the H; This craggy fantasy mountaintop enshrouded by wispy clouds looks like a bizarre landscape from Tolkien’s The Lord of the Rings. ...</Credits>
@@ -70071,6 +70353,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1007eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1007e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and M. Livio, The Hub; The NASA/ESA Hubble Space Telescope captured this billowing cloud of cold interstellar gas and dust rising from a tempestuous st...</Credits>
@@ -70097,6 +70380,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1007fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1007f"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, M. Livio and the Hubb; This is a NASA Hubble Space Telescope near-infrared image of a pillar of gas and dust, three light-years tall, that is being eat...</Credits>
@@ -70123,6 +70407,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1008bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1008b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, J. Walsh (ST-ECF) and; The young star, only one million to two million years old, may have travelled about 375 light-years from its suspected home in s...</Credits>
@@ -70149,6 +70434,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1008cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1008c"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESOAcknowledgments: J. Alves (Ca; Within this image is the runaway heavyweight star, called 30 Dor #016. It is 90 times more massive than the Sun and is travellin...</Credits>
@@ -70175,6 +70461,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1009aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1009a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and Wolfgang Brandner ; The core of the star cluster in NGC 3603 is shown in great detail in an image from the Wide Field Planetary Camera 2 (WFPC2) cam...</Credits>
@@ -70201,6 +70488,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1009cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1009c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; This view of the rich star formation region NGC 3603 and its massive compact central star cluster was taken with the Advanced Ca...</Credits>
@@ -70227,6 +70515,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1011aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1011a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and Jesús Maíz Apell; This broad vista of young stars and gas clouds in our neighbouring galaxy, the Large Magellanic Cloud, was captured by the NASA/...</Credits>
@@ -70253,6 +70542,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1011cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1011c"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This wide field view of part of the Large Magellanic Cloud includes the location of the N11 star formation region. This image wa...</Credits>
@@ -70279,6 +70569,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1012aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1012a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and Orsola De Marco (M; A colourful star-forming region is featured in this stunning new NASA/ESA Hubble Space Telescope image of NGC 2467. Looking like...</Credits>
@@ -70305,6 +70596,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1013aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1013a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and NASA; This picture, taken by Hubble’s Advanced Camera for Surveys, shows NGC 4696, the largest galaxy in the Centaurus Cluster. The hu...</Credits>
@@ -70331,6 +70623,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1015aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1015a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA.; This close-up shot of the centre of the Lagoon Nebula (Messier 8) clearly shows the delicate structures formed when the powerful...</Credits>
@@ -70357,6 +70650,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1018aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1018a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; This delicate shell, photographed by the NASA/ESA Hubble Space Telescope, appears to float serenely in the depths of space, but ...</Credits>
@@ -70383,6 +70677,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1018bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1018b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; This delicate shell, photographed by the NASA/ESA Hubble Space Telescope, appears to float serenely in the depths of space, but ...</Credits>
@@ -70409,6 +70704,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1102aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1102a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, William Keel (Univers; In this image by the NASA/ESA Hubble Space Telescope, an unusual, ghostly green blob of gas appears to float near a normal-looki...</Credits>
@@ -70435,6 +70731,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1102bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1102b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; A number of galaxies are seen in this Hubble infrared image of the area surrounding the space oddity, Hanny’s Voorwerp. Located ...</Credits>
@@ -70461,6 +70758,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1103bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1103b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, G. Illingworth (Unive; Astronomers have used Hubble to spot what they think is the furthest and one of the very earliest galaxies ever seen in the Univ...</Credits>
@@ -70487,6 +70785,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1103cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1103c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, G. Illingworth (Unive; Astronomers have used Hubble to spot what they think is the furthest and one of the very earliest galaxies ever seen in the Univ...</Credits>
@@ -70513,6 +70812,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1104aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1104a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; Star formation is one of the most important processes in shaping the Universe; it plays a pivotal role in the evolution of galax...</Credits>
@@ -70539,6 +70839,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1104bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1104b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Digitized Sky ; This image shows the area around flocculent spiral galaxy NGC 2841. It is produced from Digitised Sky Survey 2 images....</Credits>
@@ -70565,6 +70866,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1105aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1105a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA; Hubble has taken this stunning close-up shot of part of the Tarantula Nebula. This star-forming region of ionised hydrogen gas i...</Credits>
@@ -70591,6 +70893,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1105dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1105d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This ground-based view of the Tarantula Nebula shows the nebula in its entirety. It is the brightest region of star formation in...</Credits>
@@ -70617,6 +70920,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1106aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1106a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, J. Richard (CRAL) and; The giant galaxy cluster in the centre of this image contains so much dark matter mass that its gravity bends the light of more ...</Credits>
@@ -70643,6 +70947,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1106dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1106d"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; Digitized Sky Surve; This ground-based view shows the area of sky around the lensing cluster Abell 383. Lensing clusters are clusters of elliptical g...</Credits>
@@ -70669,6 +70974,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1107aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1107a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; This image of a pair of interacting galaxies called Arp 273 was released to celebrate the 21st anniversary of the launch of the ...</Credits>
@@ -70695,6 +71001,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1108aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1108a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA; This close-up Hubble view of the Meathook Galaxy (NGC 2442) focuses on the more compact of its two asymmetric spiral arms as wel...</Credits>
@@ -70721,6 +71028,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1108bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1108b"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESO; This picture of the Meathook Galaxy (NGC 2442) was taken by the Wide Field Imager on the MPG/ESO 2.2-metre telescope at La Silla...</Credits>
@@ -70747,6 +71055,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1108cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1108c"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; Digitized Sky Surve; This wide-field view from the Digitized Sky Survey shows the neighbourhood of the Meathook Galaxy (NGC 2442). A closer, more det...</Credits>
@@ -70773,6 +71082,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1109aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1109a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; Galaxy NGC 4214, pictured here in an image from the NASA/ESA Hubble Space Telescope’s newest camera, is an ideal location to stu...</Credits>
@@ -70799,6 +71109,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1109bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1109b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This ground-based image of the area around NGC 4214 shows this dwarf irregular galaxy in its context. The NASA/ESA Hubble Space ...</Credits>
@@ -70825,6 +71136,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1110aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1110a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; Centaurus A, also known as NGC 5128, is well known for its dramatic dusty lanes of dark material. Hubble’s new observations, usi...</Credits>
@@ -70851,6 +71163,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1111aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1111a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, ESO, CXC, and D. Coe ; This image combines visible light exposures of galaxy cluster Abell 2744 taken by the NASA/ESA Hubble Space Telescope and the Eu...</Credits>
@@ -70877,6 +71190,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1111bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1111b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, ESO and D. Coe (STScI; This image of galaxy cluster Abell 2744 combines data from the NASA/ESA Hubble Space Telescope’s Advanced Camera for Surveys, wi...</Credits>
@@ -70903,6 +71217,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1111cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1111c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and D. Coe (STScI)/J. ; This Hubble image, taken by the Advanced Camera for Surveys, shows the central part of merging galaxy cluster Abell 2744, nickna...</Credits>
@@ -70929,6 +71244,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1111dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1111d"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESO and D. Coe (STScI)/J. Merten; This image, made with the European Southern Observatory’s Very Large Telescope (VLT), shows a wide view of merging galaxy cluste...</Credits>
@@ -70955,6 +71271,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1111eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1111e"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; Digitized Sky Surve; This ground-based view shows the area of sky around the merging galaxy cluster Abell 2744, which has been given the nickname Pan...</Credits>
@@ -70981,6 +71298,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1112fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1112f"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; Digitized Sky Surve; This ground-based image shows the full extent of the Andromeda Galaxy, also known as Messier 31 or M 31. The Andromeda Galaxy ap...</Credits>
@@ -71007,6 +71325,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1114aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1114a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA; The  NASA/ESA Hubble Space Telescope has captured this image of dwarf  irregular galaxy Holmberg II. The galaxy is dominated by ...</Credits>
@@ -71033,6 +71352,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1114bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1114b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This  image from a ground-based telescope shows a wide view around galaxy  Holmberg II. Holmberg II is dominated by huge glowing...</Credits>
@@ -71059,6 +71379,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1116aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1116a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and J.A. Muñoz (Unive; This picture shows a quasar that has been gravitationally lensed by a galaxy in the foreground, which can be seen as a faint sha...</Credits>
@@ -71085,6 +71406,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1202aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1202a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA; The NASA/ESA Hubble Space Telescope has taken a picture of the barred spiral galaxy NGC 1073, which is found in the constellatio...</Credits>
@@ -71111,6 +71433,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1202cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1202c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This image from a ground-based telescope shows the location of and region surrounding NGC 1073.Several other galaxies are also v...</Credits>
@@ -71137,6 +71460,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1203bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1203b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and S. Farrell (Unive; This spectacular edge-on galaxy, called ESO 243-49, is home to an intermediate-mass black hole that may have been purloined from...</Credits>
@@ -71163,6 +71487,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1205aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1205a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA; This image from the NASA/ESA Hubble Space Telescope shows the globular cluster Messier 9. Hubble’s image resolves stars right in...</Credits>
@@ -71189,6 +71514,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1207aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1207a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA; The NASA/ESA Hubble Space Telescope has made detailed observations of the dwarf galaxy NGC 2366. While it lacks the elegant spir...</Credits>
@@ -71215,6 +71541,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1207bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1207b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This image from the Digitized Sky Survey 2 shows a wide field of view around the dwarf galaxy NGC 2366....</Credits>
@@ -71241,6 +71568,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1208aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1208a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage (; The NASA/ESA Hubble Space Telescope has produced an incredibly detailed image of a pair of overlapping galaxies called NGC 3314....</Credits>
@@ -71267,6 +71595,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1210aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1210a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; The NASA/ESA Hubble Space Telescope has captured a new image of Herbig-Haro 110, a geyser of hot gas flowing from a newborn star...</Credits>
@@ -71293,6 +71622,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1211aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1211a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and T. Brown (STScI); Astronomers used the NASA/ESA Hubble Space Telescope to unmask the dim, star-starved dwarf galaxy Leo IV. This Hubble image demo...</Credits>
@@ -71319,6 +71649,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1215aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1215a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Harald Ebeling (Unive; This enormous image shows Hubble’s view of massive galaxy cluster MACS J0717.5+3745. The large field of view is a combination of...</Credits>
@@ -71345,6 +71676,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1215bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1215b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Harald Ebeling(Univer; This enormous image shows Hubble’s view of massive galaxy cluster MACS J0717.5+3745. The large field of view is a combination of...</Credits>
@@ -71371,6 +71703,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1218aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1218a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA; An almost complete circle of bright pink nebulae skirts around a spiral galaxy in this NASA/ESA Hubble Space Telescope image of ...</Credits>
@@ -71397,6 +71730,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1218cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1218c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This image from a ground-based telescope shows the region around NGC 922, a galaxy with a bright ring of nebulae caused by a col...</Credits>
@@ -71423,6 +71757,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1301aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1301a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA. Acknowledgement: Josh; Nearly 200 000 light-years from Earth, the Large Magellanic Cloud, a satellite galaxy of the Milky Way, floats in space, in a lo...</Credits>
@@ -71449,6 +71784,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1302aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1302a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; This image combines Hubble observations of M 106 with additional information captured by amateur astronomers Robert Gendler and ...</Credits>
@@ -71475,6 +71811,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1303aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1303a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and J. Muzerolle (STS; This infrared image from the NASA/ESA Hubble Space Telescope shows an image of protostellar object LRLL 54361 and its rich cosmi...</Credits>
@@ -71501,6 +71838,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1303bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1303b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and J. Muzerolle (STS; This infrared image from the NASA/ESA Hubble Space Telescope shows an image of protostellar object LRLL 54361. The protostar is ...</Credits>
@@ -71527,6 +71865,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1304aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1304a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA. Acknowledgement: N. ; Abell 68, pictured here in infrared light, is a galaxy cluster. The effect of its gravity on light means it boosts Hubble’s powe...</Credits>
@@ -71553,6 +71892,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1305aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1305a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA &amp; A. van der Hoeven; The NASA/ESA Hubble Space Telescope has captured this vivid image of spiral galaxy Messier 77 — a galaxy in the constellation of...</Credits>
@@ -71579,6 +71919,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1310dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1310d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This image from the Digitized Sky Survey shows the Ring Nebula (Messier 57) and its surroundings....</Credits>
@@ -71605,6 +71946,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1311aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1311a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; This image shows the two galaxies interacting. NGC 2936, once a standard spiral galaxy, and NGC 2937, a smaller elliptical, bear...</Credits>
@@ -71631,6 +71973,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1311bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1311b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This image from the Digitized Sky Survey shows the area around a pair of merging galaxies known as Arp 142 in the constellation ...</Credits>
@@ -71657,6 +72000,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1402aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1402a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, E. Sabbi (STScI); This new Hubble image shows a cosmic creepy-crawly known as the Tarantula Nebula in infrared light. This region is full of star ...</Credits>
@@ -71683,6 +72027,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1402bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1402b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, E. Sabbi (STScI); This new Hubble image shows a cosmic creepy-crawly known as the Tarantula Nebula in visible, infrared and ultraviolet light. Thi...</Credits>
@@ -71709,6 +72054,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1406aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1406a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; To celebrate its 24th year in orbit, the NASA/ESA Hubble Space Telescope has released this beautiful new image of part of NGC 21...</Credits>
@@ -71735,6 +72081,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1415aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1415a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image credit: ESA/Hubble, NASA, ; This image shows the stunning elliptical galaxy Centaurus A. Recently, astronomers have used the NASA/ESA Hubble Space Telescope...</Credits>
@@ -71761,6 +72108,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1415cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1415c"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image credit: ESA/Hubble, NASA A; This image shows one of the areas of Centaurus A's halo probed by the NASA/ESA Hubble Space Telescope's Advanced Camera for Surv...</Credits>
@@ -71787,6 +72135,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1415dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1415d"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image credit: ESA/Hubble, NASA A; This image shows one of the areas of Centaurus A's halo probed by the  NASA/ESA Hubble Space Telescope's Advanced Camera for Sur...</Credits>
@@ -71813,6 +72162,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1416aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1416a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA, HST Frontier F; This image from the NASA/ESA Hubble Space Telescope shows the galaxy cluster MACS J0416.1–2403. This is one of six being studied...</Credits>
@@ -71839,6 +72189,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1416cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1416c"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA, HST Frontier F; This image shows the galaxy MCS J0416.1–2403, one of six clusters targeted by the Hubble Frontier Fields programme. The varying ...</Credits>
@@ -71865,6 +72216,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1420dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1420d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This image, taken with ground-based telescopes, shows the region of sky containing the star HAT-P-11. Not visible here is a Nept...</Credits>
@@ -71891,6 +72243,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1423cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1423c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA Acknowledgement: A. Z; This image, taken with the NASA/ESA Hubble Space Telescope, shows one of three images of the same very distant galaxy whose ligh...</Credits>
@@ -71917,6 +72270,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1423dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1423d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA Acknowledgement: A. Z; This image, taken with the NASA/ESA Hubble Space Telescope, shows one of three images of the same very distant galaxy whose ligh...</Credits>
@@ -71943,6 +72297,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1423eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1423e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA Acknowledgement: A. Z; This image, taken with the NASA/ESA Hubble Space Telescope, shows one of three images of the same very distant galaxy whose ligh...</Credits>
@@ -71969,6 +72324,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1424aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1424a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Image credit: ESA/Hubble and NAS; The NASA/ESA Hubble Space Telescope has snapped a striking view of a multiple star system called XZ Tauri, its neighbour HL Taur...</Credits>
@@ -71995,6 +72351,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1424cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1424c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This image from the Digitized Sky Survey shows the area around multiple star system XZ Tauri. XZ Tauri is blowing a hot bubble o...</Credits>
@@ -72021,6 +72378,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1425dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1425d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, S. Larsen (Radboud Un; This NASA/ESA Hubble Space Telescope image shows the globular cluster Fornax 2 in the dwarf galaxy Fornax. New observations of t...</Credits>
@@ -72073,6 +72431,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1501eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1501e"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This image is a colour composite of the Eagle Nebula (M 16) made from exposures from the Digitized Sky Survey 2 (DSS2). The fiel...</Credits>
@@ -72099,6 +72458,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1502bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1502b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey; This image from the Digitized Sky Survey shows the area around the Andromeda galaxy — otherwise known as M31....</Credits>
@@ -72125,6 +72485,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1503aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1503a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA, NASA Acknowledgement: A. Ga; NGC 7714 is a spiral galaxy 100 million light-years from Earth — a relatively close neighbour in cosmic terms. The galaxy has wi...</Credits>
@@ -72151,6 +72512,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1505bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1505b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, S. Rodney (John Hopki; This image shows the huge galaxy cluster MACS J1149.5+223, whose light took over 5 billion years to reach us. The huge mass of t...</Credits>
@@ -72177,6 +72539,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1505cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1505c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, S. Rodney (John Hopki; This image shows four different images of the same supernova whose light has been distorted and magnified by the huge galaxy clu...</Credits>
@@ -72203,6 +72566,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1506bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1506b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, D. Harvey (École Pol; This is a NASA/ESA Hubble Space Telescope image of the galaxy cluster Abell 370. Shown in blue on the image is a map of the dark...</Credits>
@@ -72229,6 +72593,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1506cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1506c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, D. Harvey (École Pol; This is a NASA/ESA Hubble Space Telescope image of the galaxy cluster Abell 2744. Shown in blue on the image is a map of the dar...</Credits>
@@ -72255,6 +72620,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1506dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1506d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, D. Harvey (École Pol; This is a NASA/ESA Hubble Space Telescope image of the galaxy cluster MACS J0152.5-2852. Shown in blue on the image is a map of ...</Credits>
@@ -72281,6 +72647,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1506eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1506e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, D. Harvey (École Pol; This is a NASA/ESA Hubble Space Telescope image of the galaxy cluster MACS J0416.1–2403. Shown in blue on the image is a map of ...</Credits>
@@ -72307,6 +72674,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1506fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1506f"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, D. Harvey (École Pol; This is a NASA/ESA Hubble Space Telescope image of the galaxy cluster MACS J0717.5+3745. Shown in blue on the image is a map of ...</Credits>
@@ -72333,6 +72701,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1506gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1506g"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, D. Harvey (École Pol; This is a NASA/ESA Hubble Space Telescope image of the galaxy cluster ZwCl 1358+62. Shown in blue on the image is a map of the d...</Credits>
@@ -72359,6 +72728,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1507bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1507b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, W. Keel (University o; This new NASA/ESA Hubble Space Telescope image shows ghostly green filaments, lying within the galaxy Teacup (also known as 2MAS...</Credits>
@@ -72385,6 +72755,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1507cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1507c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, W. Keel (University o; Twisting in the darkness like a disturbed double helix, NGC 5972 exhibits a remarkable structure of ionised gas, which appears t...</Credits>
@@ -72411,6 +72782,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1507dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1507d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, W. Keel (University o; This new NASA/ESA Hubble Space Telescope image shows ghostly green filaments, lying within galaxy 2MASX J15100402+0740370. This ...</Credits>
@@ -72437,6 +72809,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1507eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1507e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, W. Keel (University o; This new NASA/ESA Hubble Space Telescope image shows ghostly green filaments, lying within galaxy UGC 7342. This filament was il...</Credits>
@@ -72463,6 +72836,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1507fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1507f"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, W. Keel (University o; This new NASA/ESA Hubble Space Telescope image shows ghostly green filaments, lying within galaxy NGC 5252. This filament was il...</Credits>
@@ -72489,6 +72863,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1507gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1507g"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, W. Keel (University o; This new NASA/ESA Hubble Space Telescope image shows ghostly green filaments, lying within galaxy Mrk 1498. This filament was il...</Credits>
@@ -72515,6 +72890,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1507hL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1507h"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, W. Keel (University o; This new NASA/ESA Hubble Space Telescope image shows ghostly green filaments, lying within galaxy UGC 11185. This filament was i...</Credits>
@@ -72541,6 +72917,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1507iL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1507i"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, W. Keel (University o; This new NASA/ESA Hubble Space Telescope image shows ghostly green filaments, lying within galaxy 2MASX J22014163+1151237. This ...</Credits>
@@ -72567,6 +72944,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1508aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1508a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Image acknowle; This NASA/ESA Hubble Space Telescope image shows an elliptical galaxy known as IC 2006. Massive elliptical galaxies like these a...</Credits>
@@ -72593,6 +72971,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1509bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1509b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This image from the Digitized Sky Survey shows star cluster Westerlund 2 and its surroundings. A new image of Westerlund 2 was r...</Credits>
@@ -72619,6 +72998,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1509cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1509c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; This image shows the sparkling centerpiece of Hubble's 25th anniversary tribute. Westerlund 2 is a giant cluster of about 3000 s...</Credits>
@@ -72645,6 +73025,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1509dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1509d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; This image shows the star-forming region Gum 29 which surrounds star cluster Westerlund 2. This is a section of the new NASA/ESA...</Credits>
@@ -72671,6 +73052,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1509eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1509e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; This image shows an example of the pillars that surround the star cluster Westerlund 2. These pillars are composed of dense gas ...</Credits>
@@ -72697,6 +73079,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1509fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1509f"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; The red dots scattered throughout the cosmic landscape captured in this NASA/ESA Hubble Space Telescope image are a rich populat...</Credits>
@@ -72723,6 +73106,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1510bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1510b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; This NASA/ESA Hubble Space Telescope image shows the central region of a globular cluster known as NGC 104 — or, more commonly, ...</Credits>
@@ -72749,6 +73133,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1510cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1510c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and H. Richer and J. ; This NASA/ESA Hubble Space Telescope image shows the central region of a globular cluster known as NGC 104 — or, more commonly, ...</Credits>
@@ -72775,6 +73160,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1511cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1511c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, M. Chiaberge (STScI); This image taken with the NASA/ESA Hubble Space Telescope shows the galaxy 3C 297, which was part of a large survey of galaxies....</Credits>
@@ -72801,6 +73187,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1511dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1511d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, M. Chiaberge (STScI); This image taken with the NASA/ESA Hubble Space Telescope shows the galaxy 3C 454.1 which was part of a large survey of galaxies...</Credits>
@@ -72827,6 +73214,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1511eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1511e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, M. Chiaberge (STScI); This image taken with the NASA/ESA Hubble Space Telescope shows the galaxy 3C 356 which was part of a large survey of galaxies. ...</Credits>
@@ -72853,6 +73241,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1513aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1513a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA; This NASA/ESA Hubble Space Telescope image shows galaxy NGC 6503. The galaxy, which lies about 18 million light-years away is at...</Credits>
@@ -72879,6 +73268,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1513bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1513b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This image shows the area around galaxy NGC 6503. The galaxy, which lies about 18 000 000 light-years away is at the edge of a s...</Credits>
@@ -72905,6 +73295,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1514aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1514a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, ESO Acknowledgement: ; This new NASA/ESA Hubble Space Telescope image shows four of the seven members of galaxy group HCG 16. This quartet is composed ...</Credits>
@@ -72931,6 +73322,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1514bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1514b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This image shows a ground-based wide-field view of the region around HCG 16 from the Digitized Sky Survey 2....</Credits>
@@ -72957,6 +73349,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1516aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1516a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, P. Goudfrooij (STScI); The ghostly shells of galaxy ESO 381-12 are captured here in a new image from the NASA/ESA Hubble Space Telescope, set against a...</Credits>
@@ -72983,6 +73376,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1516bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1516b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This image from the Digitized Sky Survey shows the area around galaxy ESO 381-12. The strikingly uneven structure and the cluste...</Credits>
@@ -73009,6 +73403,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1517aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1517a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, J. Trauger (Jet Propu; This new NASA/ESA Hubble Space Telescope image shows the Lagoon Nebula, an object with a deceptively tranquil name. The region i...</Credits>
@@ -73035,6 +73430,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1518aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1518a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; The Twin Jet Nebula, or PN M2-9, is a striking example of a bipolar planetary nebula. Bipolar planetary nebulae are formed when ...</Credits>
@@ -73061,6 +73457,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1518bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1518b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This image shows the region of sky around the planetary nebula called the Twin Jet Nebula. The bipolar planetary nebula lies abo...</Credits>
@@ -73087,6 +73484,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1519aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1519a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA/STScI/ESA/JPL-Caltech/McGil; This image, using data from Spitzer and the Hubble Space Telescope, shows the galaxy cluster SpARCS1049....</Credits>
@@ -73113,6 +73511,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1519cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1519c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This image shows the region of sky around the the distant galaxy cluster SpARCS1049+56. It took the light of the cluster 9.8 bil...</Credits>
@@ -73139,6 +73538,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1520bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1520b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This image shows the Veil supernova remnant and the surrounding sky. Due to the size of the Nebula the NASA/ESA Hubble Space Tel...</Credits>
@@ -73165,6 +73565,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1521bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1521b"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESO/Digitized Sky Survey 2; This image shows the sky around the nearby young star AU Microscopii. It was created from images forming part of the Digitized S...</Credits>
@@ -73191,6 +73592,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1523aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1523a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the HST Frontier F; This image from the NASA/ESA Hubble Space Telescope shows the galaxy cluster MACS J0416.1–2403. This is one of six being studied...</Credits>
@@ -73217,6 +73619,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1523bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1523b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the HST Frontier F; This image from the NASA/ESA Hubble Space Telescope shows the galaxy cluster MACSJ0717.5+3745. This is one of six being studied ...</Credits>
@@ -73243,6 +73646,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1523cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1523c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the HST Frontier F; Abell 2744, nicknamed Pandora’s Cluster, was the first of six targets within the Frontier Fields programme, which together have ...</Credits>
@@ -73269,6 +73673,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1526aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1526a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, D. Padgett (G; The two lightsabre-like streams crossing the image are jets of energised gas, ejected from the poles of a young star. If the jet...</Credits>
@@ -73321,6 +73726,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1602aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1602a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA; This image shows the elliptical galaxy NGC 4889 in front of hundreds of background galaxies, and deeply embedded within the Coma...</Credits>
@@ -73347,6 +73753,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1602bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1602b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This image shows a ground-based wide-field view of the region around NGC 4889 from the Digitized Sky Survey 2....</Credits>
@@ -73373,6 +73780,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1605aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1605a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, P Crowther (Universit; The image shows the central region of the Tarantula Nebula in the Large Magellanic Cloud. The young and dense star cluster R136 ...</Credits>
@@ -73399,6 +73807,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1606aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1606a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; This infrared image from the NASA/ESA Hubble Space Telescope shows the centre of the Milky Way, 27 000 light-years away from Ear...</Credits>
@@ -73425,6 +73834,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1607bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1607b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This image shows the ground-based view of NGC 1600 and some of the other galaxies of the group it is located in....</Credits>
@@ -73451,6 +73861,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1608bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1608b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This ground-based image shows the Bubble Nebula and its surroundings, including the interstellar cloud which is illuminated by s...</Credits>
@@ -73477,6 +73888,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1611cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1611c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and L. Frattare (STSc; Cepheid variable stars in this spiral galaxy, known as UGC 9391, and a Type Ia supernova (not visible in this image) were used b...</Credits>
@@ -73503,6 +73915,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1612aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1612a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and D. Elmegreen (Vas; In this new image from the NASA/ESA Hubble Space Telescope, a firestorm of star birth is lighting up one end of the diminutive g...</Credits>
@@ -73529,6 +73942,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1612bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1612b"
     Xcxstatus="queue:hubble"
   >
     <Credits>  NASA, ESA, Digitized Sky Surv; This ground-based image shows the tadpole galaxy LEDA 36252 and its surroundings....</Credits>
@@ -73555,6 +73969,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1614aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1614a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA; While many other images of the famous Crab Nebula nebula have focused on the filaments in the outer part of the nebula, this ima...</Credits>
@@ -73581,6 +73996,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1615aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1615a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and J. Lotz (STScI); Abell S1063, a galaxy cluster, was observed by the NASA/ESA Hubble Space Telescope as part of the Frontier Fields programme. The...</Credits>
@@ -73607,6 +74023,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1615bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1615b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and J. Lotz (STScI); This part of the sky was observed in parallel with the galaxy cluster Abell S1063 and is also part of the Frontier Fields progra...</Credits>
@@ -73633,6 +74050,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1615cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1615c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This ground-based image shows the galaxy cluster Abell S1063 and its surroundings....</Credits>
@@ -73685,6 +74103,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1617aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1617a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA/ESA/Hubble/F. Ferraro; Peering through the thick dust clouds of the galactic bulge an international team of astronomers has revealed the unusual mix of...</Credits>
@@ -73711,6 +74130,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1617bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1617b"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESO/Digitized Sky Survey 2; This wide-field image, based on data from Digitized Sky Survey 2, shows the whole region around the stellar grouping Terzan 5....</Credits>
@@ -73737,6 +74157,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1618aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1618a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This image of the Stingray nebula, a planetary nebula 2700 light-years from Earth, was taken with the Wide Field and Planetary C...</Credits>
@@ -73763,6 +74184,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1621aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1621a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA/Hubble, A. Fabian; This picture, taken by Hubble’s Wide Field Camera 3 (WFC3), shows NGC 4696, the largest galaxy in the Centaurus Cluster. The new...</Credits>
@@ -73789,6 +74211,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1621bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1621b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This ground-based image shows the galaxy NGC 4696 and its surroundings....</Credits>
@@ -73815,6 +74238,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1623aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1623a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, STScI, K. Sandstrom (; This glowing nebula, named NGC 248, is located within the Small Magellanic Cloud, a satellite galaxy of the Milky Way and about ...</Credits>
@@ -73841,6 +74265,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1702aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1702a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA, Suyu et al.; HE0435-1223, located in the centre of this wide-field image, is among the five best lensed quasars discovered to date. The foreg...</Credits>
@@ -73867,6 +74292,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1702cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1702c"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA, Suyu et al.; B1608+656 is among the five best lensed quasars discovered to date. The two foreground galaxies smeared the light of the more di...</Credits>
@@ -73893,6 +74319,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1702dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1702d"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA, Suyu et al.; RXJ1131-1231 is among the five best lensed quasars discovered to date. The foreground galaxy smears the image of the background ...</Credits>
@@ -73919,6 +74346,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1702eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1702e"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA, Suyu et al.; HE0435-1223 is among the five best lensed quasars discovered to date. The foreground galaxy creates four almost evenly distribut...</Credits>
@@ -73945,6 +74373,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1702fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1702f"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA, Suyu et al.; WFI2033-4723 is among the five best lensed quasars discovered to date. The foreground galaxy creates four distinct images of the...</Credits>
@@ -73971,6 +74400,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1702gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1702g"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA, Suyu et al.; HE1104-1805 is among the five best lensed quasars discovered to date. The foreground galaxy in the centre of the image creates t...</Credits>
@@ -73997,6 +74427,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1704cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1704c"
     Xcxstatus="queue:hubble"
   >
     <Credits>ALMA: ESO/NAOJ/NRAO/A. Angelich ; Astronomers combined observations from three different observatoriesto produce this multiwavelength image of the remnants of SN ...</Credits>
@@ -74023,6 +74454,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1705aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1705a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA/Hubble; This composite image of the Kleinmann-Low Nebula, part of the Orion Nebula complex, is composed of several pointings of the NASA...</Credits>
@@ -74049,6 +74481,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1706aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1706a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and M. Chiaberge (STS; The galaxy 3C186, located about 8 billion years from Earth, is most likely the result of a merger of two galaxies. This is suppo...</Credits>
@@ -74075,6 +74508,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1707aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1707a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA; This image, taken with the NASA/ESA Hubble Space Telescope, shows the supernova remnant SNR 0509-68.7, also known as N103B (top ...</Credits>
@@ -74101,6 +74535,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1709bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1709b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and M. Mutchler (STSc; While one instrument of Hubble observed the target for its 27th anniversary — the galaxies NGC 4302 and NGC 4298 — another instr...</Credits>
@@ -74127,6 +74562,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1709cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1709c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This ground-based image shows the two galaxies NGC 4298 and NGC 4302 and their surroundings....</Credits>
@@ -74231,6 +74667,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1710eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1710e"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, Sloan Digital Sky Su; Astronomers used the Sloan Digital Sky Survey (SDSS), carried out by a 2.5-metre wide-angle optical telescope at Apache Point Ob...</Credits>
@@ -74257,6 +74694,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1710fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1710f"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, W. M. Keck Observato; The adaptive-optics instruments on the W.M. Keck Observatory on Mauna Kea, Hawaii, were able to resolve the supernova explosion ...</Credits>
@@ -74283,6 +74721,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1711aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1711a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA/Hubble, HST Frontier F; With the final observation of the distant galaxy cluster Abell 370 — some five billion light-years away — the Frontier Fields pr...</Credits>
@@ -74309,6 +74748,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1711bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1711b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA/Hubble, HST Frontier F; While one eye of Hubble was observing its main target, the massive galaxy cluster Abell 370, the second eye — another instrument...</Credits>
@@ -74335,6 +74775,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1711dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1711d"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble; This image of Abell 370 was released in 2009. Compared to the new image, which contains more observation time, less structures a...</Credits>
@@ -74361,6 +74802,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1712bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1712b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This image shows the sky around the two interacting galaxies NGC 1512 and NGC 1510. NGC 1512 is clearly visible in the very cent...</Credits>
@@ -74387,6 +74829,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1716aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1716a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; This image, taken with the NASA/ESA Hubble Space Telescope, shows the galaxy NGC 4490. The scattered and warped appearance of th...</Credits>
@@ -74413,6 +74856,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1717cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1717c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA and ESA; The lenticular galaxy NGC 4993 is located about 130 million light-years from Earth. On 17 August 2017 the Laser Interferometer G...</Credits>
@@ -74439,6 +74883,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1717dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1717d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This image shows the sky around the lenticular galaxy NGC 4993. Within this galaxy Hubble discovered the first visual counterpar...</Credits>
@@ -74465,6 +74910,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1719aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1719a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This image shows a small part of the Sculptor Dwarf Galaxy, a satellite galaxy of the Milky Way, situated only about 300 000 lig...</Credits>
@@ -74491,6 +74937,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1719bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1719b"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This image shows a small part of the Sculptor Dwarf Galaxy, a satellite galaxy of the Milky Way, situated only about 300 000 lig...</Credits>
@@ -74517,6 +74964,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1719cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1719c"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, Digitized Sky Survey; The Sculptor Dwarf Galaxy is one of the Milky Way’s neighbouring dwarf galaxies. Like all large galaxies, the Milky Way is thoug...</Credits>
@@ -74543,6 +74991,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1719dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1719d"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, Digitized Sky Survey; This image of the sky around the Sculptor Dwarf Galaxy was created from images from the Digitized Sky Survey 2. The galaxy appea...</Credits>
@@ -74569,6 +75018,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1720aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1720a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA; NGC 5256 is a pair of galaxies in its final stage of merging. It was previously observed by Hubble as part of a collection of 59...</Credits>
@@ -74595,6 +75045,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1720bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1720b"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA, NASA, Digitized Sky Survey ; This wide-field image shows the pair of galaxies known as NGC 5256 and their surroundings as seen from the ground. In the upper ...</Credits>
@@ -74621,6 +75072,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1803aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1803a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA; This image of the spiral galaxy NGC 3344, located about 20 million light-years from Earth, is a composite of images taken throug...</Credits>
@@ -74647,6 +75099,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1806aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1806a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and P. van Dokkum (Ya; NGC 1052-DF2 resides about 65 million light-years away in the NGC 1052 Group, which is dominated by a massive elliptical galaxy ...</Credits>
@@ -74673,6 +75126,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1806bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1806b"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA, Digitized Sky ; This image shows the sky around the ultra diffuse galaxy NGC 1052-DF2. It was created from images forming part of the Digitized ...</Credits>
@@ -74699,6 +75153,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1808aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1808a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, STScI; To celebrate its 28th anniversary in space the NASA/ESA Hubble Space Telescope took this amazing and colourful image of the Lago...</Credits>
@@ -74725,6 +75180,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1808bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1808b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, STScI; To celebrate its 28th anniversary in space the NASA/ESA Hubble Space Telescope took this amazing and colourful image of the Lago...</Credits>
@@ -74751,6 +75207,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1808eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1808e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, STScI; To celebrate its 28th anniversary in space the NASA/ESA Hubble Space Telescope took this amazing and colourful image of the Lago...</Credits>
@@ -74777,6 +75234,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1810aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1810a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the LEGUS team; This image shows the galaxy NGC 6744, about 30 million light-years away. It is one of 50 galaxies observed as part of the Hubble...</Credits>
@@ -74803,6 +75261,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1810bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1810b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the LEGUS team; UGCA 281 is a blue compact dwarf galaxy located in the constellation of Canes Venatici. Within it, two giant star clusters appea...</Credits>
@@ -74829,6 +75288,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1810cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1810c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the LEGUS team; The spiral galaxy Messier 66 is located at a distance of about 35 million light-years in the constellation of Leo (The Lion). To...</Credits>
@@ -74855,6 +75315,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1810dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1810d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the LEGUS team; The dwarf galaxy DDO 68, also known as UGC 5340, lies about 40 million light-years away from Earth. Due to its proximity it beca...</Credits>
@@ -74881,6 +75342,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1811aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1811a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA; This image, taken with the Wide Field Camera 3 (WFC3) and the Advanced Camera for Surveys (ACS), both installed on the NASA/ESA ...</Credits>
@@ -74907,6 +75369,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1816aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1816a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, A. Koekemoer, M. Jauz; The galaxy cluster Abell 370 was the first target of the BUFFALO survey, which aims to search for some of the first galaxies in ...</Credits>
@@ -74933,6 +75396,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1819bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1819b"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESO; This image shows the Serpens Nebula as seen by the HAWK-I instrument installed on the Very Large Telescope of the European South...</Credits>
@@ -74959,6 +75423,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1820aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1820a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and M. Montes (Univer; Abell S1063, a galaxy cluster, was observed by the NASA/ESA Hubble Space Telescope as part of the Frontier Fields programme. The...</Credits>
@@ -74985,6 +75450,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1901bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1901b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and M. Durbin, J. Dal; This image shows NGC 604, located within the Triangulum Galaxy. Some 1500 light-years across, this is one of the largest, bright...</Credits>
@@ -75011,6 +75477,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1901cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1901c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and M. Durbin, J. Dal; NGC 595 is is a gigantic region of ionised hydrogen in the Triangulum Galaxy, about three million light-years away. The nebula w...</Credits>
@@ -75037,6 +75504,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1901dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1901d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and M. Durbin, J. Dal; IC 142 is a region of ionised hydrogen and a large stellar association in the Triangulum Galaxy. A stellar association is a very...</Credits>
@@ -75063,6 +75531,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1901fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1901f"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESO/Digitized Sky Survey 2. Ackn; This wide-field view of the sky around the nearby galaxy Messier 33 was assembled from images forming part of the Digitized Sky ...</Credits>
@@ -75089,6 +75558,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1903aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1903a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA, Bedin et al.; This image, taken with Hubble’s Advanced Camera for Surveys shows a part the globular cluster NGC 6752. Behind the bright stars ...</Credits>
@@ -75115,6 +75585,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1903cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1903c"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA, Bedin et al.; This image, taken with the NASA/ESA Hubble Space Telescope, shows a part of the globular cluster NGC 6752. The observations were...</Credits>
@@ -75141,6 +75612,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1903dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1903d"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Digitized Sky Survey 2Acknow; This image shows a ground-based wide-field view of the region around NGC 6752 from the Digitized Sky Survey 2....</Credits>
@@ -75167,6 +75639,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1907aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1907a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and STScI; The Southern Crab Nebula — Hubble’s 29th anniversary image....</Credits>
@@ -75193,6 +75666,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1910aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1910a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA Acknowledgement; NGC 4485 has been involved in a dramatic gravitational interplay with its larger galactic neighbour NGC 4490 — out of frame to t...</Credits>
@@ -75219,6 +75693,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1910bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1910b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitized Sky Survey ; This ground-based image shows the large galaxy NGC 4490 and the irregular galaxy NGC 4485 — above the larger galaxy in the centr...</Credits>
@@ -75245,6 +75720,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1911aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1911a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA; Nestled within this field of bright foreground stars lies ESO 495-21, a tiny galaxy with a big heart. ESO 495-21 is just 3000 li...</Credits>
@@ -75271,6 +75747,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-heic1911bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|heic1911b"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA, Digitized Sky ; This image shows the sky around the galaxy ESO 495-21. It was created from images forming part of the Digitized Sky Survey 2. Lo...</Credits>
@@ -75297,6 +75774,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0003bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0003b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA/ESA and Dave Bennett (Unive; The Hubble Space Telescope clearly resolves a lensed star and yields its brightness....</Credits>
@@ -75323,6 +75801,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="0"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0003cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0003c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NOAO, Cerro Tololo Inter-America; Two images of a crowded starfield as seen through a ground-based telescope show the subtle brightening of a star due to the effe...</Credits>
@@ -75349,6 +75828,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="0"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0003dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0003d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NOAO, Cerro Tololo Inter-America; Two images of a crowded starfield as seen through a ground-based telescope show the subtle brightening of a star due to the effe...</Credits>
@@ -75375,6 +75855,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0033cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0033c"
     Xcxstatus="queue:hubble"
   >
     <Credits>David Malin (Anglo-Australian Ob; The picture at left, taken by a terrestrial telescope, shows most of the cluster, a tightly packed group of middle-aged stars he...</Credits>
@@ -75401,6 +75882,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0122cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0122c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA; Image of the Coma Cluster of galaxies...</Credits>
@@ -75427,6 +75909,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0122fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0122f"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA; Studying the star clusters and dwarf galaxies in Stephan's Quintet provides insights into how galactic encounters may have drive...</Credits>
@@ -75453,6 +75936,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0210dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0210d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA/ESA and H. Richer; Peering deep inside a cluster of several hundred thousand stars, the NASA/ESA Hubble Space Telescope uncovered the oldest burned...</Credits>
@@ -75479,6 +75963,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0212cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0212c"
     Xcxstatus="queue:hubble"
   >
     <Credits>R. Chris Smith (CTIO) and Y.-H. ; Composite image of ground-based [S II] image (white; taken at the Curtis Schmidt Telescope at the Cerro Tololo Inter-American Ob...</Credits>
@@ -75505,6 +75990,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0306eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0306e"
     Xcxstatus="queue:hubble"
   >
     <Credits>Digitized Sky Survey (DSS); Close up of M27, The Dumbbell Nebula, as taken by the Digitized Sky Survey....</Credits>
@@ -75531,6 +76017,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0312cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0312c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA/ESA and J. Blakeslee (JHU); The red spot is the glow of a very distant supernova captured exploding in the field. The supernova is estimated to be 8 billion...</Credits>
@@ -75557,6 +76044,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0324eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0324e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA/ESA, The Hubble Heritage Te; The center of NGC 3370 shows well delineated dust lanes and an uncommonly ill-defined nucleus....</Credits>
@@ -75583,6 +76071,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0324fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0324f"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA/ESA, The Hubble Heritage Te; A region on the edge of the galaxy shows bright blue clusters of young, massive stars as well as distant, red background galaxie...</Credits>
@@ -75609,6 +76098,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0324gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0324g"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA/ESA, The Hubble Heritage Te; A region on the edge of the galaxy shows bright blue clusters of young, massive stars as well as distant, red background galaxie...</Credits>
@@ -75635,6 +76125,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0324hL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0324h"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA/ESA, The Hubble Heritage Te; An unusual concentration in the upper corner shows a complex region of tidal interaction between a bright galaxy and its compani...</Credits>
@@ -75661,6 +76152,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0324iL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0324i"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA/ESA, The Hubble Heritage Te; A Sombrero-galaxy-look-alike is seen edge on with a small warp in the middle right....</Credits>
@@ -75687,6 +76179,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0324jL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0324j"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA; In the lower middle right, a distant filament of merging blue galaxies can be seen....</Credits>
@@ -75713,6 +76206,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0331cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0331c"
     Xcxstatus="queue:hubble"
   >
     <Credits>N. Smith, University of Minnesot; This image shows the Carina Nebula (NGC 3372), combining the light from 3 different filters tracing emission from oxygen (blue),...</Credits>
@@ -75739,6 +76233,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0409aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0409a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA/ESA, P. Challis, R. Kirshne; Seventeen years ago, astronomers spotted the brightest stellar explosion ever seen since the one observed by Johannes Kepler 400...</Credits>
@@ -75765,6 +76260,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0413bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0413b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and The Hubble Herita; A ground-based Digitized Sky Survey image NGC 300....</Credits>
@@ -75791,6 +76287,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0520aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0520a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and The Hubble Heritag; Gazing deep into the universe, NASA/ESA Hubble Space Telescope has spied a menagerie of galaxies. Located within the same tiny r...</Credits>
@@ -75817,6 +76314,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0525aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0525a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and The Hubble Heritag; The NASA/ESA Hubble Space Telescope caught the Boomerang Nebula in images taken with the Advanced Camera for Surveys in early 20...</Credits>
@@ -75843,6 +76341,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0530aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0530a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and The Hubble Herita; Intricate wisps of glowing gas float amid a myriad of stars in this image created by combining data from the NASA/ESA Hubble Spa...</Credits>
@@ -75869,6 +76368,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0532bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0532b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, A. Bolton (Harvard-Sm; The thin blue bull's-eye patterns in these eight Hubble Space Telescope images appear like neon signs floating over reddish-whit...</Credits>
@@ -75895,6 +76395,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0607aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0607a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, The Hubble Heritage T; This dramatic spiral galaxy is one of the latest viewed by NASA/ESA Hubble Space Telescope. Stunning details of the face-on spir...</Credits>
@@ -75921,6 +76422,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0607cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0607c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, The Hubble Heritage T; This image of NGC 1309 extends out to the physical edge of the ACS field. The image was taken in 2005. NGC 1309 is 100 million l...</Credits>
@@ -75947,6 +76449,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0613aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0613a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and The Hubble Herita; The yearly ritual of spring cleaning clears a house of dust as well as dust "bunnies", those pesky dust balls that frolic under ...</Credits>
@@ -75973,6 +76476,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0613bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0613b"
     Xcxstatus="queue:hubble"
   >
     <Credits>T.A. Rector/University of Alaska; This wide-field view of the star-forming region NGC 281 in the constellation Cassiopeia was taken with the WIYN 0.9-meter telesc...</Credits>
@@ -75999,6 +76503,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0624aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0624a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and The Hubble Herita; This is a unique NASA/ESA Hubble Space Telescope view of the disk galaxy NGC 5866 tilted nearly edge-on to our line-of-sight. Hu...</Credits>
@@ -76025,6 +76530,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0624bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0624b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and The Hubble Herita; NGC 5866 is an edge-on galaxy that is tilted to our line-of-sight. It is classified as an S0 lenticular, due to its flat stellar...</Credits>
@@ -76051,6 +76557,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0626aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0626a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and The Hubble Herita; The sharp eye of the Hubble Space Telescope's Advanced Camera for Surveys has uncovered more than 200 mammoth star clusters in t...</Credits>
@@ -76077,6 +76584,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0635aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0635a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; In the wake of Independence Day festivities surrounding the U.S. July 4th holiday, astronomers and image processors at the Space...</Credits>
@@ -76103,6 +76611,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0651cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0651c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA/CXC, B. McNamara (Universit; This image of galaxy cluster MS 0735.6+7421 was taken by the Chandra X-ray Observatory in November 2003. Diffuse, hot gas with a...</Credits>
@@ -76129,6 +76638,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0651dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0651d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and B. McNamara (Univ; This image of galaxy cluster MS 0735.6+7421 was taken with NASA/ESA Hubble Space Telescope in February 2006. The Advanced Camera...</Credits>
@@ -76155,6 +76665,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0703cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0703c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA/ESA and R. Humphreys (Unive; VY Canis Majoris is one of the largest known stars in the Universe in respect of size. The diameter of this red hypergiant is ab...</Credits>
@@ -76181,6 +76692,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0705bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0705b"
     Xcxstatus="queue:hubble"
   >
     <Credits>H. Boffin (FORS/VLT/ESO); This is a view of the barred spiral galaxy NGC 1313 taken with the the European Southern Observatory's Very Large Telescope (VLT...</Credits>
@@ -76207,6 +76719,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0705cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0705c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and A. Pellerin (STScI; This is a NASA/ESA Hubble Space Telescope image of the central region of the barred spiral galaxy NGC 1313. Hubble was used to r...</Credits>
@@ -76233,6 +76746,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0706eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0706e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, M. Davis (University ; This image, taken by NASA/ESA Hubble Space Telescope, represents a small section of a larger panoramic view of the heavens, wher...</Credits>
@@ -76259,6 +76773,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0708aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0708a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and The Hubble Herita; This image from the NASA/ESA Hubble Space Telescope shows the diverse collection of galaxies in the cluster Abell S0740 that is ...</Credits>
@@ -76285,6 +76800,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0733bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0733b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and The Hubble Herita; He 2-47...</Credits>
@@ -76311,6 +76827,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0733cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0733c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and The Hubble Herita; NGC 5315...</Credits>
@@ -76337,6 +76854,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0733dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0733d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and The Hubble Herita; IC 4593...</Credits>
@@ -76363,6 +76881,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0733eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0733e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and The Hubble Herita; NGC 5307...</Credits>
@@ -76389,6 +76908,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0737aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0737a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, D. Evans (Harvard-Smi; A powerful jet from a supermassive black hole is blasting a nearby galaxy, according to new data from NASA/ESA observatories. Th...</Credits>
@@ -76415,6 +76935,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0739bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0739b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and G. Canalizo (Univ; This image taken by Hubble shows the host galaxy of the quasar MC2 1635+119. The quasar sits in an indisturbed elliptical galaxy...</Credits>
@@ -76441,6 +76962,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0742bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0742b"
     Xcxstatus="queue:hubble"
   >
     <Credits>D. Verschatse (Antilhue Observat; Ground-based Image of Globular Cluster NGC 6397...</Credits>
@@ -76467,6 +76989,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0742cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0742c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and H. Richer (Univer; Hubble Space Telescope Image of Globular Cluster NGC 6397...</Credits>
@@ -76493,6 +77016,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0813aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0813a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; Probing a glowing bubble of gas and dust encircling a dying star, the NASA/ESA Hubble Space Telescope reveals a wealth of previo...</Credits>
@@ -76519,6 +77043,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0822aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0822a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; A delicate ribbon of gas floats eerily in our galaxy. A contrail from an alien spaceship? A jet from a black hole? Actually this...</Credits>
@@ -76545,6 +77070,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0825bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0825b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, DSS, and L. Bedin (ST; This is a ground-based telescopic view of NGC 6791, located 13,300 light-years away in the constellation Lyra....</Credits>
@@ -76571,6 +77097,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0825cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0825c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and L. Bedin (STScI); The full Hubble Advanced Camera for Surveys field is full of stars estimated to be 8 billion years old. Two background galaxies ...</Credits>
@@ -76597,6 +77124,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0825dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0825d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and L. Bedin (STScI); A blow up of view of a small region of the Advanced Camera for Surveys field reveals very faint white dwarfs. The hotter dwarfs ...</Credits>
@@ -76623,6 +77151,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0829bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0829b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, K. Sheth (Spitzer Sci; Barred spiral galaxy 3127341 is located 2.1 billion light-years away from Earth. The galaxy is part of a landmark study of more ...</Credits>
@@ -76649,6 +77178,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0829dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0829d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, K. Sheth (Spitzer Sci; Barred spiral galaxy 1161898 is located 5.3 billion light-years away from Earth.  The galaxy is part of a landmark study of more...</Credits>
@@ -76675,6 +77205,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0829eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0829e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, K. Sheth (Spitzer Sci; Barred spiral galaxy 2607238 is located 6.4 billion light-years away from Earth. The galaxy is part of a landmark study of more ...</Credits>
@@ -76701,6 +77232,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0833aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0833a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; The NASA/ESA Hubble Space Telescope has captured a rare alignment between two spiral galaxies. The outer rim of a small, foregro...</Credits>
@@ -76727,6 +77259,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0834aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0834a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and The Hubble Herita; Located in the Southern Hemisphere, NGC 3324 is at the northwest corner of the Carina Nebula (NGC 3372), home of the Keyhole Neb...</Credits>
@@ -76753,6 +77286,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0838aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0838a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit for Advanced Camera Data:; This image taken by NASA/ESA Hubble Space Telescope showcases the brilliant core of one of the most active galaxies in our local...</Credits>
@@ -76779,6 +77313,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0840aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0840a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; Like a whirl of shiny flakes sparkling in a snow globe, the NASA/ESA Hubble Space Telescope catches an instantaneous glimpse of ...</Credits>
@@ -76805,6 +77340,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0840dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0840d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; Hubble catches an instantaneous glimpse of many hundreds of thousands of stars moving about in the globular cluster M13, one of ...</Credits>
@@ -76831,6 +77367,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0902aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0902a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and Q.D. Wang (Univers; This composite colour infrared image of the centre of our Milky Way galaxy reveals a new population of massive stars and new det...</Credits>
@@ -76857,6 +77394,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0902bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0902b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and Q.D. Wang (Univers; This NASA/ESA Hubble Space Telescope infrared mosaic image represents the sharpest survey of the galactic centre to date. It rev...</Credits>
@@ -76883,6 +77421,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0907cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0907c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, CXC, SSC and STScI; The red colour is Spitzer's view in infared light. Most of this  light comes the galaxy's delicate dust lanes. Such dense dust  ...</Credits>
@@ -76909,6 +77448,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0907dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0907d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, K. Kuntz (JHU), F. Br; The yellow colour is Hubble's view in visible light. Most of this light comes from stars, and they trace the same spiral structu...</Credits>
@@ -76935,6 +77475,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0907eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0907e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, CXC, and K. Kuntz (JHU); The blue colour shows Chandra's view in X-ray light. Sources of X-rays include million-degree gas, exploded stars, and material ...</Credits>
@@ -76961,6 +77502,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0907gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0907g"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, Jet Propulsion Laboratory/; The galaxy Messier 101 is a swirling spiral of stars, gas, and dust. Messier 101 is nearly twice as wide as our Milky Way galaxy...</Credits>
@@ -76987,6 +77529,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0907iL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0907i"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, CXC and K. Kuntz (JHU); Chandra's image of Messier 101, taken in X-ray light, shows the high-energy features of this spiral galaxy. X-rays are generally...</Credits>
@@ -77013,6 +77556,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0908bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0908b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and A. Riess (STScI/JH; This is a NASA/ESA Hubble Space Telescope photo of the spiral galaxy NGC 3021. This was one of several hosts of recent Type Ia s...</Credits>
@@ -77039,6 +77583,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0908cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0908c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and A. Riess (STScI/JH; This image is part of a montage of images of the spiral galaxy NGC 3021 taken by the NASA/ESA Hubble Space Telescope. Hubble mad...</Credits>
@@ -77065,6 +77610,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0908dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0908d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and A. Riess (STScI/JH; This image is part of a montage of images of the spiral galaxy NGC 3021 taken by the NASA/ESA Hubble Space Telescope. Hubble mad...</Credits>
@@ -77091,6 +77637,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0908eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0908e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and A. Riess (STScI/JH; This image is part of a montage of images of the spiral galaxy NGC 3021 taken by the NASA/ESA Hubble Space Telescope. Hubble mad...</Credits>
@@ -77117,6 +77664,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0908fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0908f"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and A. Riess (STScI/JH; This image is part of a montage of images of the spiral galaxy NGC 3021 taken by the NASA/ESA Hubble Space Telescope. Hubble mad...</Credits>
@@ -77143,6 +77691,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0916bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0916b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and J. Madrid (McMaste; Image taken on 17 May 1999....</Credits>
@@ -77169,6 +77718,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0916cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0916c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and J. Madrid (McMaste; Image taken on 17 July 2002....</Credits>
@@ -77195,6 +77745,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0916dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0916d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and J. Madrid (McMaste; Image taken on 27 February 2002....</Credits>
@@ -77221,6 +77772,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0916eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0916e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and J. Madrid (McMaste; Image taken on 17 April 2003....</Credits>
@@ -77247,6 +77799,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0916fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0916f"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and J. Madrid (McMaste; Image taken on 9 May 2005....</Credits>
@@ -77273,6 +77826,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0916gL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0916g"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and J. Madrid (McMaste; Image taken on 28 November 2006....</Credits>
@@ -77299,6 +77853,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0919bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0919b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and K. McQuinn (Univer; This image, taken by the NASA/ESA Hubble Space Telescope, shows myriad stars residing in the central region of the dwarf galaxy ...</Credits>
@@ -77325,6 +77880,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0919cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0919c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and K. McQuinn (Univer; This image, taken by the NASA/ESA Hubble Space Telescope, shows myriad stars residing in the central regions of the dwarf galaxy...</Credits>
@@ -77351,6 +77907,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0919dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0919d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and K. McQuinn (Univer; This image, taken by the NASA/ESA Hubble Space Telescope, shows myriad stars residing in the central regions of the dwarf galaxy...</Credits>
@@ -77377,6 +77934,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0921aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0921a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; The Hubble community bids farewell to the soon-to-be decommissioned Wide Field Planetary Camera 2 (WFPC2) onboard the Hubble Spa...</Credits>
@@ -77403,6 +77961,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0928bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0928b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, SSC, CXC and STScI; In celebration of the International Year of Astronomy 2009, the NASA/ESA Hubble Space Telescope and its companion Great Observat...</Credits>
@@ -77429,6 +77988,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0928dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0928d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, JPL-Caltech, E. Churchwell; The Spitzer Space Telescope's infrared-light observations provide a detailed and spectacular view of the galactic centre region....</Credits>
@@ -77455,6 +78015,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0928eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0928e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Q.D. Wang (Univ. of M; Although best known for its visible-light images, the Hubble Space Telescope also observes over a limited range of infrared ligh...</Credits>
@@ -77481,6 +78042,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0928fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0928f"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, CXC, D. Wang (University o; X-rays detected by the Chandra X-ray Observatory expose a wealth of exotic objects and high-energy features. In this image, pink...</Credits>
@@ -77507,6 +78069,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0929bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0929b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; The spectacular new camera installed on the NASA/ESA Hubble Space Telescope during Servicing Mission 4 in May has delivered the ...</Credits>
@@ -77533,6 +78096,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0929cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0929c"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESO; This is an image of the galaxy M83, taken by the European Southern Observatory's Wide Field Imager on the ESO/MPG 2.2-metre tele...</Credits>
@@ -77559,6 +78123,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0929eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0929e"
     Xcxstatus="queue:hubble"
   >
     <Credits>Digitized Sky Survey (DSS), STScI/AURA, Palomar/Caltech and UKSTU/AAO; This is a Digitized Sky Survey (DSS) image of the field around M83. This image was used in a zoom animation highlighting the M83...</Credits>
@@ -77585,6 +78150,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0932aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0932a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and F. Paresce (INAF-; Just in time for the holidays: a Hubble Space Telescope picture postcard of hundreds of brilliant blue stars wreathed by warm, g...</Credits>
@@ -77611,6 +78177,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo0932fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo0932f"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and F. Paresce (INAF-; The massive, young stellar grouping, called R136, is only a few million years old and resides in the 30 Doradus Nebula, a turbul...</Credits>
@@ -77637,6 +78204,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1000aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1000a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; A bluish-white spiral galaxy hangs delicately in the cold vacuum of space. Known as NGC 1376, this snowflake-shaped beauty was o...</Credits>
@@ -77663,6 +78231,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1005aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1005a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and J. Dalcanton and ; NGC 2976 does not look like a typical spiral galaxy, as this  NASA/ESA Hubble Space Telescope image shows. In this view of the o...</Credits>
@@ -77714,6 +78283,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1008aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1008a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, S. Gallagher (The Uni; These four dwarf galaxies waited billions of years to come together, setting off a fireworks show as thousands of new star clust...</Credits>
@@ -77740,6 +78310,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1008bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1008b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, J. English (Universit; These four dwarf galaxies waited billions of years to come together, setting off a fireworks show as thousands of new star clust...</Credits>
@@ -77766,6 +78337,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1019bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1019b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, O. Gnedin (University; This NASA/ESA Hubble Space Telescope image shows the hypervelocity star that was kicked out of the centre of our Milky Way galax...</Credits>
@@ -77792,6 +78364,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1022aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1022a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, R. O'Connell (Univers; Like a 4th of July fireworks display, a young, glittering collection of stars looks like an aerial burst. The cluster is surroun...</Credits>
@@ -77818,6 +78391,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1024aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1024a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; A long-exposure Hubble Space Telescope image shows a majestic face-on spiral galaxy located deep within the Coma Cluster of gala...</Credits>
@@ -77844,6 +78418,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1029aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1029a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; Enjoying a frozen treat on a hot summer day can leave a sticky mess as it melts in the Sun and deforms. In the cold vacuum of sp...</Credits>
@@ -77870,6 +78445,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1030aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1030a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, K. France (University; This image shows the entire region around supernova 1987A. The most prominent feature in the image is a ring with dozens of brig...</Credits>
@@ -77896,6 +78472,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1036aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1036a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and the Hubble Herita; Though the universe is chock full of spiral-shaped galaxies, no two look exactly the same. This face-on spiral galaxy, called NG...</Credits>
@@ -77922,6 +78499,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1037aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1037a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, D. Coe (NASA Jet Prop; This NASA/ESA Hubble Space Telescope image shows the distribution of dark matter in the centre of the giant galaxy cluster Abell...</Credits>
@@ -77948,6 +78526,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1038bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1038b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, R.M. Crockett (Univer; Elliptical galaxy NGC 4150....</Credits>
@@ -77974,6 +78553,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1038cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1038c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, R.M. Crockett (Univer; Core of elliptical galaxy NGC 4150 (detailed view)....</Credits>
@@ -78000,6 +78580,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1116bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1116b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, W. Clarkson (Indiana ; Hubble ACS SWEEPS field....</Credits>
@@ -78026,6 +78607,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1130bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1130b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and J. Lotz (STScI); Merging galaxies — 2.4 billion light-years from Earth....</Credits>
@@ -78052,6 +78634,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1130cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1130c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and J. Lotz (STScI); Merging galaxies — 3 billion light-years from Earth....</Credits>
@@ -78078,6 +78661,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1130dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1130d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and J. Lotz (STScI); Merging galaxies — 5.3 billion light-years from Earth....</Credits>
@@ -78104,6 +78688,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1130eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1130e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and J. Lotz (STScI); Merging galaxies — 6.2 billion light-years from Earth....</Credits>
@@ -78130,6 +78715,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1212eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1212e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NOAO, AURA, NSF, and N. Smith (U; This image shows a giant star-forming region in the southern sky known as the Carina Nebula and combines the light from three di...</Credits>
@@ -78156,6 +78742,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1247aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1247a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, S. Baum and C. O'Dea ; Spectacular jets powered by the gravitational energy of a supermassive black hole in the core of the elliptical galaxy Hercules ...</Credits>
@@ -78182,6 +78769,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1308aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1308a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Digitized Sky Survey (DSS), STSc; This is a Digitized Sky Survey image of the oldest star with a well-determined age in our galaxy. The ageing star, catalogued as...</Credits>
@@ -78208,6 +78796,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1432bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1432b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, The Hubble Heritage T; This image shows spiral galaxy NGC 1309. Astronomers have observed a rare type Iax supernova in the outskirts of the galaxy. The...</Credits>
@@ -78234,6 +78823,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1432cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1432c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, C. McCully and S. Jha; These Hubble data from 2005 and 2006 show the progenitor system for Supernova 2012Z, a supernova in the outskirts of spiral gala...</Credits>
@@ -78260,6 +78850,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1432dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1432d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, C. McCully and S. Jha; This image shows Supernova 2012Z, found in the outskirts of the spiral galaxy NGC 1309. The stellar blast is a member of a uniqu...</Credits>
@@ -78286,6 +78877,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1443aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1443a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, M. Montes (IAC), and ; The massive galaxy cluster Abell 2744, nicknamed Pandora's Cluster, takes on a ghostly look in this NASA/ESA Hubble Space Telesc...</Credits>
@@ -78312,6 +78904,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1448jL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1448j"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and P. Sell (Texas Te; This NASA/ESA Hubble Space Telescope image of the galaxy J1613+2834 shows it is undergoing a firestorm of star birth, as shown b...</Credits>
@@ -78338,6 +78931,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1448kL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1448k"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and P. Sell (Texas Te; This NASA/ESA Hubble Space Telescope image of the galaxy J1634+4619 shows it is undergoing a firestorm of star birth, as shown b...</Credits>
@@ -78364,6 +78958,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1448lL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1448l"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and P. Sell (Texas Te; This NASA/ESA Hubble Space Telescope image of the galaxy J1713+2817 shows it is undergoing a firestorm of star birth, as shown b...</Credits>
@@ -78390,6 +78985,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1521bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1521b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and J. Mauerhan (Univ; This visible-light image taken by NASA's Hubble Space Telescope reveals a pancake-shaped disk of gas around an extremely bright ...</Credits>
@@ -78416,6 +79012,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1531bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1531b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage T; This Hubble Space Telescope image reveals a bright starlike glow in the center of the interacting galaxy Markarian 231, the near...</Credits>
@@ -78442,6 +79039,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1629bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1629b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and E. Tollerud (STSc; This image shows the galaxy Pisces A. The bright object at the top of the image is a distant background galaxy. Other distant ba...</Credits>
@@ -78468,6 +79066,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1629cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1629c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and E. Tollerud (STS; This image shows the galaxy Pisces B. The bright object with the diffraction spikes below left of centre is a foreground star in...</Credits>
@@ -78494,6 +79093,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1727bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1727b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and T. Johnson (Unive; The galaxy cluster shown here, SDSS J1110+6459, was discovered as part of the Sloan Giant Arcs Survey. It is located about 6 bil...</Credits>
@@ -78520,6 +79120,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1733aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1733a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and B. Sunnquist and ; Some asteroids from within our Solar System have photobombed deep images of the Universe taken by the NASA/ESA Hubble Space Tele...</Credits>
@@ -78546,6 +79147,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1733bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1733b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and B. Sunnquist and ; As if this Hubble Space Telescope picture isn't cluttered enough with myriad galaxies, nearby asteroids photobomb the image, the...</Credits>
@@ -78572,6 +79174,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo1801aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo1801a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and T. Brown (STScI),; This image from the NASA/ESA Hubble Space Telescope shows a sparkling jewel box full of stars captured the heart of our Milky Wa...</Credits>
@@ -78598,6 +79201,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9009cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9009c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA/ESA; Computer processing of the HST image sharpens the appearance of the cluster by subtracting stellar halos introduced by spherical...</Credits>
@@ -78624,6 +79228,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9009dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9009d"
     Xcxstatus="queue:hubble"
   >
     <Credits>George Meylan and ESO; This is a 2.7 X 2.7 arc minute view of star cluster R136 as seen from a ground-based telescope under exceptional observing condi...</Credits>
@@ -78650,6 +79255,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9009eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9009e"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA/ESA; This unprocessed image, taken with NASA/ESA Hubble Space Telescope, yields stellar diameters of 0.1 arc second, allowing many mo...</Credits>
@@ -78676,6 +79282,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9212aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9212a"
     Xcxstatus="queue:hubble"
   >
     <Credits>S. Heap, NASA/ESA/Goddard Space ; This photograph from the NASA/ESA Hubble Space Telescope presents the first clear view of one of the hottest known stars, the ce...</Credits>
@@ -78702,6 +79309,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9216bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9216b"
     Xcxstatus="queue:hubble"
   >
     <Credits>E. Shaya, D. Dowling/U. of Maryl; An image of the central part of the ultra-luminuous infrared galaxy Arp 220 taken with the WFPC on the Hubble Space Telescope. H...</Credits>
@@ -78728,6 +79336,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9227aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9227a"
     Xcxstatus="queue:hubble"
   >
     <Credits>N/A; This is a Hubble Space Telescope (HST) image of the core of galaxy NGC 4261....</Credits>
@@ -78754,6 +79363,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9229aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9229a"
     Xcxstatus="queue:hubble"
   >
     <Credits>C.R. O'Dell (Rice University), a; A NASA Hubble Space Telescope "true color" mosaic image of a small portion of the Orion  Nebula, taken the Wide Field and Planet...</Credits>
@@ -78780,6 +79390,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9404bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9404b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA/ESA, STScI; The image shows the Star Cluster R136 in 30 Doradus....</Credits>
@@ -78806,6 +79417,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9404cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9404c"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, STScI, ESA/Hubble; The star cluster R136 is a cluster of young, bright stars in 30 Doradus. The image of the cluster was obtained using the second ...</Credits>
@@ -78832,6 +79444,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9425aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9425a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Alan Dressier (Carnegie Institut; This NASA/ESA Hubble Space Telescope (HST) image of the central portion of a remote cluster of galaxies (CL 0939+4713) as it loo...</Credits>
@@ -78858,6 +79471,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9451aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9451a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Dwingeloo Obscured Galaxy Survey; This visual light image of a newly discovered galaxy called "Dwingeloo 1," was taken with the Isaac Newton Telescope on La Palma...</Credits>
@@ -78884,6 +79498,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9544aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9544a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Jeff Hester and Paul Scowen (Ari; Undersea coral? Enchanted castles? Space serpents? These eerie, dark pillar-like structures are actually columns of cool interst...</Credits>
@@ -78910,6 +79525,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9617bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9617b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Nino Panagia ( Space Telescope S; The NASA/ESA Hubble Space Telescope has snapped a view of several star generations in the central region of the Whirlpool Galaxy...</Credits>
@@ -78936,6 +79552,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="0"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9635b2L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9635b2"
     Xcxstatus="queue:hubble"
   >
     <Credits>John Bahcall (Institute for Adva; In this image astronomers can thoroughly examine the quasar's nucleus....</Credits>
@@ -78962,6 +79579,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9638aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9638a"
     Xcxstatus="queue:hubble"
   >
     <Credits>A. Caulet (ST-ECF, ESA) and NASA; This Hubble Space Telescope (HST) image reveals a pair of one-half light-year long interstellar 'twisters' -- eerie funnels and ...</Credits>
@@ -78988,6 +79606,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9638bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9638b"
     Xcxstatus="queue:hubble"
   >
     <Credits>A. Caulet (ST-ECF, ESA) and NASA; This Hubble Space Telescope (HST) image reveals a pair of one-half light-year long interstellar 'twisters' - eerie funnels and t...</Credits>
@@ -79014,6 +79633,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9711bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9711b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Rodger Thompson, Marcia Rieke, G; The Egg Nebula, also known as CRL 2688, is shown as it appears in visible light with the Hubble Space Telescope's Wide Field and...</Credits>
@@ -79040,6 +79660,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="0"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9711cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9711c"
     Xcxstatus="queue:hubble"
   >
     <Credits>Rodger Thompson, Marcia Rieke, G; The Egg Nebula, also known as CRL 2688, is shown as it appears in infrared light with Hubble's Near Infrared Camera and Multi-Ob...</Credits>
@@ -79066,6 +79687,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9734pL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9734p"
     Xcxstatus="queue:hubble"
   >
     <Credits>Francois Schweizer (CIW/DTM); The spiral galaxies NGC 4038 and NGC 4039 form together the famous Antennae Galaxies, named after  the long tails of gas, dust a...</Credits>
@@ -79092,6 +79714,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9734qL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9734q"
     Xcxstatus="queue:hubble"
   >
     <Credits>Francois Schweizer (CIW/DTM); NGC 7252 is the resulting objects of two galaxies colliding with each  others a billion years ago. Because of its loop-like stur...</Credits>
@@ -79118,6 +79741,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9734uL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9734u"
     Xcxstatus="queue:hubble"
   >
     <Credits>B. Whitmore (STScI); In NGC 7252, where we had discovered ~40 globular clusters with the Hubble before its refurbishment, we have recently discovered...</Credits>
@@ -79144,6 +79768,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9734vL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9734v"
     Xcxstatus="queue:hubble"
   >
     <Credits>B. Whitmore (STScI); In NGC 3921, we have discovered over 100 new young clusters. There are two reasons to believe that all these young clusters form...</Credits>
@@ -79170,6 +79795,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9734wL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9734w"
     Xcxstatus="queue:hubble"
   >
     <Credits>Brad Whitmore (STScI); Includes an image made in red light from hydrogen gas....</Credits>
@@ -79196,6 +79822,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c10L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9738c,esahubble|opo9738c1,esahubble|opo9738c10"
     Xcxstatus="queue:hubble"
   >
     <Credits>Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble Gallery of Planetary Nebulae....</Credits>
@@ -79222,6 +79849,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c11L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9738c11"
     Xcxstatus="queue:hubble"
   >
     <Credits>Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble Gallery of Planetary Nebulae....</Credits>
@@ -79248,6 +79876,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c12L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9738c12"
     Xcxstatus="queue:hubble"
   >
     <Credits>Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble Gallery of Planetary Nebulae....</Credits>
@@ -79274,6 +79903,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c13L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9738c13"
     Xcxstatus="queue:hubble"
   >
     <Credits>Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble Gallery of Planetary Nebulae....</Credits>
@@ -79300,6 +79930,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c14L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9738c14"
     Xcxstatus="queue:hubble"
   >
     <Credits>Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble Gallery of Planetary Nebulae....</Credits>
@@ -79326,6 +79957,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c15L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9738c15"
     Xcxstatus="queue:hubble"
   >
     <Credits>Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble Gallery of Planetary Nebulae....</Credits>
@@ -79352,6 +79984,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c17L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9738c17"
     Xcxstatus="queue:hubble"
   >
     <Credits>Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble Gallery of Planetary Nebulae....</Credits>
@@ -79378,6 +80011,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="0"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c19L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9738c19"
     Xcxstatus="queue:hubble"
   >
     <Credits>Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble Gallery of Planetary Nebulae....</Credits>
@@ -79430,6 +80064,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c21L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9738c2,esahubble|opo9738c21"
     Xcxstatus="queue:hubble"
   >
     <Credits>Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble Gallery of Planetary Nebulae....</Credits>
@@ -79456,6 +80091,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="0"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c22L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9738c22"
     Xcxstatus="queue:hubble"
   >
     <Credits>Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble Gallery of Planetary Nebulae....</Credits>
@@ -79482,6 +80118,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c3L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9738c3"
     Xcxstatus="queue:hubble"
   >
     <Credits>Bruce Balick and Jason Alexander; This image is a part of the Hubble Gallery of Planetary Nebulae....</Credits>
@@ -79508,6 +80145,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c4L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9738c4"
     Xcxstatus="queue:hubble"
   >
     <Credits>Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble Gallery of Planetary Nebulae....</Credits>
@@ -79534,6 +80172,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c5L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9738c5"
     Xcxstatus="queue:hubble"
   >
     <Credits>Bruce Balick (University of Wash; This image is a part of the Hubble Gallery of Planetary Nebulae....</Credits>
@@ -79560,6 +80199,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c6L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9738c6"
     Xcxstatus="queue:hubble"
   >
     <Credits>Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble Gallery of Planetary Nebulae....</Credits>
@@ -79586,6 +80226,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="0"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c7L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9738c7"
     Xcxstatus="queue:hubble"
   >
     <Credits>Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble Gallery of Planetary Nebulae....</Credits>
@@ -79612,6 +80253,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9738c9L{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9738c9"
     Xcxstatus="queue:hubble"
   >
     <Credits>Howard Bond (ST ScI) and NASA/ES; This image is a part of the Hubble Gallery of Planetary Nebulae....</Credits>
@@ -79638,6 +80280,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9808fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9808f"
     Xcxstatus="queue:hubble"
   >
     <Credits>Peter Garnavich (Harvard-Smithso; Latest Hubble image shows knot in ring significantly brighter....</Credits>
@@ -79664,6 +80307,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9815bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9815b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Matt Bobrowsky (Orbital Sciences; This Wide Field and Planetary Camera 2image captures the infancy of the Stingray nebula (Hen-1357), the youngest known planetary...</Credits>
@@ -79690,6 +80334,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9816aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9816a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Rebecca Elson and Richard Sword,; A dazzling 'jewel-box' collection of over 20, 000 stars can be seen in crystal clarity in this NASA/ESA Hubble Space Telescope i...</Credits>
@@ -79716,6 +80361,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9821fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9821f"
     Xcxstatus="queue:hubble"
   >
     <Credits>G. Fritz Benedict, Andrew Howell; The two spiral arms outside the ring are probably unrelated to the dust lanes, and seem to contain very little dust or gas. The ...</Credits>
@@ -79742,6 +80388,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9836fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9836f"
     Xcxstatus="queue:hubble"
   >
     <Credits>Robert Rubin and Christopher Ort; A combination of two composite images of NGC 6210. The outer, mostly green portion represents the light of doubly ionized oxygen...</Credits>
@@ -79768,6 +80415,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9838eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9838e"
     Xcxstatus="queue:hubble"
   >
     <Credits>Yves Grosdidier (University of M; The massive, hot central star is known as a Wolf-Rayet star. This extremely rare and short-lived class of super-hot star is goin...</Credits>
@@ -79794,6 +80442,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9841kL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9841k"
     Xcxstatus="queue:hubble"
   >
     <Credits>STScI and the Anglo-Australian T; Location of the HDF South Sky Survey Image with overlay...</Credits>
@@ -79820,6 +80469,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9841nL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9841n"
     Xcxstatus="queue:hubble"
   >
     <Credits>J. Gardner (NOAO/GSFC), Cerro To; After the great success of the origninal Hubble Deep Field, later called Hubble Deep Field North (HDF-N), an identical project f...</Credits>
@@ -79846,6 +80496,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9905iL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9905i"
     Xcxstatus="queue:hubble"
   >
     <Credits>John Krist (STScI) and the WFPC2; This wide-angle image (17,000 AU from top to bottom) shows the region around Haro 6-5b, which is located at the center of the fi...</Credits>
@@ -79872,6 +80523,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9910bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9910b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Torsten Boeker,  Space Telescope; Astronomers have used the NASA/ESA Hubble Space Telescope to produce an infrared 'photo essay' of spiral galaxies. By penetratin...</Credits>
@@ -79898,6 +80550,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9910cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9910c"
     Xcxstatus="queue:hubble"
   >
     <Credits>Torsten Boeker,  Space Telescope; Astronomers have used the NASA/ESA Hubble Space Telescope to produce an infrared 'photo essay' of spiral galaxies. By penetratin...</Credits>
@@ -79924,6 +80577,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-opo9923bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|opo9923b"
     Xcxstatus="queue:hubble"
   >
     <Credits>M. Heydari-Malayeri (Paris Obser; A NASA/ESA Hubble Space Telescope view of a turbulent cauldron of starbirth, called N159, taking place 170,000 light-years away ...</Credits>
@@ -79950,6 +80604,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1001aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1001a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; As the first in the new weekly series of spectacular images from the NASA/ESA Hubble Space Telescope, the Hubble Picture of the ...</Credits>
@@ -79976,6 +80631,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1002aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1002a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and NASA; The richly textured spiral galaxy NGC 2082 is found about 60 million light-years away in the constellation of Dorado (the Swordf...</Credits>
@@ -80002,6 +80658,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1003aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1003a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and NASA.; This striking Hubble image of the planetary nebula IC 4634 reveals two shining, S-shaped ejections from a dying star. This star,...</Credits>
@@ -80028,6 +80685,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1004aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1004a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and NASA; That galaxies come in very different shapes and sizes is dramatically demonstrated by this striking Hubble image of the Hickson ...</Credits>
@@ -80054,6 +80712,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1006aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1006a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and NASA; The bright galaxy NGC 3810 demonstrates classical spiral structure in this very detailed image from Hubble. The bright central r...</Credits>
@@ -80080,6 +80739,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1007aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1007a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and NASA; The star HD 44179 is surrounded by an extraordinary structure known as the Red Rectangle. It acquired its moniker because of its...</Credits>
@@ -80106,6 +80766,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1008aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1008a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, R. Sahai and NASA; The little-known nebula IRAS 05437+2502 billows out among the bright stars and dark dust clouds that surround it in this strikin...</Credits>
@@ -80132,6 +80793,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1009aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1009a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and NASA; The small spiral galaxy NGC 2758 is captured in great detail in this image from the Advanced Camera for Surveys (ACS) on the NAS...</Credits>
@@ -80158,6 +80820,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1010aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1010a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and NASA; The Hubble Space Telescope captured this beautiful image of NGC 6326, a planetary nebula with glowing wisps of outpouring gas th...</Credits>
@@ -80184,6 +80847,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1011aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1011a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and NASA; This image, taken by the Advanced Camera for Surveys on the Hubble Space Telescope, shows the core of the great globular cluster...</Credits>
@@ -80210,6 +80874,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1012aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1012a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and NASA.; This Hubble Space Telescope picture captures a brief but beautiful phase late in the life of a star. The curious cloud around th...</Credits>
@@ -80236,6 +80901,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1013aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1013a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and NASA; This spectacular NASA/ESA Hubble Space Telescope picture shows NGC 1872, a rich cluster of thousands of stars lying in our small...</Credits>
@@ -80262,6 +80928,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1014aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1014a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and NASA; This NASA/ESA Hubble Space Telescope picture depicts the galaxy NGC 1533 in the southern constellation of Dorado (the Dolphin-fi...</Credits>
@@ -80288,6 +80955,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1015aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1015a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and NASA; This dramatic image from the NASA/ESA Hubble Space Telescope shows the planetary nebula NGC 3918, a brilliant cloud of colourful...</Credits>
@@ -80314,6 +80982,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1016aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1016a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble/ESO and NASA; Haro 11 appears to shine gently amid clouds of gas and dust, but this placid facade belies the monumental rate of star formation...</Credits>
@@ -80340,6 +81009,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1017aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1017a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA and H. Ebeling.; At first glance, the scatter of pale dots on this NASA/ESA Hubble Space Telescope image looks like a snowstorm in the night sky....</Credits>
@@ -80366,6 +81036,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1018aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1018a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and NASA; This spectacular NASA/ESA Hubble Space Telescope image shows a bright scattering of stars in the small constellation of Sagitta ...</Credits>
@@ -80392,6 +81063,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1019aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1019a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and NASA ; A billowing cloud of hydrogen in the Triangulum galaxy (Messier 33), about 2.7 million light-years away from Earth, glows with t...</Credits>
@@ -80418,6 +81090,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1020aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1020a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/NASA &amp; R. Sahai; This remarkable picture from the Advanced Camera for Surveys on the NASA/ESA Hubble Space Telescope shows one of the most perfec...</Credits>
@@ -80444,6 +81117,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1021aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1021a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; Astronomers are used to encountering challenges in their work, but studying the prosaically-named galaxy PGC 39058 proves more d...</Credits>
@@ -80470,6 +81144,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1022aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1022a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and NASA﻿; The NASA/ESA Hubble Space Telescope snapped this striking image of an aging star whose outer layers of gas have blown off into s...</Credits>
@@ -80496,6 +81171,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1023aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1023a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This bright spray of stars in the small but evocative constellation of Delphinus (the Dolphin) is the globular cluster NGC 6934....</Credits>
@@ -80522,6 +81198,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1024aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1024a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: ESA/Hubble &amp; NASA; The keen eye of the NASA/ESA Hubble Space Telescope has often peered deeply into the Orion Nebula to see the processes occurring...</Credits>
@@ -80548,6 +81225,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1025aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1025a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and NASA; The beautiful spiral galaxy NGC 406 was discovered in 1834 by John Herschel and is here imaged in great detail by the NASA/ESA H...</Credits>
@@ -80574,6 +81252,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1026aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1026a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and NASA; The NASA/ESA Hubble Space Telescope has taken a striking high resolution image of the curious planetary nebula NGC 6210. Located...</Credits>
@@ -80600,6 +81279,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1027aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1027a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The NASA/ESA Hubble Space Telescope has turned its sharp eye towards a tight collection of stars, first seen 174 years ago. The ...</Credits>
@@ -80626,6 +81306,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1028aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1028a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; At first glance NGC 3077 looks like a typical, relatively peaceful elliptical galaxy. However, as this NASA/ESA Hubble Space Tel...</Credits>
@@ -80652,6 +81333,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1029aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1029a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The NASA/ESA Hubble Space Telescope has imaged a striking galaxy called NGC 4452, which appears to lie exactly edge-on as seen f...</Credits>
@@ -80678,6 +81360,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1030aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1030a"
     Xcxstatus="queue:hubble"
   >
     <Credits> ESA/Hubble &amp; NASA; The NASA/ESA Hubble Space Telescope has used its Advanced Camera for Surveys to peer closely at the strange cloud of gas and dus...</Credits>
@@ -80704,6 +81387,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1031aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1031a"
     Xcxstatus="queue:hubble"
   >
     <Credits> ESA/Hubble and NASA; Smaller, dimmer galaxies appear to flit like moths around a radiant street light in this image captured by the NASA/ESA Hubble S...</Credits>
@@ -80730,6 +81414,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1032aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1032a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and NASA; Fresh starbirth infuses the galaxy NGC 6503 with a vital pink glow in this image from the NASA/ESA Hubble Space Telescope. This ...</Credits>
@@ -80756,6 +81441,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1033aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1033a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The star cluster is very bright and was discovered in the mid-eighteenth century. The nebula, however, is much more elusive and ...</Credits>
@@ -80782,6 +81468,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1034aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1034a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The NASA/ESA Hubble Space Telescope has turned its eagle eye to the planetary nebula NGC 6572, a very bright example of these st...</Credits>
@@ -80808,6 +81495,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1035aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1035a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The galaxy captured in this image, called UGC 12158, certainly isn’t camera-shy: this spiral stunner is posing face-on to the NA...</Credits>
@@ -80834,6 +81522,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1036aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1036a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; An image of the Cartwheel Galaxy taken with the NASA/ESA Hubble Space Telescope has been reprocessed using the latest techniques...</Credits>
@@ -80860,6 +81549,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1101aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1101a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; A spectacular section of the well-known Eagle Nebula has been targeted by the NASA/ESA Hubble Space Telescope. This collection o...</Credits>
@@ -80886,6 +81576,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1102aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1102a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; Astronomers have used the NASA/ESA Hubble Space Telescope to image the tiny planetary nebula NGC 6886. These celestial objects s...</Credits>
@@ -80912,6 +81603,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1103aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1103a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The spiral galaxy NGC 1345 and its loose and ragged arms dominate this rich image from the NASA/ESA Hubble Space Telescope. It i...</Credits>
@@ -80938,6 +81630,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1104aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1104a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The NASA/ESA Hubble Space Telescope has captured a clear view of the unusual globular cluster Palomar 1, whose youthful beauty i...</Credits>
@@ -80964,6 +81657,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1105aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1105a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; Hubble's Advanced Camera for Surveys has captured this moment in the ever-changing life of a spiral galaxy called IC 391. Althou...</Credits>
@@ -80990,6 +81684,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1107aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1107a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The dazzling stars in Messier 15 look fresh and new in this image from the NASA/Hubble Space Telescope, but they are actually al...</Credits>
@@ -81016,6 +81711,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1108aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1108a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The NASA/ESA Hubble Space Telescope has produced this finely detailed image of the beautiful spiral galaxy NGC 6384. This galaxy...</Credits>
@@ -81042,6 +81738,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1109aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1109a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The NASA/ESA Hubble Space Telescope has taken a close-up view of an outer part of the Orion Nebula’s little brother, Messier 43....</Credits>
@@ -81068,6 +81765,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1110aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1110a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The strange and irregular bundle of jets and clouds in this curious image from the NASA/ESA Hubble Space Telescope is the result...</Credits>
@@ -81094,6 +81792,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1111aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1111a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA ; Most of the rich globular star clusters that orbit the Milky Way have cores that are tightly packed with stars, but NGC 288 is o...</Credits>
@@ -81120,6 +81819,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1112aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1112a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, A. Riess (STScI/JHU),; This view from the NASA/ESA Hubble Space Telescope shows the beautiful spiral galaxy NGC 5584. This galaxy has played a key role...</Credits>
@@ -81146,6 +81846,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1113aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1113a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA ; The high concentration of stars within globular clusters, like Messier 12, shown here in an image from the NASA/ESA Hubble Space...</Credits>
@@ -81172,6 +81873,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1114aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1114a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The NASA/ESA Hubble Space Telescope has captured a planetary nebula with unconventional good looks. Planetary nebulae signal the...</Credits>
@@ -81198,6 +81900,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1115aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1115a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; Astronomers have used the NASA/ESA Hubble Space Telescope to study the young open star cluster IC 1590, which is found within th...</Credits>
@@ -81224,6 +81927,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1116aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1116a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The NASA/ESA Hubble Space Telescope usually works as a solo artist to capture awe-inspiring images of the distant Universe. For ...</Credits>
@@ -81250,6 +81954,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1117aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1117a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA ; Galaxies come in all sorts of shapes and sizes, with most being classed as either elliptical or spiral. However, some fall into ...</Credits>
@@ -81276,6 +81981,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1118aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1118a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA ; The globular cluster Messier 5, shown here in this NASA/ESA Hubble Space Telescope image, is one of the oldest belonging to the ...</Credits>
@@ -81302,6 +82008,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1119aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1119a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This NASA/ESA Hubble Space Telescope image shows the edge-on profile of the slender spiral galaxy NGC 5775. Although the spiral ...</Credits>
@@ -81328,6 +82035,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1120aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1120a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA ; Like a Dali masterpiece, this image of Messier 8 from the NASA/ESA Hubble Space Telescope is both intensely colourful and distin...</Credits>
@@ -81354,6 +82062,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1121aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1121a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA ; Deep within the Milky Way lies the ancient globular cluster Terzan 5. This NASA/ESA Hubble Space Telescope image shows the clust...</Credits>
@@ -81380,6 +82089,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1122aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1122a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The NASA/ESA Hubble Space Telescope is renowned for its breathtaking images and this snapshot of NGC 634 is definitely that — th...</Credits>
@@ -81406,6 +82116,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1123aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1123a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The two billowing structures in this NASA/ESA Hubble Space Telescope image of IRAS 13208-6020 are formed from material that is s...</Credits>
@@ -81432,6 +82143,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1124aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1124a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The NASA/ESA Hubble Space Telescope has made a rare celestial catch. Close to a bright, nearby star in this image, the bizarre, ...</Credits>
@@ -81458,6 +82170,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1125aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1125a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; In this NASA/ESA Hubble Space Telescope image of NGC 7479 — created from observations at visible and near-infrared wavelengths —...</Credits>
@@ -81484,6 +82197,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1126aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1126a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The NASA/ESA Hubble Space Telescope has imaged an area so jam-packed with stars that they almost overwhelm the inky blackness of...</Credits>
@@ -81510,6 +82224,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1127aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1127a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA ; Looking like an elegant abstract art piece painted by talented hands, this picture is actually a NASA/ESA Hubble Space Telescope...</Credits>
@@ -81536,6 +82251,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1129aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1129a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The NASA/ESA Hubble Space Telescope has imaged an elongated stream of stars, gas and dust called IC 755, which is actually a spi...</Credits>
@@ -81562,6 +82278,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1130aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1130a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA ; NGC 2023 surrounds a massive young B-type star. These stars are large, bright and blue-white in colour, and have a high surface ...</Credits>
@@ -81588,6 +82305,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1133aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1133a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the Hubble Heritag; A giant cosmic necklace glows brightly in this NASA/ESA Hubble Space Telescope image.The  object, aptly named the Necklace Nebul...</Credits>
@@ -81614,6 +82332,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1134aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1134a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA ; NGC 2146 is classified as a barred spiral due to its shape, but the most distinctive feature is the dusty spiral arm that has lo...</Credits>
@@ -81640,6 +82359,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1135aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1135a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; Peering into the depths of space, the sharp-eyed NASA/ESA Hubble Space Telescope has imaged the nearby but faint dwarf galaxy ES...</Credits>
@@ -81666,6 +82386,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1136aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1136a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA and R. Sahai ; Protoplanetary nebulae offer glimpses of how stars similar to the Sun end their lives and how they make the transition to white ...</Credits>
@@ -81692,6 +82413,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1138aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1138a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA ; In  this NASA/ESA Hubble Space Telescope image, NGC 4874 is the brightest  object, located to the right of the frame and seen as...</Credits>
@@ -81718,6 +82440,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1139aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1139a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This NASA/ESA Hubble Space Telescope image shows remarkable structures in a galaxy cluster around an object called LRG-4-606. LR...</Credits>
@@ -81744,6 +82467,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1140aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1140a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; Thousands  and thousands of brilliant stars make up this globular cluster, Messier  53, captured with crystal clarity in this im...</Credits>
@@ -81770,6 +82494,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1141aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1141a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; Galaxies  come in a variety of shapes and sizes, and these features change as  they evolve. Some, like the galaxy in the centre ...</Credits>
@@ -81796,6 +82521,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1142aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1142a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; Supernova SN 1987A, one of the brightest stellar explosions since the invention of the telescope more than 400 years ago, is no ...</Credits>
@@ -81822,6 +82548,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1143aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1143a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The NASA/ESA Hubble Space Telescope has taken this image of the Phoenix Dwarf Galaxy, which is located 1.4 million light-years a...</Credits>
@@ -81848,6 +82575,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1144aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1144a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA ; The  pearly wisps surrounding the central star IRAS 10082-5647 in this  Hubble image certainly draw the eye towards the heavens....</Credits>
@@ -81874,6 +82602,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1145aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1145a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The object shown in this beautiful Hubble image, dubbed Messier 54, could be just another globular cluster, but this dense and f...</Credits>
@@ -81900,6 +82629,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1146aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1146a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA; The NASA/ESA Hubble Space Telescope has peered deep into NGC 4631, better known as the Whale Galaxy. Here, a profusion of starbi...</Credits>
@@ -81926,6 +82656,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1147aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1147a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA and D. A. Gouli; In one of the largest known star formation regions in the Large Magellanic Cloud (LMC), a small satellite galaxy of the Milky Wa...</Credits>
@@ -81952,6 +82683,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1148aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1148a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The NASA/ESA Hubble Space Telescope has caught sight of a soft, diffuse-looking galaxy that is probably the aftermath of a long-...</Credits>
@@ -81978,6 +82710,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1149aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1149a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; Three thousand light-years from Earth lies the strange protoplanetary nebula IRAS 09371+1212, nicknamed the Frosty Leo Nebula. D...</Credits>
@@ -82004,6 +82737,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1202aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1202a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This  classic shot of a galaxy in the constellation of Ursa Major was taken  by the NASA/ESA Hubble Space Telescope. NGC 3259 is...</Credits>
@@ -82030,6 +82764,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1206aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1206a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA ; Many  of the Universe’s galaxies are like our own, displaying beautiful  spiral arms wrapping around a bright nucleus. Examples ...</Credits>
@@ -82056,6 +82791,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1207aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1207a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA ; It’s  well known that the Universe is changeable: even the stars that appear  static and predictable every night are subject to ...</Credits>
@@ -82082,6 +82818,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1209aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1209a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The myriad faint stars that comprise the Antlia Dwarf galaxy are more than four million light-years from Earth, but this NASA/ES...</Credits>
@@ -82108,6 +82845,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1210aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1210a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The NASA/ESA Hubble Space Telescope has produced this beautiful image of the galaxy NGC 1483. NGC 1483 is a barred spiral galaxy...</Credits>
@@ -82134,6 +82872,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1213aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1213a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The NASA/ESA Hubble Space Telescope has spotted a UFO — well, the UFO Galaxy, to be precise. NGC 2683 is a spiral galaxy seen al...</Credits>
@@ -82160,6 +82899,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1214aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1214a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This image from the NASA/ESA Hubble Space Telescope shows NGC 4980, a spiral galaxy in the southern constellation of Hydra. The ...</Credits>
@@ -82186,6 +82926,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1215aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1215a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; In this image, the NASA/ESA Hubble Space Telescope has captured the brilliance of the compact centre of Messier 70, a globular c...</Credits>
@@ -82212,6 +82953,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1217aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1217a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The NASA/ESA Hubble Space Telescope has been at the cutting edge of research into what happens to stars like our Sun at the ends...</Credits>
@@ -82238,6 +82980,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1218aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1218a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This image from the NASA/ESA Hubble Space Telescope could seem like a quiet patch of sky at first glance. But zooming into the c...</Credits>
@@ -82264,6 +83007,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1224aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1224a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The NASA/ESA Hubble Space Telescope has captured this view of the dwarf galaxy UGC 5497, which looks a bit like salt dashed on b...</Credits>
@@ -82290,6 +83034,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1226aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1226a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; Relatively few galaxies possess the sweeping, luminous spiral arms or brightly glowing centre of our home galaxy the Milky Way. ...</Credits>
@@ -82316,6 +83061,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1230aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1230a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA ; The  galaxy NGC 4700 bears the signs of the vigorous birth of many new stars  in this image captured by the NASA/ESA Hubble Spac...</Credits>
@@ -82342,6 +83088,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1231aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1231a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The NASA/ESA Hubble Space Telescope offers this delightful view of the crowded stellar encampment called Messier 68, a spherical...</Credits>
@@ -82368,6 +83115,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1234aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1234a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA Acknowledgement: Gill; The  NASA/ESA Hubble Space Telescope has produced this beautiful image of  the globular cluster Messier 56 (also known as M 56 o...</Credits>
@@ -82394,6 +83142,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1235aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1235a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; A  new image from the NASA/ESA Hubble Space Telescope shows NGC 5806, a  spiral galaxy in the constellation Virgo (the Virgin). ...</Credits>
@@ -82420,6 +83169,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1238aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1238a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The NASA/ESA Hubble Space Telescope has produced a sharp image of NGC 4634, a spiral galaxy seen exactly side-on. Its disc is sl...</Credits>
@@ -82446,6 +83196,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1238bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1238b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, Digitzed Sky Survey 2; This wide-field view from the Digitized Sky Survey shows NGC 4634 and NGC 4633, a pair of interacting galaxies in the constellat...</Credits>
@@ -82472,6 +83223,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1240aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1240a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This dazzling image shows the globular cluster Messier 69, or M 69 for short, as viewed through the NASA/ESA Hubble Space Telesc...</Credits>
@@ -82498,6 +83250,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1242aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1242a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; NGC 3344 is a glorious spiral galaxy around half the size of the Milky Way, which lies 25 million light-years distant. We are fo...</Credits>
@@ -82524,6 +83277,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1243aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1243a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The NASA/ESA Hubble Space Telescope has imaged the faint irregular galaxy NGC 3738, a starburst galaxy. The galaxy is in the mid...</Credits>
@@ -82550,6 +83304,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1244aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1244a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA ; The  NASA/ESA Hubble Space Telescope offers an impressive view of the centre  of globular cluster NGC 6362. The image of this sp...</Credits>
@@ -82576,6 +83331,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1245aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1245a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The NASA/ESA Hubble Space Telescope has captured a beautiful galaxy that, with its reddish and yellow central area, looks rather...</Credits>
@@ -82602,6 +83358,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1249aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1249a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA ; The  brilliant cascade of stars through the middle of this image is the  galaxy ESO 318-13 as seen by the NASA/ESA Hubble Space ...</Credits>
@@ -82628,6 +83385,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1252aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1252a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASAAcknowledgement; The NASA/ESA Hubble Space Telescope provides us this week with a spectacular image of the bright star-forming ring that surround...</Credits>
@@ -82654,6 +83412,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1253aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1253a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The Universe loves to fool our eyes, giving the impression that celestial objects are located at the same distance from Earth. A...</Credits>
@@ -82680,6 +83439,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1301aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1301a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The  constellation of Ursa Major (The Great Bear) is home to Messier 101,  the Pinwheel Galaxy. One of the biggest and brightest...</Credits>
@@ -82706,6 +83466,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1302aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1302a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA ; A  busy patch of space has been captured in this image from the NASA/ESA  Hubble Space Telescope. Scattered with many nearby sta...</Credits>
@@ -82732,6 +83493,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1303aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1303a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA ; Globular  clusters are roughly spherical collections of extremely old stars, and  around 150 of them are scattered around our ga...</Credits>
@@ -82758,6 +83520,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1305aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1305a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA ; This  thin, glittering streak of stars is the spiral galaxy ESO 121-6, which  lies in the southern constellation of Pictor (The ...</Credits>
@@ -82784,6 +83547,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1313aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1313a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, M. Hayes; Visible  as a small, sparkling hook in the dark sky, this beautiful object is  known as J082354.96+280621.6, or J082354.96 for s...</Credits>
@@ -82810,6 +83574,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1323aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1323a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA ; The  contorted object captured by Hubble in this picture is IRAS 22491-1808,  also known as the South America Galaxy. It is an u...</Credits>
@@ -82836,6 +83601,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1330aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1330a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASAAcknowledgement; Another treasure unearthed from the Hubble archives, this beautiful image shows a spiral galaxy named NGC 4517. Slightly bigger ...</Credits>
@@ -82862,6 +83628,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1351aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1351a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; Located some 25 million light-years away, this new Hubble image shows spiral galaxy ESO 373-8. Together with at least seven of i...</Credits>
@@ -82888,6 +83655,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1403aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1403a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; In this new Hubble image two objects are clearly visible, shining brightly. When they were first discovered in 1979, they were t...</Credits>
@@ -82914,6 +83682,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1421aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1421a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; This new Hubble image shows IRAS 14568-6304, a young star that is cloaked in a haze of golden gas and dust. It appears to be emb...</Credits>
@@ -82940,6 +83709,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1434aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1434a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This new NASA/ESA Hubble Space Telescope image shows a variety of intriguing cosmic phenomena. Surrounded by bright stars, towar...</Credits>
@@ -82966,6 +83736,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1435aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1435a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; This new NASA/ESA Hubble Space Telescope image shows a beautiful spiral galaxy known as PGC 54493, located in the constellation ...</Credits>
@@ -82992,6 +83763,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1436aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1436a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA, D. Calzetti ; Far beyond the stars in the constellation of Leo (The Lion) is irregular galaxy IC 559. IC 559 is not your everyday galaxy. With...</Credits>
@@ -83018,6 +83790,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1438aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1438a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; This new image from the NASA/ESA Hubble Space Telescope shows NGC 7793, a spiral galaxy in the constellation of Sculptor some 13...</Credits>
@@ -83044,6 +83817,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1439aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1439a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; In this new Hubble image, the strikingly luminous star AG Carinae — otherwise known as HD 94910 — takes centre stage. Found with...</Credits>
@@ -83070,6 +83844,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1440aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1440a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; This magnificent new image taken with the NASA/ESA Hubble Space Telescope shows the edge-on spiral galaxy NGC 4206, located abou...</Credits>
@@ -83096,6 +83871,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1441aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1441a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; The brightly glowing plumes seen in this image are reminiscent of an underwater scene, with turquoise-tinted currents and nebulo...</Credits>
@@ -83122,6 +83898,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1442aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1442a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; This neat little galaxy is known as NGC 4526. Its dark lanes of dust and bright diffuse glow make the galaxy appear to hang like...</Credits>
@@ -83148,6 +83925,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1443aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1443a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This spectacular image was captured by the NASA/ESA Hubble Space Telescope's Advanced Camera for Surveys (ACS). The bright strea...</Credits>
@@ -83174,6 +83952,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1445aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1445a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASAAcknowledgement; This new image from the NASA/ESA Hubble Space Telescope shows the super-rich galaxy cluster Abell 1413. Located between the cons...</Credits>
@@ -83200,6 +83979,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1447aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1447a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; The galaxy cutting dramatically across the frame of this NASA/ESA Hubble Space Telescope image is a slightly warped dwarf galaxy...</Credits>
@@ -83226,6 +84006,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1448aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1448a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA and S. Smartt; The NASA/ESA Hubble Space Telescope observes some of the most beautiful galaxies in our skies — spirals sparkling with bright st...</Credits>
@@ -83252,6 +84033,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1449aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1449a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; This striking new NASA/ESA Hubble Space Telescope image shows a glittering bauble named Messier 92. Located in the northern cons...</Credits>
@@ -83278,6 +84060,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1450aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1450a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; This sprinkle of cosmic glitter is a blue compact dwarf galaxy known as Markarian 209. Galaxies of this type are blue-hued, comp...</Credits>
@@ -83304,6 +84087,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1451aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1451a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This new NASA/ESA Hubble Space Telescope image shows the galaxy IC 335 in front of a backdrop of distant galaxies. IC 335 is par...</Credits>
@@ -83330,6 +84114,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1452aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1452a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; This image captures the stunning NGC 6535, a globular cluster 22 000 light-years away in the constellation of Serpens (The Serpe...</Credits>
@@ -83356,6 +84141,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1501aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1501a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This new NASA/ESA Hubble Space Telescope image shows a star known as R Sculptoris, a red giant located 1500 light-years from Ear...</Credits>
@@ -83382,6 +84168,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1502aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1502a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; The subject of this image is NGC 6861, a galaxy discovered in 1826 by the Scottish astronomer James Dunlop. Almost two centuries...</Credits>
@@ -83408,6 +84195,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1503aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1503a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: ESA/Hubble &amp; NASAAcknowl; In this image the NASA/ESA Hubble Space Telescope takes a close look at the spiral galaxy NGC 4217, 60 million light-years away....</Credits>
@@ -83434,6 +84222,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1504aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1504a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: ESA/Hubble &amp; NASAAcknowl; This Picture of the Week shows Arp 230, also known as IC 51, observed by the NASA/ESA Hubble Space Telescope. Arp 230 is a galax...</Credits>
@@ -83460,6 +84249,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1505aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1505a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: ESA/Hubble &amp; NASAAcknowl; Galaxies can take many shapes and be oriented any way relative to us in the sky. This can make it hard to figure out their actua...</Credits>
@@ -83486,6 +84276,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1506aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1506a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA Acknowledgement: Judy; In the centre of this image, taken with the NASA/ESA Hubble Space Telescope, are two faint galaxies that seem to be smiling. You...</Credits>
@@ -83512,6 +84303,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1507aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1507a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; Panta rhei is a simplified version of the famous greek philosopher Heraclitus' teachings. It basically means, everything flows. ...</Credits>
@@ -83538,6 +84330,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1508aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1508a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASAAcknowledgement; The galaxy pictured here is NGC 4424, located in the constellation of  Virgo. It is not visible with the naked eye but has been ...</Credits>
@@ -83564,6 +84357,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1509aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1509a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA, Karl Stapelfe;   With its helical appearance resembling a snail’s shell, this reflection nebula seems to spiral out from a luminous central sta...</Credits>
@@ -83590,6 +84384,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1510aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1510a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The galaxy UGC 8201, captured here by the NASA/ESA Hubble Space Telescope, is a dwarf irregular galaxy, so called because of its...</Credits>
@@ -83616,6 +84411,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1511aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1511a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; The bright streak of glowing gas and stars in this NASA/ESA Hubble Space Telescope image is known as PGC 51017, or SBSG 1415+437...</Credits>
@@ -83642,6 +84438,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1512aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1512a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This NASA/ESA Hubble Space Telescope image shows an edge-on view of the spiral galaxy NGC 5023. Due to its orientation we cannot...</Credits>
@@ -83668,6 +84465,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1513aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1513a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA Acknowledgement: A. R; This NASA/ESA Hubble Space Telescope image shows the spiral galaxy NGC 3021 which lies about 100 million light-years away in the...</Credits>
@@ -83694,6 +84492,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1514aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1514a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This image shows the centre of the globular cluster Messier 22, also known as M22, as observed by the NASA/ESA Hubble Space Tele...</Credits>
@@ -83720,6 +84519,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1515aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1515a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; This NASA/ESA Hubble Space Telescope image shows an elliptical galaxy called NGC 2865. It lies just over 100 million light-years...</Credits>
@@ -83746,6 +84546,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1516aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1516a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This galaxy goes by the name of ESO 162-17 and is located about 40 million light-years away in the constellation of Carina. At f...</Credits>
@@ -83772,6 +84573,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1517aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1517a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; The smudge of stars at the centre of this NASA/ESA Hubble Space Telescope image is a galaxy known as UGC 5797. UGC 5797 is an em...</Credits>
@@ -83798,6 +84600,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1518aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1518a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This image provides the clearest ever view of galaxy NGC 949, which lies over 30 million light-years away in the constellation o...</Credits>
@@ -83824,6 +84627,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1519aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1519a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; The glowing object in this image is an elliptical galaxy called NGC 3923. It is located over 90 million light-years away in the ...</Credits>
@@ -83850,6 +84654,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1520aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1520a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, the Hubble Heritage (; Not all galaxies are neatly shaped, as this new NASA/ESA Hubble Space Telescope image of NGC 6240 clearly demonstrates. Hubble p...</Credits>
@@ -83876,6 +84681,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1521aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1521a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA; This new NASA/ESA Hubble Space Telescope image presents the Arches Cluster, the densest known star cluster in the Milky Way. It ...</Credits>
@@ -83902,6 +84708,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1522aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1522a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This NASA/ESA Hubble Space Telescope image captures the galaxy Messier 84 — also known as NGC 4374 — an object from the Messier ...</Credits>
@@ -83928,6 +84735,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1523aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1523a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; There are many galaxies in the Universe and although there is plenty of room, they tend to stick together. The Milky Way, for ex...</Credits>
@@ -83954,6 +84762,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1524aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1524a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This NASA/ESA Hubble Space Telescope image shows a galaxy known as UGC 11411. It is a galaxy type known as an irregular blue com...</Credits>
@@ -83980,6 +84789,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1525aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1525a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; This NASA/ESA Hubble Space Telescope image shows a planetary nebula named NGC 6153, located about 4000 light-years away in the s...</Credits>
@@ -84006,6 +84816,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1526aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1526a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This NASA/ESA Hubble Space Telescope picture shows a galaxy named SBS 1415+437 or SDSS CGB 12067.1, located about 45 million lig...</Credits>
@@ -84032,6 +84843,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1527aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1527a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; This little-known galaxy, officially named J04542829-6625280, but most often referred to as LEDA 89996, is a classic example of ...</Credits>
@@ -84058,6 +84870,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1528aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1528a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; Although this cluster of stars gained its name due to its five brightest stars, it is home to hundreds more. The huge number of ...</Credits>
@@ -84084,6 +84897,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1529aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1529a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This dramatic image shows the NASA/ESA Hubble Space Telescope’s view of dwarf galaxy known as NGC 1140, which lies 60 million li...</Credits>
@@ -84110,6 +84924,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1530aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1530a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; A dying star’s final moments are captured in this image from the NASA/ESA Hubble Space Telescope. The death throes of this star ...</Credits>
@@ -84136,6 +84951,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1531aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1531a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; This colourful bubble is a planetary nebula called NGC 6818, also known as the Little Gem Nebula. It is located in the constella...</Credits>
@@ -84162,6 +84978,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1532aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1532a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and NASA and S. Smart; Bursts of pink and red, dark lanes of mottled cosmic dust, and a bright scattering of stars — this NASA/ESA Hubble Space Telesco...</Credits>
@@ -84188,6 +85005,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1533aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1533a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA  Acknowledgeme; Here we see the spectacular cosmic pairing of the star Hen 2-427 — more commonly known as WR 124 — and the nebula M1-67 which su...</Credits>
@@ -84214,6 +85032,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1534aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1534a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; Shown here in a new image taken with the Advanced Camera for Surveys (ACS) on board the NASA/ESA Hubble Space Telescope, is the ...</Credits>
@@ -84240,6 +85059,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1535aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1535a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA and the LEGUS ; This new NASA/ESA Hubble Space Telescope shows Messier 96, a spiral galaxy just over 35 million light-years away in the constell...</Credits>
@@ -84266,6 +85086,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1536aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1536a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The arrangement of the spiral arms in the galaxy Messier 63, seen here in a new image from the NASA/ESA Hubble Space Telescope, ...</Credits>
@@ -84292,6 +85113,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1537aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1537a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; It is known today that merging galaxies play a large role in the evolution of galaxies and the formation of elliptical galaxies ...</Credits>
@@ -84318,6 +85140,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1538aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1538a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA and S. Smartt ; This new image of the spiral galaxy NGC 3521 from the NASA/ESA Hubble Space Telescope is not out of focus. Instead, the galaxy i...</Credits>
@@ -84344,6 +85167,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1539aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1539a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA and S. Smartt ; Ribbons of dust festoon the galaxy NGC 613 in this new image from the NASA/ESA Hubble Space Telescope. NGC 613 is classified as ...</Credits>
@@ -84370,6 +85194,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1540aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1540a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; This planetary nebula is called PK 329-02.2 and is located in the constellation of Norma in the southern sky. It is also sometim...</Credits>
@@ -84396,6 +85221,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1541aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1541a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; NGC 4639 is a beautiful example of a type of galaxy known as a barred spiral. It lies over 70 million light-years away in the co...</Credits>
@@ -84422,6 +85248,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1542aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1542a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This image shows the galaxy Messier 94, which lies in the small northern constellation of the Hunting Dogs, about 16 million lig...</Credits>
@@ -84448,6 +85275,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1543aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1543a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; Two stars shine through the centre of a ring of cascading dust in this image taken by the NASA/ESA Hubble Space Telescope. The s...</Credits>
@@ -84474,6 +85302,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1544aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1544a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA and N. Grogin ; This galaxy is known as Mrk 820 and is classified as a lenticular galaxy — type S0 on the Hubble Tuning Fork. The Hubble Tuning ...</Credits>
@@ -84500,6 +85329,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1545aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1545a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA and N. Gorin (; Only three local stars appear in this image, quartered by right-angled diffraction spikes. Everything besides them is a galaxy; ...</Credits>
@@ -84526,6 +85356,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1546aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1546a"
     Xcxstatus="queue:hubble"
   >
     <Credits>  ESA/Hubble &amp; NASA, Acknowledge; At the centre of this amazing image is the elliptical galaxy NGC 3610. Surrounding the galaxy are a wealth of other galaxies of ...</Credits>
@@ -84552,6 +85383,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1547aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1547a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; This curious galaxy — only known by the seemingly random jumble of letters and numbers 2MASX J16270254+4328340 — has been captur...</Credits>
@@ -84578,6 +85410,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1548aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1548a"
     Xcxstatus="queue:hubble"
   >
     <Credits>   ESA/Hubble, NASA and S. Smar; Like a lighthouse in the fog the luminous core of NGC 2768 slowly fades outwards to a dull white haze in this image taken by the...</Credits>
@@ -84604,6 +85437,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1549aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1549a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA, Acknowledgements: J; Only rarely does an astronomical object have a political association. However, the spiral galaxy NGC 7252 acquired exactly that ...</Credits>
@@ -84630,6 +85464,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1550aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1550a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA, Acknowledgement: Ju; This image, taken with the Wide Field Planetary Camera 2 on board the NASA/ESA Hubble Space Telescope, shows the globular cluste...</Credits>
@@ -84656,6 +85491,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1551aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1551a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The artistic outburst of an extremely young star, in the earliest phase of formation, is captured in this spectacular image from...</Credits>
@@ -84682,6 +85518,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1552aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1552a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, Acknowledgeme; This image, taken with the Wide Field Planetary Camera 2 on board the NASA/ESA Hubble Space Telescope, shows the galaxy NGC 6052...</Credits>
@@ -84708,6 +85545,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1601aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1601a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA and S. Smartt ; This NASA/ESA Hubble Space Telescope image shows the spiral galaxy NGC 4845, located over 65 million light-years away in the con...</Credits>
@@ -84734,6 +85572,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1602aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1602a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; The subject of this NASA/ESA Hubble Space Telescope image is known as NGC 3597. It is the product of a collision between two goo...</Credits>
@@ -84760,6 +85599,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1603aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1603a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; Most galaxies possess a majestic spiral or elliptical structure. About a quarter of galaxies, though, defy such conventional, ro...</Credits>
@@ -84786,6 +85626,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1604aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1604a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; Despite its unassuming appearance, the edge-on spiral galaxy captured in the left half of this NASA/ESA Hubble Space Telescope i...</Credits>
@@ -84812,6 +85653,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1605aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1605a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; This image, taken by the NASA/ESA Hubble Space Telescope, shows a peculiar galaxy known as NGC 1487, lying about 30 million ligh...</Credits>
@@ -84838,6 +85680,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1606aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1606a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; In this cosmic snapshot, the spectacularly symmetrical wings of Hen 2-437 show up in a magnificent icy blue hue. Hen 2-437 is a ...</Credits>
@@ -84864,6 +85707,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1607aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1607a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; Surrounded by an envelope of dust, the subject of this NASA/ESA Hubble Space Telescope image is a young pre-main-sequence star k...</Credits>
@@ -84890,6 +85734,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1608aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1608a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; Sparkling at the centre of this beautiful NASA/ESA Hubble Space Telescope image is a Wolf–Rayet star known as WR 31a, located ab...</Credits>
@@ -84916,6 +85761,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1609aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1609a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen;   Showcased at the centre of this NASA/ESA Hubble Space Telescope image is an emission-line star known as IRAS 12196-6300.  Loca...</Credits>
@@ -84942,6 +85788,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1610aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1610a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and the HST Frontier F; Peering deep into the early Universe, this picturesque parallel field observation from the NASA/ESA Hubble Space Telescope revea...</Credits>
@@ -84968,6 +85815,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1611aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1611a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, CXC, NRAO/AUI/NSF, ST;   In October of 2013 Hubble kicked off the Frontier Fields programme, a three-year series of observations aiming to produce the ...</Credits>
@@ -84994,6 +85842,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1612aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1612a"
     Xcxstatus="queue:hubble"
   >
     <Credits>  NASA, ESA, CXC, NRAO/AUI/NSF, ; At first glance, this cosmic kaleidoscope of purple, blue and pink offers a strikingly beautiful — and serene — snapshot of the ...</Credits>
@@ -85020,6 +85869,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1613aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1613a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen;   Despite being less famous than their elliptical and spiral galactic cousins, irregular  dwarf galaxies, such as the one captur...</Credits>
@@ -85046,6 +85896,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1614aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1614a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen;   This striking NASA/ESA Hubble Space Telescope image captures the galaxy UGC 477, located just over 110 million light-years awa...</Credits>
@@ -85072,6 +85923,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1615aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1615a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA  Acknowledgeme; At first glance this NASA/ESA Hubble Space Telescope image seems to show an array of different cosmic objects, but the speckling...</Credits>
@@ -85098,6 +85950,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1616aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1616a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen;   The elegant simplicity of NGC 4111, seen here in this image from the NASA/ESA Hubble Space Telescope, hides a more violent his...</Credits>
@@ -85124,6 +85977,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1617aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1617a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen;   This NASA/ESA Hubble Space Telescope image reveals the simple beauty of NGC 339, a massive intermediate age star cluster  in t...</Credits>
@@ -85150,6 +86004,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1618aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1618a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen;   Discovered in 1784 by the German–British astronomer William Herschel, NGC 4394 is a barred spiral galaxy situated about 55 mil...</Credits>
@@ -85176,6 +86031,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1619aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1619a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA  Acknowledgeme; Spiral galaxies together with irregular galaxies make up approximately 60% of the galaxies in the local Universe. However, despi...</Credits>
@@ -85228,6 +86084,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1621aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1621a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA  Acknowledgeme; Nearly as deep as the Hubble Ultra Deep Field, which contains approximately 10 000 galaxies, this incredible image from the NASA...</Credits>
@@ -85254,6 +86111,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1622aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1622a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; This 10.5-billion-year-old globular cluster, NGC 6496, is home to heavy-metal stars of a celestial kind! The stars comprising th...</Credits>
@@ -85280,6 +86138,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1623aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1623a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA &amp; ESA; The drizzle of stars scattered across this image forms a galaxy known as UGC 4879. UGC 4879 is an irregular dwarf galaxy — as th...</Credits>
@@ -85306,6 +86165,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1624aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1624a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This colourful and star-studded view of the Milky Way galaxy was captured when the NASA/ESA Hubble Space Telescope pointed its c...</Credits>
@@ -85332,6 +86192,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1625aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1625a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This NASA/ESA Hubble Space Telescope image shows the globular cluster NGC 1854, a gathering of white and blue stars in the south...</Credits>
@@ -85358,6 +86219,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1626aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1626a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, Aloisi, Ford ; This NASA/ESA Hubble Space Telescope image reveals the iridescent interior of one of the most active galaxies in our local neigh...</Credits>
@@ -85384,6 +86246,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1627aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1627a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The fuzzy collection of stars seen in this NASA/ESA Hubble Space Telescope image forms an intriguing dwarf galaxy named LEDA 677...</Credits>
@@ -85410,6 +86273,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1628aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1628a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA and N. Grogin ;   This image was taken by the NASA/ESA Hubble Space Telescope’s Advanced Camera for Surveys (ACS), and shows a starburst galaxy ...</Credits>
@@ -85436,6 +86300,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1629aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1629a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASAAcknowledgement;   This NASA/ESA Hubble Space Telescope image reveals the vibrant core of the galaxy NGC 3125. Discovered by John Herschel in 183...</Credits>
@@ -85462,6 +86327,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1630aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1630a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, Y. Chu; This NASA/ESA Hubble Space Telescope image captures the remnants of a long-dead star. These rippling wisps of ionised gas, named...</Credits>
@@ -85488,6 +86354,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1631aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1631a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble and NASA;   Located approximately 22 000 light-years away in the constellation of Musca (The Fly), this tightly packed collection of stars...</Credits>
@@ -85514,6 +86381,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1632aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1632a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This galaxy, known as NGC 2337, resides 25 million light-years away in the constellation of Lynx. NGC 2337 is an irregular galax...</Credits>
@@ -85540,6 +86408,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1633aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1633a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, Y. Chu; Several thousand years ago, a star some 160 000 light-years away from us exploded, scattering stellar shrapnel across the sky. T...</Credits>
@@ -85566,6 +86435,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1634aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1634a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   This image, courtesy of the NASA/ESA Hubble Space Telescope’s Advanced Camera for Surveys (ACS), captures the glow of distant ...</Credits>
@@ -85592,6 +86462,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1635aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1635a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The closest star system to the Earth is the famous Alpha Centauri group. Located in the constellation of Centaurus (The Centaur)...</Credits>
@@ -85618,6 +86489,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1636aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1636a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This shot from the NASA/ESA Hubble Space Telescope shows a maelstrom of glowing gas and dark dust within one of the Milky Way’s ...</Credits>
@@ -85644,6 +86516,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1637aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1637a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen;   A lone source shines out brightly from the dark expanse of deep space, glowing softly against a picturesque backdrop of distan...</Credits>
@@ -85670,6 +86543,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1639aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1639a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   This shining disc of a spiral galaxy sits approximately 25 million light-years away from Earth in the constellation of Sculpto...</Credits>
@@ -85696,6 +86570,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1640aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1640a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   This Hubble image shows the central region of a spiral galaxy known as NGC 247. NGC 247 is a relatively small spiral galaxy in...</Credits>
@@ -85722,6 +86597,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1641aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1641a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA and S. Smartt; This image, taken by the NASA/ESA Hubble Space Telescope’s Wide Field Planetary Camera 2, shows a spiral galaxy named NGC 278. T...</Credits>
@@ -85748,6 +86624,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1642aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1642a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; It may be famous for hosting spectacular sights such as the Tucana Dwarf Galaxy and 47 Tucanae (heic1510), the second brightest ...</Credits>
@@ -85774,6 +86651,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1643aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1643a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; Globular clusters offer some of the most spectacular sights in the night sky. These ornate spheres contain hundreds of thousands...</Credits>
@@ -85800,6 +86678,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1644aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1644a"
     Xcxstatus="queue:hubble"
   >
     <Credits>  ESA/Hubble &amp; NASA. Acknowledg;   In 1054 AD, during the Song dynasty, Chinese astronomers spotted a bright new star in the night sky. This newcomer turned out ...</Credits>
@@ -85826,6 +86705,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1645aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1645a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;  NGC 1222, seen in this image taken with the Wide Field Camera 3 on board the NASA/ESA Hubble Space Telescope (HST), is a galaxy...</Credits>
@@ -85852,6 +86732,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1646aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1646a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen;   This Hubble image shows NGC 4789A, a dwarf irregular galaxy in the constellation of Coma Berenices. It certainly lives up to i...</Credits>
@@ -85878,6 +86759,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1647aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1647a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, D. Calzetti; This image of the spiral galaxy NGC 3274 comes courtesy of the NASA/ESA Hubble Space Telescope’s Wide Field Camera 3 (WFC3). Hub...</Credits>
@@ -85904,6 +86786,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1648aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1648a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;  This delicate blue group of stars — actually an irregular galaxy named IC 3583 — sits some 30 million light-years away in the c...</Credits>
@@ -85930,6 +86813,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1649aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1649a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;  The constellation of Virgo (The Virgin) is especially rich in galaxies, due in part to the presence of a massive and gravitatio...</Credits>
@@ -85956,6 +86840,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1650aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1650a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; In 1900, astronomer Joseph Lunt made a discovery: Peering through a telescope at Cape Town Observatory, the British–South Africa...</Credits>
@@ -85982,6 +86867,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1651aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1651a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; On a clear evening in April of 1789, the renowned astronomer William Herschel continued his unrelenting survey of the night sky,...</Credits>
@@ -86008,6 +86894,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1652aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1652a"
     Xcxstatus="queue:hubble"
   >
     <Credits>  ESA/Hubble &amp; NASAAcknowledgeme;   This galaxy has a far more exciting and futuristic classification than most — it is a megamaser. Megamasers are intensely brig...</Credits>
@@ -86034,6 +86921,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1701aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1701a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;  This delicate smudge in deep space is far more turbulent than it first appears. Known as IRAS 14348-1447 — a name  derived in p...</Credits>
@@ -86060,6 +86948,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1702aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1702a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen;   This image taken with the Advanced Camera for Surveys (ACS) onboard the NASA/ESA Hubble Space Telescope captures a galaxy in t...</Credits>
@@ -86086,6 +86975,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1703aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1703a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;  This stunning image, captured by the NASA/ESA Hubble Space Telescope’s Advanced Camera for Surveys (ACS), shows part of the sky...</Credits>
@@ -86112,6 +87002,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1704aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1704a"
     Xcxstatus="queue:hubble"
   >
     <Credits>  ESA/Hubble &amp; NASA;   The lesser-known constellation of Canes Venatici (The Hunting Dogs), is home to a variety of deep-sky objects — including this...</Credits>
@@ -86138,6 +87029,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1705aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1705a"
     Xcxstatus="queue:hubble"
   >
     <Credits>  ESA/Hubble &amp; NASA Acknowledgem; The Calabash Nebula, pictured here — which has the technical name OH 231.8+04.2 — is a spectacular example of the death of a low...</Credits>
@@ -86164,6 +87056,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1706aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1706a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;  Not to be confused with our neighbouring Andromeda Galaxy, the Andromeda constellation is one of the 88 modern constellations. ...</Credits>
@@ -86190,6 +87083,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1707aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1707a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   This image was captured by the NASA/ESA Hubble Space Telescope’s Advanced Camera for Surveys (ACS), a highly efficient wide-fi...</Credits>
@@ -86216,6 +87110,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1708aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1708a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, T. Kitayama (; The events surrounding the Big Bang were so cataclysmic that they left an indelible imprint on the fabric of the cosmos. We can ...</Credits>
@@ -86242,6 +87137,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1708bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1708b"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA; This cluster of galaxies, RX J1347.5–1145, was observed by the NASA/ESA Hubble Space Telescope as part of the Cluster Lensing An...</Credits>
@@ -86268,6 +87164,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1709aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1709a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This NASA/ESA Hubble Space Telescope image showcases the remarkable galaxy UGC 12591. Classified as an S0/Sa galaxy, UGC 12591 s...</Credits>
@@ -86294,6 +87191,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1710aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1710a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   Light travels through space at just under 300 000 kilometres per second! This staggering speed is used to calculate astronomic...</Credits>
@@ -86320,6 +87218,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1711aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1711a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;  This image from Hubble’s Wide Field Camera 3 (WFC3) shows NGC 1448, a spiral galaxy located about 50 million light-years from E...</Credits>
@@ -86346,6 +87245,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1712aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1712a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   Some galaxies are harder to classify than others. Here, Hubble’s trusty Wide Field Camera 3 (WFC3) has captured a striking vie...</Credits>
@@ -86372,6 +87272,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1713aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1713a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;  Some astronomical objects have endearing or quirky nicknames, inspired by mythology or their own appearance. Take, for example,...</Credits>
@@ -86398,6 +87299,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1715aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1715a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;  Despite all efforts galaxy formation and evolution are still far from being fully understood. Fortunately, the conditions we se...</Credits>
@@ -86424,6 +87326,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1716aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1716a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   This entrancing image shows a few of the tenuous threads that comprise Sh2-308, a faint and wispy shell of gas located 5200 li...</Credits>
@@ -86450,6 +87353,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1717aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1717a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;  In space, being outshone is an occupational hazard. This NASA/ESA Hubble Space Telescope image captures a galaxy named NGC 7250...</Credits>
@@ -86476,6 +87380,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1718aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1718a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This image from Hubble’s Wide Field Camera 3 (WFC3) shows a spiral galaxy NGC 5917, perhaps best known for its intriguing intera...</Credits>
@@ -86502,6 +87407,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1719aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1719a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;  This image from the NASA/ESA Hubble Space Telescope shows the unusual galaxy IRAS 06076-2139, found in the constellation Lepus ...</Credits>
@@ -86528,6 +87434,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1720aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1720a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, G. Dubner (IAFE, CONI; This captivating new image shows the Crab Nebula in bright neon colours. The unusual image was produced by combining data from t...</Credits>
@@ -86554,6 +87461,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1720bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1720b"
     Xcxstatus="queue:hubble"
   >
     <Credits>NRAO/AUI/NSF; The Karl G. Jansky Very Large Array (VLA) observed the Crab Nebula, a supernova remnant located 6500 light-years from Earth, at ...</Credits>
@@ -86580,6 +87488,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1720cL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1720c"
     Xcxstatus="queue:hubble"
   >
     <Credits>JPL/Caltech; NASA’s Spitzer Space Telescope observed the Crab Nebula, a supernova remnant located 6500 light-years from Earth, in the infrare...</Credits>
@@ -86606,6 +87515,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1720dL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1720d"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA/Hubble; The NASA/ESA Hubble Space Telescope observed the Crab Nebula, a supernova remnant located 6500 light-years from Earth, in optica...</Credits>
@@ -86632,6 +87542,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1720eL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1720e"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA; ESA’s XMM-Newton telescope observed the Crab Nebula, a supernova remnant located 6500 light-years from Earth, in the ultraviolet...</Credits>
@@ -86658,6 +87569,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1720fL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1720f"
     Xcxstatus="queue:hubble"
   >
     <Credits>CXC; NASA’s Chandra X-ray Observatory observed X-ray emissions from the Crab Nebula, a supernova remnant located 6500 light-years fro...</Credits>
@@ -86684,6 +87596,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1721aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1721a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   The NASA/ESA Hubble Space Telescope still has a few tricks up its sleeve in its task of exploring the Universe. For one, it is...</Credits>
@@ -86710,6 +87623,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1724aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1724a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and K. Sahu (STScI); A century ago, Albert Einstein published his famous theory of relativity. He proposed that all objects physically warp the fabri...</Credits>
@@ -86736,6 +87650,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1725aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1725a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; The object in the middle of this image, sitting alone within a star-studded cosmos, is a galaxy known as ESO 486-21. ESO 486-21 ...</Credits>
@@ -86762,6 +87677,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1726aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1726a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   Not all galaxies have the luxury of possessing a simple moniker or quirky nickname. The subject of this NASA/ESA Hubble Space ...</Credits>
@@ -86788,6 +87704,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="1"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1727aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1727a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   IC 342 is a challenging cosmic target. Although it is bright, the galaxy sits near the equator of the Milky Way’s galactic dis...</Credits>
@@ -86814,6 +87731,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1728aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1728a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   Discovered by British astronomer William Herschel over 200 years ago, NGC 2500 lies about 30  million light-years away in the ...</Credits>
@@ -86840,6 +87758,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1729aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1729a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   Tucked away in the small northern constellation of Canes Venatici (The Hunting Dogs) is the galaxy NGC 4242, shown here as see...</Credits>
@@ -86866,6 +87785,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1730aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1730a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   This beautiful clump of glowing gas, dark dust, and glittering stars is the spiral galaxy NGC 4248, located about 24 million l...</Credits>
@@ -86892,6 +87812,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1731aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1731a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   The star of this Hubble Picture of the Week is a galaxy known as NGC 4656, located in the constellation of Canes Venatici (The...</Credits>
@@ -86918,6 +87839,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1732aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1732a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   The subject of this NASA/ESA Hubble Space Telescope image is a dwarf galaxy named NGC 5949. Thanks to its proximity to Earth —...</Credits>
@@ -86944,6 +87866,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1733aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1733a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   Gravity governs the movements of the cosmos. It draws flocks of galaxies together to form small groups and more massive galaxy...</Credits>
@@ -86970,6 +87893,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1734aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1734a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   NGC 178 may be small, but it packs quite a punch. Measuring around 40 000 light-years across, its diameter is less than half t...</Credits>
@@ -86996,6 +87920,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1735aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1735a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   Phenomena across the Universe emit radiation spanning the entire electromagnetic spectrum — from high-energy gamma rays, which...</Credits>
@@ -87022,6 +87947,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1736aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1736a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   Like firecrackers lighting up the sky on New Year’s Eve, the majestic spiral arms of NGC 5559 are alight with new stars being ...</Credits>
@@ -87048,6 +87974,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1737aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1737a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   This NASA/ESA Hubble Space Telescope picture shows NGC 5398, a barred spiral galaxy located about 55 million light-years away....</Credits>
@@ -87074,6 +88001,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1738aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1738a"
     Xcxstatus="queue:hubble"
   >
     <Credits>  ESA/Hubble &amp; NASAAcknowledgeme;   Despite the advances made in past decades, the process of galaxy formation remains an open question in astronomy. Various theo...</Credits>
@@ -87100,6 +88028,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1739aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1739a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   The distances to objects in the Universe can differ enormously. The nearest star to us — Proxima Centauri — lies some 4.2 ligh...</Credits>
@@ -87126,6 +88055,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1740aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1740a"
     Xcxstatus="queue:hubble"
   >
     <Credits> ESA/Hubble &amp; NASAAcknowledgemen;  At a distance of just 160 000 light-years, the Large Magellanic Cloud (LMC) is one of the Milky Way’s closest companions. It is...</Credits>
@@ -87152,6 +88082,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1741aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1741a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   As far as galaxies are concerned, size can be deceiving. Some of the largest galaxies in the Universe are dormant, while some ...</Credits>
@@ -87178,6 +88109,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1742aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1742a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   This image, captured by the NASA/ESA Hubble Space Telescope, shows what happens when two galaxies become one. The twisted cosm...</Credits>
@@ -87204,6 +88136,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1743aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1743a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   This NASA/ESA Hubble Space Telescope image is chock-full of galaxies — each glowing speck is a different galaxy, bar the brigh...</Credits>
@@ -87230,6 +88163,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1744aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1744a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;  The Universe contains some truly massive objects. Although we are still unsure how such gigantic things come to be, the current...</Credits>
@@ -87256,6 +88190,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1745aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1745a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   This NASA/ESA Hubble Space Telescope image seems to sink into the screen, plunging the viewer into the dark depths of the earl...</Credits>
@@ -87282,6 +88217,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1746aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1746a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;  This new Picture of the Week, taken by the NASA/ESA Hubble Space Telescope, shows the dwarf galaxy NGC 4625, located about 30 m...</Credits>
@@ -87308,6 +88244,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1747aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1747a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA; This NASA/ESA Hubble Space Telescope image reveals the Cosmic Snake, a distant galaxy peppered with clumpy regions of intense st...</Credits>
@@ -87334,6 +88271,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1747bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1747b"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This image shows the galaxy cluster MACSJ1206.2-0847. The cluster is so far away, it took the light from the cluster more than 4...</Credits>
@@ -87360,6 +88298,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1748aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1748a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   This picturesque view from the NASA/ESA Hubble Space Telescope peers into the distant Universe to reveal a galaxy cluster call...</Credits>
@@ -87386,6 +88325,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1749aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1749a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; Don’t be fooled! The subject of this Picture of the Week, ESO 580-49, may seem tranquil and unassuming, but this spiral galaxy a...</Credits>
@@ -87412,6 +88352,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1750aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1750a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   Galaxies glow like fireflies in this spectacular NASA/ESA Hubble Space Telescope image! This flickering swarm of cosmic firefl...</Credits>
@@ -87438,6 +88379,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1751aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1751a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA and ESA Acknowledgement: S.; It’s beginning to look a lot like Christmas in this NASA/ESA Hubble Space Telescope image of a blizzard of stars, which resemble...</Credits>
@@ -87464,6 +88406,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1752aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1752a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESO, ESA/Hubble &amp; NASA; This image shows something spectacular: a massive galaxy cluster that it is warping the space around it! The cluster, whose hear...</Credits>
@@ -87490,6 +88433,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1752bL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1752b"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESO &amp; ESA/Hubble &amp; NASA; This image shows the galaxy cluster RCS2 J2327. The mass of the cluster causes both strong and weak gravitational lensing, which...</Credits>
@@ -87516,6 +88460,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1801aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1801a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This image, captured by the NASA/ESA Hubble Space Telescope’s Wide Field Camera 3 (WFC3), shows a galaxy named UGC 6093. As can ...</Credits>
@@ -87542,6 +88487,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1802aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1802a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, RELICS; In 2014, astronomers using the NASA/ESA Hubble Space Telescope found that this enormous galaxy cluster contains the mass of a st...</Credits>
@@ -87568,6 +88514,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1803aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1803a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and J. Comerford (Uni; Researchers using a suite of telescopes including the NASA/ESA Hubble Space Telescope have spotted a supermassive black hole blo...</Credits>
@@ -87594,6 +88541,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1804aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1804a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This image from the NASA/ESA Hubble Space Telescope reveals a glistening and ancient globular cluster named NGC 3201 — a gatheri...</Credits>
@@ -87620,6 +88568,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1805aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1805a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA/D. Milisavljev; This NASA/ESA Hubble Space Telescope image shows a spiral galaxy known as NGC 7331. First spotted by the prolific galaxy hunter ...</Credits>
@@ -87646,6 +88595,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1806aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1806a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; Roughly 50 million light-years away lies a somewhat overlooked little galaxy named NGC 1559. Pictured here by Hubble’s Wide Fiel...</Credits>
@@ -87672,6 +88622,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1807aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1807a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, RELICS; This image from the NASA/ESA Hubble Space Telescope shows the galaxy cluster PLCK G004.5-19.5. It was discovered by the ESA Plan...</Credits>
@@ -87698,6 +88649,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1809aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1809a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; Discovered in 1900 by astronomer DeLisle Stewart and here imaged by the NASA/ESA Hubble Space Telescope, IC 4710 is an undeniabl...</Credits>
@@ -87724,6 +88676,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1811aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1811a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, A. Riess (STS; This stunning image from Hubble shows the majestic galaxy NGC 1015, found nestled within the constellation of Cetus (The Whale) ...</Credits>
@@ -87750,6 +88703,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1812aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1812a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and M. Beasley (Insti;   This idyllic scene, packed with glowing galaxies, has something truly remarkable at its core: an untouched relic of the ancien...</Credits>
@@ -87776,6 +88730,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1813aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1813a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;   This image, captured by the Advanced Camera for Surveys (ACS) on the NASA/ESA Hubble Space Telescope, shows the spiral galaxy ...</Credits>
@@ -87802,6 +88757,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1816aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1816a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, RELICS; This intriguing image from the NASA/ESA Hubble Space Telescope shows a massive galaxy cluster called PSZ2 G138.61-10.84, about s...</Credits>
@@ -87828,6 +88784,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1817aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1817a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, A. Fillipenko;   This pretty, cloud-like object may not look much like a galaxy — it lacks the well-defined arms of a spiral galaxy, or the red...</Credits>
@@ -87854,6 +88811,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1819aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1819a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, RELICS; In the darkness of the distant Universe, galaxies resemble glowing fireflies, flickering candles, charred embers floating up fro...</Credits>
@@ -87880,6 +88838,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1820aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1820a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; Resembling a wizard’s staff set aglow, NGC 1032 cleaves the quiet darkness of space in two in this image from the NASA/ESA Hubbl...</Credits>
@@ -87906,6 +88865,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1822aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1822a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; This NASA/ESA Hubble Space Telescope image shows a cluster of hundreds of galaxies located about 7.5 billion light-years from Ea...</Credits>
@@ -87932,6 +88892,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1823aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1823a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; A ripple of bright blue threads through this galaxy like a misshapen lake system. The foreground of this image is littered with ...</Credits>
@@ -87958,6 +88919,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1824aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1824a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, RELICS; This sparkling Picture of the Week features a massive galaxy cluster named RXC J0232.2-4420. This image was taken by Hubble’s Ad...</Credits>
@@ -87984,6 +88946,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1825aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1825a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, RELICS; In astronomy, the devil is in the details — as this image, taken by the NASA/ESA Hubble Space Telescope’s Advanced Camera for Su...</Credits>
@@ -88010,6 +88973,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1826aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1826a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This rich and dense smattering of stars is a massive globular cluster, a gravitationally-bound collection of stars that orbits t...</Credits>
@@ -88036,6 +89000,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1827aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1827a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, RELICS; This busy image is a treasure trove of wonders. Bright stars from the Milky Way sparkle in the foreground, the magnificent swirl...</Credits>
@@ -88062,6 +89027,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1829aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1829a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; At first glance, it may seem as though this image was taken through a faulty lens, but the mind-bending distortions visible in t...</Credits>
@@ -88088,6 +89054,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1830aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1830a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; This image taken by the NASA/ESA Hubble Space Telescope’s Wide Field Camera 3 (WFC3) shows a beautiful spiral galaxy called NGC ...</Credits>
@@ -88114,6 +89081,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1831aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1831a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; Obtained for a research programme on star formation in old and distant galaxies, this NASA/ESA Hubble Space Telescope image obta...</Credits>
@@ -88140,6 +89108,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1832aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1832a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This Picture of the Week shows the colourful globular cluster NGC 2108. The cluster is nestled within the Large Magellanic Cloud...</Credits>
@@ -88192,6 +89161,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1835aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1835a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; Following on from last week’s Picture of the Week, this week we showcase the second part of the Hubble Deep UV (HDUV) Legacy Fie...</Credits>
@@ -88218,6 +89188,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1836aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1836a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; This week’s NASA/ESA Hubble Space Telescope image showcases the galaxy NGC 4036: a lenticular galaxy some 70 million light-years...</Credits>
@@ -88244,6 +89215,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1837aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1837a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; Gravity is so much a part of our daily lives that it is all too easy to forget its awesome power — but on a galactic scale, its ...</Credits>
@@ -88270,6 +89242,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1838aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1838a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA;  In the northern constellation of Coma Berenices (Berenice's Hair) lies the impressive Coma Cluster — a structure of over a thou...</Credits>
@@ -88296,6 +89269,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1839aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1839a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASAAcknowledgement; This NASA/ESA Hubble Space Telescope image contains a veritable mix of different galaxies, some of which belong to the same larg...</Credits>
@@ -88348,6 +89322,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1841aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1841a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This image from the NASA/ESA Hubble Space Telescope reveals a spiral galaxy named Messier 95 (also known as M95 or NGC 3351). Lo...</Credits>
@@ -88374,6 +89349,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1842aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1842a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA Acknowledgemen; This image, taken with the  NASA/ESA Hubble Space Telescope's  Wide Field Camera 3 (WFC3), shows a patch of space filled with ga...</Credits>
@@ -88400,6 +89376,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1843aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1843a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASAAcknowledgement; This Picture of the Week shows the unbarred spiral galaxy NGC 5033, located about 40 million light-years away in the constellati...</Credits>
@@ -88426,6 +89403,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1845aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1845a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This captivating image from the NASA/ESA Hubble Space Telescope’s Wide Field Camera 3 shows a lonely dwarf galaxy, a staggering ...</Credits>
@@ -88452,6 +89430,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1846aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1846a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASAAcknowledgement; At first glance, a bright blue crescent immediately jumps out of this NASA/ESA Hubble Space Telescope image: is it a bird? A pla...</Credits>
@@ -88478,6 +89457,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1847aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1847a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; Star clusters are common structures throughout the Universe, each made up of hundreds of thousands of stars all bound together b...</Credits>
@@ -88504,6 +89484,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1848aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1848a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA; This dark, tangled web is an object named SNR 0454-67.2. It formed in a very violent fashion — it is a supernova remnant, create...</Credits>
@@ -88530,6 +89511,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="6"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1849aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1849a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, J. Mack, and J. Madri; This image, from the NASA/ESA Hubble Space Telescope’s Advanced Camera for Surveys (ACS), reveals thousands of globular clusters...</Credits>
@@ -88556,6 +89538,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1851aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1851a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA, and A. Shapley (UCLA); For three weeks in October, Hubble’s eyes on the Universe closed. On the evening of Friday 5 October, the orbiting observatory p...</Credits>
@@ -88582,6 +89565,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1852aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1852a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA; This image from the NASA/ESA Hubble Space Telescope reveals an ancient, glimmering ball of stars called NGC 1466. It is a globul...</Credits>
@@ -88608,6 +89592,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1853aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1853a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, K. Stapelfeld; In this image the NASA/ESA Hubble Space Telescope has captured the smoking gun of a newborn star, the Herbig–Haro objects number...</Credits>
@@ -88634,6 +89619,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="5"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1901aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1901a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, C. Sarazin et; It might appear featureless and unexciting at first glance, but NASA/ESA Hubble Space Telescope observations of this elliptical ...</Credits>
@@ -88660,6 +89646,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1902aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1902a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, S. Faber et a; This huge ball of stars — around 100 billion in total — is an elliptical galaxy located some 55 million light-years away from us...</Credits>
@@ -88686,6 +89673,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1903aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1903a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, M. Gladders e; This picture showcases a gravitational lensing system called SDSS J0928+2031. Quite a few images of this type of lensing have be...</Credits>
@@ -88712,6 +89700,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1904aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1904a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, Cramer et al.; This striking image combines data gathered with the Advanced Camera for Surveys, installed on the NASA/ESA Hubble Space Telescop...</Credits>
@@ -88738,6 +89727,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1905aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1905a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, R. O'Connell; This atmospheric image shows a galaxy named Messier 85, captured in all its delicate, hazy glory by the NASA/ESA Hubble Space Te...</Credits>
@@ -88764,6 +89754,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1908aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1908a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, S. Larsen et ; Globular clusters like NGC 2419, visible in this image taken with the NASA/ESA Hubble Space Telescope, are not only beautiful, b...</Credits>
@@ -88790,6 +89781,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1909aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1909a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, A. Adamo et a; Located in the constellation of Hercules, about 230 million light-years away, NGC 6052 is a pair of colliding galaxies. They wer...</Credits>
@@ -88816,6 +89808,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1910aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1910a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, J. E. Grindla; This Hubble Picture of the Week shows Messier 28, a globular cluster in the constellation of Sagittarius (The Archer), in jewel-...</Credits>
@@ -88842,6 +89835,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1911aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1911a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, J. Blakenslee; This fuzzy orb of light is a giant elliptical galaxy filled with an incredible 200 billion stars. Unlike spiral galaxies, which ...</Credits>
@@ -88868,6 +89862,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1912aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1912a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, P. Dobbie et ; This star-studded image shows us a portion of Messier 11, an open star cluster in the southern constellation of Scutum (The Shie...</Credits>
@@ -88894,6 +89889,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1913aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1913a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, G. Piotto et ; Star clusters are commonly featured in cosmic photoshoots, and are also well-loved by the keen eye of the NASA/ESA Hubble Space ...</Credits>
@@ -88920,6 +89916,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1914aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1914a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, G. Piotto et ; Globular clusters are inherently beautiful objects, but the subject of this NASA/ESA Hubble Space Telescope image, Messier 3, is...</Credits>
@@ -88946,6 +89943,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1915aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1915a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, S. Anderson e; Most globular clusters are almost perfectly spherical collections of stars — but Messier 62 breaks the mould. The 12-billion-yea...</Credits>
@@ -88972,6 +89970,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1916aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1916a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, F. Ferraro et; This sparkling burst of stars is Messier 75. It is a globular cluster: a spherical collection of stars bound together by gravity...</Credits>
@@ -88998,6 +89997,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1917aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1917a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, L. Ho et al.; Few of the Universe’s residents are as iconic as the spiral galaxy. These limelight-hogging celestial objects combine whirling, ...</Credits>
@@ -89024,6 +90024,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1918aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1918a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, I. Karachents; Dotted across the sky in the constellation of Pictor (The Painter’s Easel) is the galaxy cluster highlighted here by the NASA/ES...</Credits>
@@ -89050,6 +90051,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1919aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1919a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, B. Lehmer et ; NGC 3384, visible in this image, has many of the features characteristic of so-called elliptical galaxies. Such galaxies glow di...</Credits>
@@ -89076,6 +90078,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1920aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1920a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, W. Sargent et; This Picture of the Week stars Messier 90, a beautiful spiral galaxy located roughly 60 million light-years from the Milky Way i...</Credits>
@@ -89102,6 +90105,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1921aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1921a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, P. Cote; This luminous orb is the galaxy NGC 4621, better known as Messier 59. As this latter moniker indicates, the galaxy was listed in...</Credits>
@@ -89128,6 +90132,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1922aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1922a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, J. Walsh; This striking image was taken by the NASA/ESA Hubble Space Telescope’s Wide Field Camera 3, a powerful instrument installed on t...</Credits>
@@ -89154,6 +90159,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1923aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1923a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, D. Crenshaw a; When massive stars die at the end of their short lives, they light up the cosmos with bright, explosive bursts of light and mate...</Credits>
@@ -89180,6 +90186,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="4"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1924aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1924a"
     Xcxstatus="queue:hubble"
   >
     <Credits>NASA, ESA and F. Bauer; This image shows an irregular galaxy named IC 10, a member of the Local Group — a collectiongrouping of over 50 galaxies inwithi...</Credits>
@@ -89206,6 +90213,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="2"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1925aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1925a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble &amp; NASA, V. Rubin et a; This Hubble Picture of the Week shows the spiral galaxy Messier 98, which is located about 45 million light-years away in the co...</Credits>
@@ -89232,6 +90240,7 @@ galaxy has been found in data from NASA's Chandra X-ray Observator...</Credits>
     TileLevels="3"
     Url="http://wwtfiles.blob.core.windows.net/vamp/Hubble-potw1926aL{1}X{2}Y{3}.png"
     WidthFactor="1"
+    Xastropix_ids="esahubble|potw1926a"
     Xcxstatus="queue:hubble"
   >
     <Credits>ESA/Hubble, NASA, L. Ho; This NASA/ESA Hubble Space Telescope Picture of the Week shows bright, colourful pockets of star formation blooming like roses i...</Credits>

--- a/imagesets/sky__visible.xml
+++ b/imagesets/sky__visible.xml
@@ -38514,6 +38514,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000013322{Q}?g=131"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16as"
     Xcxstatus="in:6607080edc7be96c90c53413"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -38540,6 +38541,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000013330{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16bn"
     Xcxstatus="in:6607080edc7be96c90c53415"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -38566,6 +38568,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000013331{Q}?g=131"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16aq"
     Xcxstatus="in:6607080fdc7be96c90c53417"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -38592,6 +38595,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000020020{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16bp"
     Xcxstatus="in:66070810dc7be96c90c53419"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -40315,6 +40319,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000012001{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16bc"
     Xcxstatus="in:66070811dc7be96c90c5341b"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -40341,6 +40346,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000012011{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16as"
     Xcxstatus="in:66070812dc7be96c90c5341d"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -40367,6 +40373,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="0"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000012101{Q}?g=131"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16ah"
     Xcxstatus="in:66070813dc7be96c90c5341f"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -40393,6 +40400,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000012111{Q}?g=131"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16ab"
     Xcxstatus="in:66070814dc7be96c90c53421"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -40419,6 +40427,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000012211{Q}?g=131"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16am"
     Xcxstatus="in:660708d3dc7be96c90c53481"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and K. Noll (STScI)</Credits>
@@ -40445,6 +40454,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000012311{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16cc"
     Xcxstatus="in:66070815dc7be96c90c53423"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -40471,6 +40481,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000012321{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16bf"
     Xcxstatus="in:66070816dc7be96c90c53425"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -40497,6 +40508,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000012331{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16bm"
     Xcxstatus="in:66070817dc7be96c90c53427"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -40523,6 +40535,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000013021{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16aw"
     Xcxstatus="in:66070818dc7be96c90c53429"
   >
     <Credits>The Hubble image was created using HST data from proposal 10592: A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University). NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -40549,6 +40562,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000013031{Q}?g=131"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16ab"
     Xcxstatus="in:66070819dc7be96c90c5342b"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -40575,6 +40589,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000013101{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16bg"
     Xcxstatus="in:6607081adc7be96c90c5342d"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -40601,6 +40616,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000013211{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16au"
     Xcxstatus="in:6607081bdc7be96c90c5342f"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -40627,6 +40643,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000013231{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16av"
     Xcxstatus="in:6607081cdc7be96c90c53431"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -40653,6 +40670,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000020001{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16ca"
     Xcxstatus="in:6607081ddc7be96c90c53433"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -42370,6 +42388,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000012012{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16bx"
     Xcxstatus="in:6607081edc7be96c90c53435"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -42396,6 +42415,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000012022{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16bt"
     Xcxstatus="in:6607081fdc7be96c90c53437"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -42422,6 +42442,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000012102{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16be"
     Xcxstatus="in:6607081fdc7be96c90c53439"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -42448,6 +42469,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000012122{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16bv"
     Xcxstatus="in:66070820dc7be96c90c5343b"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -42474,6 +42496,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000012202{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16br"
     Xcxstatus="in:66070821dc7be96c90c5343d"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -42500,6 +42523,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000012222{Q}?g=131"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16af"
     Xcxstatus="in:66070822dc7be96c90c5343f"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -42526,6 +42550,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000012322{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16ay"
     Xcxstatus="in:66070823dc7be96c90c53441"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -42552,6 +42577,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000013012{Q}?g=131"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16at"
     Xcxstatus="in:66070824dc7be96c90c53443"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -42578,6 +42604,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000013032{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16bd"
     Xcxstatus="in:66070825dc7be96c90c53445"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -42604,6 +42631,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000013132{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16cg"
     Xcxstatus="in:66070826dc7be96c90c53447"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -42630,6 +42658,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000013202{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16cd"
     Xcxstatus="in:66070827dc7be96c90c53449"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -42656,6 +42685,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000013222{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16bs"
     Xcxstatus="in:66070828dc7be96c90c5344b"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -44245,6 +44275,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000012003{Q}?g=131"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16ad"
     Xcxstatus="in:66070829dc7be96c90c5344d"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -44271,6 +44302,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000012033{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16bw"
     Xcxstatus="in:6607082adc7be96c90c5344f"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -44324,6 +44356,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000012213{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16by"
     Xcxstatus="in:6607082bdc7be96c90c53451"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -44350,6 +44383,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000012223{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16ba"
     Xcxstatus="in:6607082cdc7be96c90c53453"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -44376,6 +44410,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000012313{Q}?g=131"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16aa"
     Xcxstatus="in:6607082ddc7be96c90c53455"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -44402,6 +44437,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000013013{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16bk"
     Xcxstatus="in:6607082edc7be96c90c53457"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -44428,6 +44464,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000013103{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16ax"
     Xcxstatus="in:6607082fdc7be96c90c53459"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -44454,6 +44491,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000013113{Q}?g=131"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16al"
     Xcxstatus="in:6607082fdc7be96c90c5345b"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -44480,6 +44518,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000013133{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16bz"
     Xcxstatus="in:66070830dc7be96c90c5345d"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -44506,6 +44545,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000013203{Q}?g=131"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16ae"
     Xcxstatus="in:66070831dc7be96c90c5345f"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -44532,6 +44572,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000013213{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16bj"
     Xcxstatus="in:66070832dc7be96c90c53461"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>
@@ -44584,6 +44625,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000013323{Q}?g=182"
     WidthFactor="2"
+    Xastropix_ids="stsci|2008-16bl"
     Xcxstatus="in:66070834dc7be96c90c53465"
   >
     <Credits>NASA, ESA, the Hubble Heritage (STScI/AURA)-ESA/Hubble Collaboration, and A. Evans (University of Virginia, Charlottesville/NRAO/Stony Brook University)</Credits>

--- a/imagesets/sky__visible.xml
+++ b/imagesets/sky__visible.xml
@@ -32891,6 +32891,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/packages/2022/07_jwst/carina_nircam/{1}/{3}/{3}_{2}.png"
     WidthFactor="2"
+    Xastropix_ids="stsci|2022-031a"
     Xcxstatus="in:642761e7975014bc743f15a1"
   >
     <Credits>NASA, ESA, CSA, STScI, Webb ERO Production Team</Credits>
@@ -32957,6 +32958,7 @@ NIRCam was built by a team at the University of Arizona and Lockheed Martin’s 
     TileLevels="3"
     Url="http://data1.wwtassets.org/packages/2022/07_jwst/jwst_s_ring_miri/{1}/{3}/{3}_{2}.png"
     WidthFactor="2"
+    Xastropix_ids="stsci|2022-033c"
     Xcxstatus="in:642761e9975014bc743f15a3"
   >
     <Credits>NASA, ESA, CSA, STScI, Webb ERO Production Team</Credits>
@@ -33000,6 +33002,7 @@ MIRI was contributed by ESA and NASA, with the instrument designed and built by 
     TileLevels="5"
     Url="http://data1.wwtassets.org/packages/2022/07_jwst/jwst_s_ring_nircam/{1}/{3}/{3}_{2}.png"
     WidthFactor="2"
+    Xastropix_ids="stsci|2022-033b"
     Xcxstatus="in:642761e9975014bc743f15a4"
   >
     <Credits>NASA, ESA, CSA, STScI, Webb ERO Production Team</Credits>
@@ -33045,6 +33048,7 @@ NIRCam was built by a team at the University of Arizona and Lockheed Martin’s 
     TileLevels="5"
     Url="http://data1.wwtassets.org/packages/2022/07_jwst/smacs0723/{1}/{3}/{3}_{2}.png"
     WidthFactor="2"
+    Xastropix_ids="stsci|2022-035a"
     Xcxstatus="in:642761ea975014bc743f15a7"
   >
     <Credits>NASA, ESA, CSA, STScI, Webb ERO Production Team</Credits>
@@ -33073,6 +33077,7 @@ NIRCam was built by a team at the University of Arizona and Lockheed Martin’s 
     TileLevels="6"
     Url="http://data1.wwtassets.org/packages/2022/07_jwst/weic2208a/{1}/{3}/{3}_{2}.png"
     WidthFactor="2"
+    Xastropix_ids="stsci|2022-034a"
     Xcxstatus="in:642761ea975014bc743f15a5"
   >
     <Credits>NASA, ESA, CSA, STScI, Webb ERO Production Team</Credits>
@@ -33153,6 +33158,7 @@ NIRCam was built by a team at the University of Arizona and Lockheed Martin’s 
     TileLevels="3"
     Url="http://data1.wwtassets.org/packages/2022/08_jwst/cartwheel_miri/{1}/{3}/{3}_{2}.png"
     WidthFactor="2"
+    Xastropix_ids="stsci|2022-039b"
     Xcxstatus="in:642761e6975014bc743f15a0"
   >
     <Credits>NASA, ESA, CSA, STScI, Webb ERO Production Team</Credits>
@@ -33383,6 +33389,7 @@ The smaller spiral galaxy to the upper left of Cartwheel displays much of the sa
     TileLevels="3"
     Url="http://data1.wwtassets.org/packages/2022/12_jwst/VV191a/{1}/{3}/{3}_{2}.png"
     WidthFactor="2"
+    Xastropix_ids="stsci|2022-503a"
     Xcxstatus="in:642761e0975014bc743f1591"
   >
     <Credits>NASA, ESA, CSA, W. Keel, R. Windhorst, and STScI</Credits>
@@ -33491,6 +33498,7 @@ The smaller spiral galaxy to the upper left of Cartwheel displays much of the sa
     TileLevels="4"
     Url="http://data1.wwtassets.org/packages/2022/12_jwst/jades/{1}/{3}/{3}_{2}.png"
     WidthFactor="2"
+    Xastropix_ids="stsci|2023-127a"
     Xcxstatus="in:642761de975014bc743f158d"
   >
     <Credits>IMAGE: NASA, ESA, CSA, M. Zamani (ESA/Webb)

--- a/imagesets/sky__visible.xml
+++ b/imagesets/sky__visible.xml
@@ -36511,6 +36511,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000000230{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2005-35a"
     Xcxstatus="in:6564c460f864172823763c23"
   >
     <Credits>Credit: NASA, ESA, and A. Nota (STScI/ESA)</Credits>
@@ -36886,6 +36887,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000001210{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2005-12x"
     Xcxstatus="in:64276319975014bc743f17bb"
   >
     <Credits>Photo Credit: T.A.Rector (University of Alaska Anchorage, NRAO/AUI/NSF and NOAO/AURA/NSF) and B.A.Wolpa (NOAO/AURA/NSF)</Credits>
@@ -37441,6 +37443,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000002330{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-17c"
     Xcxstatus="in:65aea06f3d5676423ec14c10"
   >
     <Credits>Image Credit: European Space Agency &amp; NASA Acknowledgment: E. Olszewski (University of Arizona)</Credits>
@@ -37653,6 +37656,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="1"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000003230{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2004-17d"
     Xcxstatus="in:65d8c482affb32cbf1d96a65"
   >
     <Credits>Image Credit: NASA, ESA, and The Hubble Heritage Team (AURA/STScI) Acknowledgment: F. Yusef-Zadeh (Northwestern Univ.)</Credits>
@@ -37706,6 +37710,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000003310{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2007-17a"
     Xcxstatus="in:65dccffcaffb32cbf1d96fba"
   >
     <Credits>Credit: NASA, ESA, M.J. Jee and H. Ford (Johns Hopkins University)</Credits>
@@ -37813,7 +37818,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000010010{Q}?g=138"
     WidthFactor="2"
-    Xastropix_ids="stsci|1995-02b"
+    Xastropix_ids="stsci|1995-02b,stsci|2007-17d"
     Xcxstatus="in:65dcd000affb32cbf1d96fc2"
   >
     <Credits>Kirk Borne (STScI), and NASA</Credits>
@@ -38682,7 +38687,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000000221{Q}?g=138"
     WidthFactor="2"
-    Xastropix_ids="stsci|1997-38e"
+    Xastropix_ids="stsci|1997-38e,stsci|1998-11i"
     Xcxstatus="in:661fef61befbe21fbdf49b95"
   >
     <Credits>Credits: Howard Bond (Space Telescope Science Institute), Robin Ciardullo (Pennsylvania State University) and NASA</Credits>
@@ -38843,6 +38848,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001011{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2005-12e"
     Xcxstatus="in:661fef66befbe21fbdf49ba1"
   >
     <Credits>Credit: NASA, ESA, and The Hubble Heritage Team (STScI/AURA)</Credits>
@@ -39110,6 +39116,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="5"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001231{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2005-12b"
     Xcxstatus="in:661fef70befbe21fbdf49bb5"
   >
     <Credits>Credit: NASA, ESA, and The Hubble Heritage Team (STScI/AURA)</Credits>
@@ -39618,6 +39625,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003001{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2005-25a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA and The Hubble Heritage Team (STScI/AURA) Acknowledgment: J. Biretta (STScI)</Credits>
@@ -39910,6 +39918,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000003231{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2005-15a"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, HEIC, and The Hubble Heritage Team (STScI/AURA) Acknowledgment: Y.-H. Chu and R. M. Williams (UIUC)</Credits>
@@ -40939,6 +40948,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="3"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000000322{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2003-30b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA and The Hubble Heritage Team (AURA/STScI)</Credits>
@@ -41151,6 +41161,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="2"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000001202{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2005-12g"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, and The Hubble Heritage Team (STScI/AURA)</Credits>
@@ -41603,6 +41614,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="4"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000002232{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2004-29l"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, The Hubble Heritage Team (STScI/AURA) Acknowledgment: R. Sankrit and W. Blair (Johns Hopkins University)</Credits>
@@ -42299,6 +42311,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="5"
     Url="http://r{S:2}.ortho.tiles.virtualearth.net/tiles/wsa0000010202{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-07c"
     Xcxstatus="queue:hubble"
   >
     <Credits>Credit: NASA, ESA, The Hubble Heritage Team, (STScI/AURA) and A. Riess (STScI)</Credits>
@@ -43066,6 +43079,7 @@ Messier 78 lies 1300 light-years away in the constellation of Orion.
     TileLevels="5"
     Url="http://r{S:3}.ortho.tiles.virtualearth.net/tiles/wsa0000001213{Q}?g=138"
     WidthFactor="2"
+    Xastropix_ids="stsci|2006-51b"
     Xcxstatus="queue:hubble"
   >
     <Credits>Hubble and Chandra Image Credit: NASA, ESA, CXC, STScI, and B. McNamara (University of Waterloo) Very Large Array Telescope Image Credit: NRAO, and L. Birzan and team (Ohio University)</Credits>

--- a/imagesets/sky__visible.xml
+++ b/imagesets/sky__visible.xml
@@ -17228,6 +17228,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/ann21013c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|ann21013c"
     Xcxstatus="in:6427623a975014bc743f15e4"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURAAcknowledgements: J. Miller (Gemini Observatory/NOIRLab), T.A. Rector (University of Alaska Anchorage/NSF’s NOIRLab), M. Zamani &amp;amp; D. de Martin (NSF’s NOIRLab)  </Credits>
@@ -17256,6 +17257,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/ann21023a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|ann21023a"
     Xcxstatus="in:6427623b975014bc743f15e5"
   >
     <Credits>Dark Energy Survey/DOE/FNAL/DECam/CTIO/NOIRLab/NSF/AURA Acknowledgments: T.A. Rector (University of Alaska Anchorage/NSF’s NOIRLab), M. Zamani (NSF’s NOIRLab) &amp;amp; D. de Martin (NSF’s NOIRLab)</Credits>
@@ -17284,6 +17286,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini-20061001-ngc7009-ao/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini-20061001-ngc7009-ao"
     Xcxstatus="in:6427623b975014bc743f15e6"
   >
     <Credits>International Gemini Observatory</Credits>
@@ -17312,6 +17315,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini-20070806-ngc6520gem-clnflattrim/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini-20070806-ngc6520gem-clnflattrim"
     Xcxstatus="in:6427623c975014bc743f15e7"
   >
     <Credits>International Gemini Observatory</Credits>
@@ -17340,6 +17344,7 @@
     TileLevels="1"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini-20080825-galactic-center-abu-0001/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini-20080825-galactic-center-abu-0001"
     Xcxstatus="in:6427623c975014bc743f15e8"
   >
     <Credits>International Gemini Observatory/NOIRLab/Abu Team</Credits>
@@ -17368,6 +17373,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini-20080825-gemini-deepf-quasar-0001/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini-20080825-gemini-deepf-quasar-0001"
     Xcxstatus="in:6427623d975014bc743f15e9"
   >
     <Credits>International Gemini Observatory/Isobel Hook and the GMOS System Verification Team</Credits>
@@ -17396,6 +17402,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini-20080825-m2-9-0001/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini-20080825-m2-9-0001"
     Xcxstatus="in:6427623d975014bc743f15ea"
   >
     <Credits>International Gemini Observatory</Credits>
@@ -17424,6 +17431,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini-20080825-ngc6357-0001/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini-20080825-ngc6357-0001"
     Xcxstatus="in:6427623e975014bc743f15eb"
   >
     <Credits>International Gemini Observatory/University of Florida/Nidia Morrell/UNLP-CONICET</Credits>
@@ -17452,6 +17460,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini-20080825-trapezium-m42-0001/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini-20080825-trapezium-m42-0001"
     Xcxstatus="in:6427623e975014bc743f15ec"
   >
     <Credits>International Gemini Observatory/University of Florida/Phil Lucas</Credits>
@@ -17480,6 +17489,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini-2013-ngc2346-legacy/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini-2013-ngc2346-legacy"
     Xcxstatus="in:6427623f975014bc743f15ed"
   >
     <Credits>International Gemini Observatory, Letizia Stanghellini (National Optical Astronomy Observatory) and T.A. Rector (University of Alaska Anchorage)</Credits>
@@ -17508,6 +17518,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini-2013-rcw41-legacy/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini-2013-rcw41-legacy"
     Xcxstatus="in:6427623f975014bc743f15ee"
   >
     <Credits>International Gemini Observatory, Henri Michel Pierre Plana (Universidade Estadual de Santa Cruz) and T.A. Rector (University of Alaska Anchorage)</Credits>
@@ -17536,6 +17547,7 @@
     TileLevels="1"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini-bowshock-color/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini-bowshock-color"
     Xcxstatus="in:6427623f975014bc743f15ef"
   >
     <Credits>International Gemini Observatory, National Science Foundation and the University of Hawaii Adaptive Optics Group</Credits>
@@ -17564,6 +17576,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini-gccolor/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini-gccolor"
     Xcxstatus="in:64276240975014bc743f15f0"
   >
     <Credits>International Gemini Observatory, National Science Foundation and the University of Hawaii Adaptive Optics Group</Credits>
@@ -17620,6 +17633,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini-ngc7232-final/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini-ngc7232-final"
     Xcxstatus="in:64276241975014bc743f15f2"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA/T. A. Rector (University of Alaska Anchorage)</Credits>
@@ -17648,6 +17662,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini-vv166-final/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini-vv166-final"
     Xcxstatus="in:64276242975014bc743f15f3"
   >
     <Credits>International Gemini Observatory/AURA</Credits>
@@ -17676,6 +17691,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0101a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0101a"
     Xcxstatus="in:64276242975014bc743f15f4"
   >
     <Credits>International Gemini Observatory</Credits>
@@ -17704,6 +17720,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0101b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0101b"
     Xcxstatus="in:64276243975014bc743f15f5"
   >
     <Credits>International Gemini Observatory</Credits>
@@ -17732,6 +17749,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0101c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0101c"
     Xcxstatus="in:64276243975014bc743f15f6"
   >
     <Credits>International Gemini Observatory</Credits>
@@ -17760,6 +17778,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0207a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0207a"
     Xcxstatus="in:64276243975014bc743f15f7"
   >
     <Credits>International Gemini Observatory/Ingrid Braul, Southlands Elementary, Vancouver BC</Credits>
@@ -17788,6 +17807,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0302a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0302a"
     Xcxstatus="in:64276244975014bc743f15f8"
   >
     <Credits>International Gemini Observatory</Credits>
@@ -17816,6 +17836,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0302b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0302b"
     Xcxstatus="in:64276244975014bc743f15f9"
   >
     <Credits>Hubble Heritage Team/STScI/AURA/NASA</Credits>
@@ -17844,6 +17865,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0401c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0401c"
     Xcxstatus="in:64276245975014bc743f15fa"
   >
     <Credits>Gemini Observatory: GMOS Commissioning Team`</Credits>
@@ -17872,6 +17894,7 @@
     TileLevels="1"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0401d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0401d"
     Xcxstatus="in:64276245975014bc743f15fb"
   >
     <Credits>Isaac Newton Telescope, Jonathan Irwin</Credits>
@@ -17900,6 +17923,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0402a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0402a"
     Xcxstatus="in:64276246975014bc743f15fc"
   >
     <Credits>International Gemini Observatory</Credits>
@@ -17928,6 +17952,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0406a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0406a"
     Xcxstatus="in:64276246975014bc743f15fd"
   >
     <Credits>“Canada-France-Hawaii Telescope/J.-C. Cuillandre/Coelum”</Credits>
@@ -17956,6 +17981,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0501a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0501a"
     Xcxstatus="in:64276247975014bc743f15fe"
   >
     <Credits>International Gemini Observatory/AURA/Manuel Paredes</Credits>
@@ -17984,6 +18010,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0502b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0502b"
     Xcxstatus="in:64276247975014bc743f15ff"
   >
     <Credits>International Gemini Observatory</Credits>
@@ -18012,6 +18039,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0502c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0502c"
     Xcxstatus="in:64276248975014bc743f1600"
   >
     <Credits>International Gemini Observatory/Travis Rector, University of Alaska Anchorage</Credits>
@@ -18068,6 +18096,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0509c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0509c"
     Xcxstatus="in:64276249975014bc743f1602"
   >
     <Credits>International Gemini Observatory</Credits>
@@ -18096,6 +18125,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0601a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0601a"
     Xcxstatus="in:64276249975014bc743f1603"
   >
     <Credits>International Gemini Observatory</Credits>
@@ -18124,6 +18154,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0602f/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0602f"
     Xcxstatus="in:64276249975014bc743f1604"
   >
     <Credits>NOIRLab</Credits>
@@ -18152,6 +18183,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0603a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0603a"
     Xcxstatus="in:6427624a975014bc743f1605"
   >
     <Credits>International Gemini Observatory</Credits>
@@ -18180,6 +18212,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0604b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0604b"
     Xcxstatus="in:6427624a975014bc743f1606"
   >
     <Credits>International Gemini Observatory</Credits>
@@ -18208,6 +18241,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0605a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0605a"
     Xcxstatus="in:6427624b975014bc743f1607"
   >
     <Credits>International Gemini Observatory</Credits>
@@ -18236,6 +18270,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0605b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0605b"
     Xcxstatus="in:6427624b975014bc743f1608"
   >
     <Credits>International Gemini Observatory</Credits>
@@ -18264,6 +18299,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0607a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0607a"
     Xcxstatus="in:6427624c975014bc743f1609"
   >
     <Credits>International Gemini Observatory/GMOS Commissioning Team</Credits>
@@ -18292,6 +18328,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0703a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0703a"
     Xcxstatus="in:6427624c975014bc743f160a"
   >
     <Credits>International Gemini Observatory</Credits>
@@ -18320,6 +18357,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0707b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0707b"
     Xcxstatus="in:6427624d975014bc743f160b"
   >
     <Credits>Inseok Song/Digital Sky Survey, inset: Gemini Observatory/Lynette Cook</Credits>
@@ -18348,6 +18386,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0801a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0801a"
     Xcxstatus="in:6427624d975014bc743f160c"
   >
     <Credits>P. Michaud, S. Fisher, and R. Carrasco from Gemini and T. Rector from the Univ. of Alaska at Anchorage/International Gemini Observatory</Credits>
@@ -18376,6 +18415,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0805a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0805a"
     Xcxstatus="in:6427624e975014bc743f160d"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA</Credits>
@@ -18404,6 +18444,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0901a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0901a"
     Xcxstatus="in:6427624e975014bc743f160e"
   >
     <Credits>International Gemini Observatory</Credits>
@@ -18432,6 +18473,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini0901b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini0901b"
     Xcxstatus="in:6427624e975014bc743f160f"
   >
     <Credits>International Gemini Observatory</Credits>
@@ -18460,6 +18502,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini1004a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini1004a"
     Xcxstatus="in:6427624f975014bc743f1610"
   >
     <Credits>International Gemini Observatory</Credits>
@@ -18488,6 +18531,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini1006b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini1006b"
     Xcxstatus="in:6427624f975014bc743f1611"
   >
     <Credits>R. Carrasco et al., International Gemini Observatory/AURA</Credits>
@@ -18516,6 +18560,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini1007a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini1007a"
     Xcxstatus="in:64276250975014bc743f1612"
   >
     <Credits>International Gemini Observatory</Credits>
@@ -18544,6 +18589,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini1104a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini1104a"
     Xcxstatus="in:64276250975014bc743f1613"
   >
     <Credits>International Gemini Observatory/AURA/Australian Gemini Office</Credits>
@@ -18572,6 +18618,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini1108a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini1108a"
     Xcxstatus="in:64276251975014bc743f1614"
   >
     <Credits>International Gemini Observatory/AURA</Credits>
@@ -18600,6 +18647,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini1205a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini1205a"
     Xcxstatus="in:64276251975014bc743f1615"
   >
     <Credits>International Gemini Observatory</Credits>
@@ -18656,6 +18704,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini1301a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini1301a"
     Xcxstatus="in:64276252975014bc743f1617"
   >
     <Credits>International Gemini Observatory/AURA</Credits>
@@ -18684,6 +18733,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini1306a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini1306a"
     Xcxstatus="in:64276253975014bc743f1618"
   >
     <Credits>International Gemini Observatory/AURA</Credits>
@@ -18712,6 +18762,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini1306c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini1306c"
     Xcxstatus="in:64276253975014bc743f1619"
   >
     <Credits>International Gemini Observatory/AURA</Credits>
@@ -18740,6 +18791,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini1306d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini1306d"
     Xcxstatus="in:64276254975014bc743f161a"
   >
     <Credits>International Gemini Observatory/AURA</Credits>
@@ -18768,6 +18820,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini1307c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini1307c"
     Xcxstatus="in:64276254975014bc743f161b"
   >
     <Credits>International Gemini Observatory, J. Bally and A. Ginsberg (University of Colorado) and T.A. Rector (University of Alaska Anchorage)</Credits>
@@ -18796,6 +18849,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini1504a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini1504a"
     Xcxstatus="in:64276255975014bc743f161c"
   >
     <Credits>NOIRLab</Credits>
@@ -18824,6 +18878,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini1508a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini1508a"
     Xcxstatus="in:64276255975014bc743f161d"
   >
     <Credits>International Gemini Observatory/AURA</Credits>
@@ -18852,6 +18907,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini1604a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini1604a"
     Xcxstatus="in:64276255975014bc743f161e"
   >
     <Credits>International Gemini Observatory/AURA</Credits>
@@ -18880,6 +18936,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/gemini1611a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|gemini1611a"
     Xcxstatus="in:64276256975014bc743f161f"
   >
     <Credits>International Gemini Observatory/AURA</Credits>
@@ -18908,6 +18965,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/geminiann02007a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|geminiann02007a"
     Xcxstatus="in:64276256975014bc743f1620"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA/I. Hook/GMOS System Verification Team</Credits>
@@ -18936,6 +18994,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/geminiann02010a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|geminiann02010a"
     Xcxstatus="in:64276257975014bc743f1621"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA</Credits>
@@ -18964,6 +19023,7 @@
     TileLevels="1"
     Url="http://data1.wwtassets.org/feeds/noirlab/geminiann02010b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|geminiann02010b"
     Xcxstatus="in:64276258975014bc743f1622"
   >
     <Credits>Gemini Observatory/Francois Rigaut</Credits>
@@ -18992,6 +19052,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/geminiann03005a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|geminiann03005a"
     Xcxstatus="in:64276258975014bc743f1623"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA/WIYN Observatory/Dr. L. Macri  </Credits>
@@ -19020,6 +19081,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/geminiann04014a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|geminiann04014a"
     Xcxstatus="in:64276258975014bc743f1624"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA</Credits>
@@ -19048,6 +19110,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/geminiann08002e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|geminiann08002e"
     Xcxstatus="in:64276259975014bc743f1625"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURAThis image was obtained by Gemini Observatory/Colin Aspin and processed into a color composite by Kirk Pu&amp;#x27;uohau-Pummill (Gemini Observatory) and Travis Rector (University of Alaska, Anchorage)</Credits>
@@ -19076,6 +19139,7 @@
     TileLevels="1"
     Url="http://data1.wwtassets.org/feeds/noirlab/geminiann08018a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|geminiann08018a"
     Xcxstatus="in:64276259975014bc743f1626"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA</Credits>
@@ -19104,6 +19168,7 @@
     TileLevels="1"
     Url="http://data1.wwtassets.org/feeds/noirlab/geminiann09001a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|geminiann09001a"
     Xcxstatus="in:6427625a975014bc743f1627"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA</Credits>
@@ -19132,6 +19197,7 @@
     TileLevels="1"
     Url="http://data1.wwtassets.org/feeds/noirlab/geminiann09013c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|geminiann09013c"
     Xcxstatus="in:6427625a975014bc743f1628"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA/M. Westmoquette (UCL)/J. Gallagher (Wisconsin-Madison)/ L. Smith (STScI/UCL)</Credits>
@@ -19160,6 +19226,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/geminiann09019a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|geminiann09019a"
     Xcxstatus="in:6427625b975014bc743f1629"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA/D. Tran (PAL College)/T. Rector (U. Alaska Anchorage)/T. Bridges (Queen&amp;#x27;s U.)/Australian Gemini Office.</Credits>
@@ -19188,6 +19255,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/geminiann10008a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|geminiann10008a"
     Xcxstatus="in:6427625b975014bc743f162a"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA/Émilie Storer (Collège Charlemagne, QUE)/André-Nicolas Chené (HIA/NRCof Canada)/T. Rector (U.Alaska, Anchorage).</Credits>
@@ -19216,6 +19284,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/geminiann11015a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|geminiann11015a"
     Xcxstatus="in:6427625c975014bc743f162b"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA/B. Reynolds (Sutherland Shire Christian School)/T. Rector (University of Alaska, Anchorage)/Australian Gemini Office.</Credits>
@@ -19244,6 +19313,7 @@
     TileLevels="1"
     Url="http://data1.wwtassets.org/feeds/noirlab/geminiann12015a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|geminiann12015a"
     Xcxstatus="in:6427625c975014bc743f162c"
   >
     <Credits>CFHT/ESO/M. Schirmer</Credits>
@@ -19272,6 +19342,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/iotw2019a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|iotw2019a"
     Xcxstatus="in:6427625d975014bc743f162d"
   >
     <Credits>KPNO/NOIRLab/NSF/AURA Acknowledgements:PI: M T. Patterson (New Mexico State University)Image processing: Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -19300,6 +19371,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/iotw2023a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|iotw2023a"
     Xcxstatus="in:6427625d975014bc743f162e"
   >
     <Credits>KPNO/NOIRLab/NSF/AURAAcknowledgements: PI: M T. Patterson (New Mexico State University)Image processing: Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -19328,6 +19400,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/iotw2030a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|iotw2030a"
     Xcxstatus="in:6427625d975014bc743f162f"
   >
     <Credits>KPNO/NOIRLab/NSF/AURAAcknowledgements: PI: M T. Patterson (New Mexico State University)Image processing: Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin  </Credits>
@@ -19356,6 +19429,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/iotw2035a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|iotw2035a"
     Xcxstatus="in:6427625e975014bc743f1630"
   >
     <Credits>KPNO/NOIRLab/NSF/AURA.  Acknowledgments: PI: M T. Patterson (New Mexico State University) Image processing: Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -19384,6 +19458,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/iotw2043a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|iotw2043a"
     Xcxstatus="in:6427625e975014bc743f1631"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA Acknowledgments:Image processing: Jen Miller (Gemini Observatory/NSF&amp;#x27;s NOIRLab), Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -19412,6 +19487,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/iotw2048a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|iotw2048a"
     Xcxstatus="in:6427625f975014bc743f1632"
   >
     <Credits>CTIO/NOIRLab/NSF/AURA Acknowledgments: Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -19440,6 +19516,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/iotw2051b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|iotw2051b"
     Xcxstatus="in:6427625f975014bc743f1633"
   >
     <Credits>CTIO/NOIRLab/NSF/AURA Acknowledgments: Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -19468,6 +19545,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/iotw2101a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|iotw2101a"
     Xcxstatus="in:64276260975014bc743f1634"
   >
     <Credits>KPNO/NOIRLab/NSF/AURA.  Acknowledgments: PI: M T. Patterson (New Mexico State University)Image processing: Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -19496,6 +19574,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/iotw2104a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|iotw2104a"
     Xcxstatus="in:64276260975014bc743f1635"
   >
     <Credits>CTIO/NOIRLab/NSF/AURAAcknowledgment: Image processing: Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -19524,6 +19603,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/iotw2110a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|iotw2110a"
     Xcxstatus="in:64276261975014bc743f1636"
   >
     <Credits>CTIO/NOIRLab/DOE/NSF/AURAImage processing: Travis Rector (University of Alaska, Anchorage/NSF&amp;#x27;s NOIRLab), Jen Miller (Gemini Observatory/NSF&amp;#x27;s NOIRLab), Mahdi Zamani &amp;amp; Davide de Martin (NSF&amp;#x27;s NOIRLab)</Credits>
@@ -19552,6 +19632,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/iotw2113a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|iotw2113a"
     Xcxstatus="in:64276261975014bc743f1637"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA Acknowledgements: PI: Rafael Andrés Pignata (Universidad Nacional de Córdoba)Image processing: T. A. Rector (University of Alaska Anchorage/NSF’s NOIRLab), J. Miller (Gemini Observatory/NSF&amp;#x27;s NOIRLab), M. Zamani &amp;amp; D. de Martin (NSF’s NOIRLab)</Credits>
@@ -19580,6 +19661,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/iotw2115a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|iotw2115a"
     Xcxstatus="in:64276262975014bc743f1638"
   >
     <Credits>CTIO/NOIRLab/NSF/AURA/SMARTS ConsortiumImage processing: T. A. Rector (University of Alaska Anchorage/NSF’s NOIRLab), M. Zamani &amp;amp; D. de Martin (NSF’s NOIRLab)</Credits>
@@ -19608,6 +19690,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/iotw2121a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|iotw2121a"
     Xcxstatus="in:64276263975014bc743f1639"
   >
     <Credits>CTIO/NOIRLab/NSF/AURAAcknowledgment: Image processing: T. A. Rector (University of Alaska Anchorage/NSF’s NOIRLab), M. Zamani &amp;amp; D. de Martin (NSF’s NOIRLab)</Credits>
@@ -19636,6 +19719,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/iotw2126a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|iotw2126a"
     Xcxstatus="in:64276263975014bc743f163a"
   >
     <Credits>KPNO/NOIRLab/NSF/AURAData obtained and processed by: P. Massey (Lowell Obs.), G. Jacoby, K. Olsen, &amp;amp; C. Smith (AURA/NSF)Image processing: T.A. Rector (University of Alaska Anchorage/NSF’s NOIRLab), M. Zamani (NSF’s NOIRLab) &amp;amp; D. de Martin (NSF’s NOIRLab)</Credits>
@@ -19664,6 +19748,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/iotw2127a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|iotw2127a"
     Xcxstatus="in:64276264975014bc743f163b"
   >
     <Credits>Dark Energy Survey/DOE/FNAL/DECam/CTIO/NOIRLab/NSF/AURAImage processing: Travis Rector (University of Alaska Anchorage/NSF’s NOIRLab), Jen Miller (Gemini Observatory/NSF’s NOIRLab), Mahdi Zamani &amp;amp; Davide de Martin (NSF’s NOIRLab)</Credits>
@@ -19692,6 +19777,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/iotw2136a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|iotw2136a"
     Xcxstatus="in:64276264975014bc743f163c"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURAAcknowledgment: T.A. Rector (University of Alaska Anchorage/NSF’s NOIRLab), J. Miller (Gemini Observatory/NSF’s NOIRLab), M. Zamani &amp;amp; D. de Martin (NSF’s NOIRLab)</Credits>
@@ -19720,6 +19806,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao--m101sy/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao--m101sy"
     Xcxstatus="in:64276265975014bc743f163d"
   >
     <Credits>Mike Pierce, John Jurcevic (Indiana)/WIYN/NOIRLab/NSF</Credits>
@@ -19748,6 +19835,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02171/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02171"
     Xcxstatus="in:64276265975014bc743f163e"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -19776,6 +19864,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02172/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02172"
     Xcxstatus="in:64276265975014bc743f163f"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -19804,6 +19893,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02173/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02173"
     Xcxstatus="in:64276266975014bc743f1640"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -19888,6 +19978,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02176/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02176"
     Xcxstatus="in:64276267975014bc743f1643"
   >
     <Credits>Bill Schoening/NOIRLab/NSF/AURA</Credits>
@@ -20000,6 +20091,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02182/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02182"
     Xcxstatus="in:64276269975014bc743f1647"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -20056,6 +20148,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02184/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02184"
     Xcxstatus="in:6427626a975014bc743f1649"
   >
     <Credits>Bill Schoening, Nigel Sharp/NOIRLab/NSF/AURA</Credits>
@@ -20084,6 +20177,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02185/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02185"
     Xcxstatus="in:6427626b975014bc743f164a"
   >
     <Credits>Bill Schoening/NOIRLab/NSF/AURA</Credits>
@@ -20252,6 +20346,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02192/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02192"
     Xcxstatus="in:6427626d975014bc743f1650"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -20308,6 +20403,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02202/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02202"
     Xcxstatus="in:6427626e975014bc743f1652"
   >
     <Credits>Todd Boroson/NOIRLab/NSF/AURA</Credits>
@@ -20336,6 +20432,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02204/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02204"
     Xcxstatus="in:6427626f975014bc743f1653"
   >
     <Credits>Todd Boroson/NOIRLab/NSF/AURA/</Credits>
@@ -20364,6 +20461,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02210/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02210"
     Xcxstatus="in:6427626f975014bc743f1654"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -20392,6 +20490,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02212/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02212"
     Xcxstatus="in:64276270975014bc743f1655"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -20476,6 +20575,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02216/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02216"
     Xcxstatus="in:64276271975014bc743f1658"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -20504,6 +20604,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02268/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02268"
     Xcxstatus="in:64276271975014bc743f1659"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -20532,6 +20633,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02269/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02269"
     Xcxstatus="in:64276272975014bc743f165a"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -20616,6 +20718,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02274/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02274"
     Xcxstatus="in:64276273975014bc743f165d"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -20700,6 +20803,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02283/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02283"
     Xcxstatus="in:64276275975014bc743f1660"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -20868,6 +20972,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02325/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02325"
     Xcxstatus="in:64276278975014bc743f1666"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -20980,6 +21085,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02332/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02332"
     Xcxstatus="in:6427627a975014bc743f166a"
   >
     <Credits>NOIRLab/AURA/NSF</Credits>
@@ -21176,6 +21282,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02342/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02342"
     Xcxstatus="in:6427627d975014bc743f1671"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -21232,6 +21339,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02346/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02346"
     Xcxstatus="in:6427627e975014bc743f1673"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -21260,6 +21368,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02347/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02347"
     Xcxstatus="in:6427627f975014bc743f1674"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -21288,6 +21397,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02349/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02349"
     Xcxstatus="in:6427627f975014bc743f1675"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -21316,6 +21426,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02350/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02350"
     Xcxstatus="in:64276280975014bc743f1676"
   >
     <Credits>NOIRLab/AURA/NSF</Credits>
@@ -21344,6 +21455,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02351/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02351"
     Xcxstatus="in:64276280975014bc743f1677"
   >
     <Credits>NOIRLab/AURA/NSF</Credits>
@@ -21400,6 +21512,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02353/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02353"
     Xcxstatus="in:64276281975014bc743f1679"
   >
     <Credits>NOIRLab/NSF/AURA/NSF</Credits>
@@ -21484,6 +21597,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02463/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02463"
     Xcxstatus="in:64276282975014bc743f167c"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -21568,6 +21682,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02673/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02673"
     Xcxstatus="in:64276284975014bc743f167f"
   >
     <Credits>Bill Schoening/NOIRLab/NSF/AURA</Credits>
@@ -21596,6 +21711,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02674/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02674"
     Xcxstatus="in:64276284975014bc743f1680"
   >
     <Credits>Bill Schoening/NOIRLab/NSF/AURA</Credits>
@@ -21624,6 +21740,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02675/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02675"
     Xcxstatus="in:64276285975014bc743f1681"
   >
     <Credits>Bill Schoening/NOIRLab/NSF/AURA/</Credits>
@@ -21652,6 +21769,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02677/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02677"
     Xcxstatus="in:64276285975014bc743f1682"
   >
     <Credits>Bill Schoening/NOIRLab/NSF/AURA</Credits>
@@ -21680,6 +21798,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02678/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02678"
     Xcxstatus="in:64276285975014bc743f1683"
   >
     <Credits>Bill Schoening/NOIRLab/NSF/AURA</Credits>
@@ -21708,6 +21827,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02881/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02881"
     Xcxstatus="in:64276286975014bc743f1684"
   >
     <Credits>George Jacoby, Bruce Bohannan, Mark Hanna/NOIRLab/NSF/AURA/</Credits>
@@ -21736,6 +21856,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-02953/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-02953"
     Xcxstatus="in:64276286975014bc743f1685"
   >
     <Credits>C. Howk (JHU), B. Savage (U. Wisconsin), N.A.Sharp (NOAO)/WIYN/NOIRLab/NSF</Credits>
@@ -21764,6 +21885,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-03315/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-03315"
     Xcxstatus="in:64276287975014bc743f1686"
   >
     <Credits>K.M. Merrill, NOIRLab/NSF/AURA</Credits>
@@ -21848,6 +21970,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-04086/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-04086"
     Xcxstatus="in:64276288975014bc743f1689"
   >
     <Credits>T.A.Rector (NRAO/AUI/NSF and NOIRLab/NSF/AURA) and B.A.Wolpa (NOIRLab/NSF/AURA)</Credits>
@@ -21904,6 +22027,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-04493/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-04493"
     Xcxstatus="in:64276289975014bc743f168b"
   >
     <Credits>T.A. Rector (NRAO/AUI/NSF and NOIRLab/NSF/AURA) and B.A. Wolpa (NOIRLab/NSF/AURA)</Credits>
@@ -21932,6 +22056,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-04494/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-04494"
     Xcxstatus="in:6427628a975014bc743f168c"
   >
     <Credits>T.A. Rector (NRAO/AUI/NSF and NOIRLab/NSF/AURA)</Credits>
@@ -21960,6 +22085,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-04745/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-04745"
     Xcxstatus="in:6427628a975014bc743f168d"
   >
     <Credits>John Bally (U. Colorado), Bo Reipurth (U. Hawaii)/NOIRLab/NSF/AURA</Credits>
@@ -22016,6 +22142,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-30-doradus/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-30-doradus"
     Xcxstatus="in:6427628b975014bc743f168f"
   >
     <Credits>S. Points, C. Smith, R. Leiton, C. Aguilera and NOIRLab/NSF/AURA</Credits>
@@ -22044,6 +22171,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-6051/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-6051"
     Xcxstatus="in:6427628b975014bc743f1690"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -22072,6 +22200,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-J1337-29_crop1/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-J1337-29_crop1"
     Xcxstatus="in:6427629b975014bc743f16b1"
   >
     <Credits>The SINGG Survey Team and NOIRLab/NSF/AURA/</Credits>
@@ -22128,6 +22257,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-abell74/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-abell74"
     Xcxstatus="in:6427628c975014bc743f1692"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -22184,6 +22314,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-arp-104/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-arp-104"
     Xcxstatus="in:6427628d975014bc743f1694"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -22212,6 +22343,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-arp286/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-arp286"
     Xcxstatus="in:6427628e975014bc743f1695"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -22296,6 +22428,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-crab1/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-crab1"
     Xcxstatus="in:6427628f975014bc743f1698"
   >
     <Credits>Jay Gallagher (U. Wisconsin)/WIYN/NOIRLab/NSF</Credits>
@@ -22324,6 +22457,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-crab3/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-crab3"
     Xcxstatus="in:64276290975014bc743f1699"
   >
     <Credits>Jay Gallagher (U. Wisconsin), N.A. Sharp (NOAO)/WIYN/NOIRLab/NSF</Credits>
@@ -22352,6 +22486,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-cyg_x1/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-cyg_x1"
     Xcxstatus="in:64276290975014bc743f169a"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -22380,6 +22515,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-dumb/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-dumb"
     Xcxstatus="in:64276290975014bc743f169b"
   >
     <Credits>Nigel Sharp, Rich Reed, Dave Dryden, Dave Mills, Doug Williams, Charles Corson, Roger Lynds and Arjun Dey/NOAO/WIYN/NSF</Credits>
@@ -22408,6 +22544,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ear/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ear"
     Xcxstatus="in:64276291975014bc743f169c"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -22436,6 +22573,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-g70-51-9/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-g70-51-9"
     Xcxstatus="in:64276291975014bc743f169d"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -22492,6 +22630,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-hfg1/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-hfg1"
     Xcxstatus="in:64276292975014bc743f169f"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -22520,6 +22659,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-hgc92/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-hgc92"
     Xcxstatus="in:64276293975014bc743f16a0"
   >
     <Credits>International Gemini Observatory/Travis Rector, University of Alaska Anchorage</Credits>
@@ -22546,6 +22686,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-hst0034/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-hst0034"
     Xcxstatus="in:64276293975014bc743f16a1"
   >
     <Credits>Roger Lynds (NOAO), NASA and The Hubble Heritage Team, STScI/AURA</Credits>
@@ -22602,6 +22743,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ic1340/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ic1340"
     Xcxstatus="in:64276294975014bc743f16a3"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -22630,6 +22772,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ic1396/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ic1396"
     Xcxstatus="in:64276295975014bc743f16a4"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and WIYN/NOIRLab/NSF/AURA</Credits>
@@ -22658,6 +22801,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ic1396a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ic1396a"
     Xcxstatus="in:64276295975014bc743f16a5"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage), H. Schweiker &amp;amp; S. Pakzad (NOIRLab/NSF/AURA)</Credits>
@@ -22686,6 +22830,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ic1396b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ic1396b"
     Xcxstatus="in:64276296975014bc743f16a6"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage), H. Schweiker &amp;amp; S. Pakzad (NOIRLab/NSF/AURA)</Credits>
@@ -22714,6 +22859,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ic1396c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ic1396c"
     Xcxstatus="in:64276296975014bc743f16a7"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage), H. Schweiker &amp;amp; S. Pakzad (NOIRLab/NSF/AURA)</Credits>
@@ -22742,6 +22888,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ic1805/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ic1805"
     Xcxstatus="in:64276296975014bc743f16a8"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA</Credits>
@@ -22798,6 +22945,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ic417/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ic417"
     Xcxstatus="in:64276297975014bc743f16aa"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -22826,6 +22974,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ic426/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ic426"
     Xcxstatus="in:64276298975014bc743f16ab"
   >
     <Credits>T. A. Rector/University of Alaska Anchorage, H. Schweiker/WIYN and NOIRLab/NSF/AURA</Credits>
@@ -22854,6 +23003,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ic468/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ic468"
     Xcxstatus="in:64276298975014bc743f16ac"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and NOIRLab/NSF/AURA</Credits>
@@ -22910,6 +23060,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-j0403-43_crop1/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-j0403-43_crop1"
     Xcxstatus="in:64276299975014bc743f16ae"
   >
     <Credits>The SINGG Survey Team and NOIRLab/NSF/AURA</Credits>
@@ -22938,6 +23089,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-j1018-17_crop1/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-j1018-17_crop1"
     Xcxstatus="in:6427629a975014bc743f16af"
   >
     <Credits>The SINGG Survey Team and NOIRLab/NSF/AURA</Credits>
@@ -22966,6 +23118,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-j1318-21_crop1/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-j1318-21_crop1"
     Xcxstatus="in:6427629a975014bc743f16b0"
   >
     <Credits>The SINGG Survey Team and NOIRLab/NSF/AURA</Credits>
@@ -22994,6 +23147,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-j1339-31_crop1/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-j1339-31_crop1"
     Xcxstatus="in:6427629b975014bc743f16b2"
   >
     <Credits>The SINGG Survey Team and NOIRLab/NSF/AURA/</Credits>
@@ -23050,6 +23204,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-kjpn8/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-kjpn8"
     Xcxstatus="in:6427629c975014bc743f16b4"
   >
     <Credits>T.A. Rector/University of Alaska Anchorage, H. Schweiker/WIYN and NOIRLab/NSF/AURA</Credits>
@@ -23078,6 +23233,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-lag/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-lag"
     Xcxstatus="in:6427629c975014bc743f16b5"
   >
     <Credits>N.A.Sharp, REU program/NOIRLab/NSF/AURA</Credits>
@@ -23106,6 +23262,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-lagoon-nebula/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-lagoon-nebula"
     Xcxstatus="in:6427629d975014bc743f16b6"
   >
     <Credits>SSRO/PROMPT/CTIO</Credits>
@@ -23134,6 +23291,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-lbn438/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-lbn438"
     Xcxstatus="in:6427629d975014bc743f16b7"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -23162,6 +23320,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-lbn777/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-lbn777"
     Xcxstatus="in:6427629e975014bc743f16b8"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -23190,6 +23349,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ldn673/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ldn673"
     Xcxstatus="in:6427629e975014bc743f16b9"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -23218,6 +23378,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ldn810/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ldn810"
     Xcxstatus="in:6427629f975014bc743f16ba"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -23246,6 +23407,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m10/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m10"
     Xcxstatus="in:6427629f975014bc743f16bb"
   >
     <Credits>N.A.Sharp, Vanessa Harvey/REU program/NOIRLab/NSF/AURA</Credits>
@@ -23274,6 +23436,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m100/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m100"
     Xcxstatus="in:642762a0975014bc743f16bc"
   >
     <Credits>N.A.Sharp/NOIRLab/NSF/AURA/</Credits>
@@ -23302,6 +23465,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m101sn2011fe/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m101sn2011fe"
     Xcxstatus="in:642762a0975014bc743f16bd"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage), H. Schweiker &amp;amp; S. Pakzad NOIRLab/NSF/AURA</Credits>
@@ -23414,6 +23578,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m105/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m105"
     Xcxstatus="in:642762a2975014bc743f16c1"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -23442,6 +23607,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m106/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m106"
     Xcxstatus="in:642762a2975014bc743f16c2"
   >
     <Credits>N.A.Sharp, REU program/NOIRLab/NSF/AURA/</Credits>
@@ -23470,6 +23636,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m108/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m108"
     Xcxstatus="in:642762a3975014bc743f16c3"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -23498,6 +23665,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m109/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m109"
     Xcxstatus="in:642762a3975014bc743f16c4"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -23554,6 +23722,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m110/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m110"
     Xcxstatus="in:642762a4975014bc743f16c6"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -23582,6 +23751,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m12/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m12"
     Xcxstatus="in:642762a5975014bc743f16c7"
   >
     <Credits>REU Program/NOIRLab/NSF/AURA</Credits>
@@ -23610,6 +23780,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m13kpno4m/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m13kpno4m"
     Xcxstatus="in:642762a5975014bc743f16c8"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -23666,6 +23837,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m15-kpno-0-9-m/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m15-kpno-0-9-m"
     Xcxstatus="in:642762a6975014bc743f16ca"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -23694,6 +23866,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m17/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m17"
     Xcxstatus="in:642762a7975014bc743f16cb"
   >
     <Credits>Hillary Mathis, N.A.Sharp, REU program/NOIRLab/NSF/AURA</Credits>
@@ -23722,6 +23895,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m18/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m18"
     Xcxstatus="in:642762a7975014bc743f16cc"
   >
     <Credits>Hillary Mathis, REU program/NOIRLab/NSF/AURA</Credits>
@@ -23750,6 +23924,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m19/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m19"
     Xcxstatus="in:642762a8975014bc743f16cd"
   >
     <Credits>Doug Williams, REU Program/NOIRLab/NSF/AURA</Credits>
@@ -23778,6 +23953,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m20/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m20"
     Xcxstatus="in:642762a8975014bc743f16ce"
   >
     <Credits>Todd Boroson/NOIRLab/NSF/AURA</Credits>
@@ -23806,6 +23982,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m21/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m21"
     Xcxstatus="in:642762a8975014bc743f16cf"
   >
     <Credits>REU program/NOIRLab/NSF/AURA</Credits>
@@ -23834,6 +24011,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m21a20/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m21a20"
     Xcxstatus="in:642762a9975014bc743f16d0"
   >
     <Credits>REU program/NOIRLab/NSF/AURA</Credits>
@@ -24030,6 +24208,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m3-burrell-schmid/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m3,noirlab|noao-m3-burrell-schmid"
     Xcxstatus="in:642762ac975014bc743f16d7"
   >
     <Credits>N.A.Sharp, Vanessa Harvey/REU program/NOIRLab/NSF/AURA</Credits>
@@ -24058,6 +24237,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m3-kpno-mayall-4-m/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m3-kpno-mayall-4-m"
     Xcxstatus="in:642762ad975014bc743f16d8"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -24086,6 +24266,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m30/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m30"
     Xcxstatus="in:642762ad975014bc743f16d9"
   >
     <Credits>REU program/NOIRLab/NSF/AURA</Credits>
@@ -24114,6 +24295,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m31/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m31"
     Xcxstatus="in:642762ae975014bc743f16da"
   >
     <Credits>T.A.Rector and B.A.Wolpa/NOIRLab/NSF/AURA/</Credits>
@@ -24142,6 +24324,7 @@
     TileLevels="8"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m31lgs_ubvIha/{1}/{3}/{3}_{2}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m31lgs_ubvIha"
     Xcxstatus="in:642762ae975014bc743f16db"
   >
     <Credits>Local Group Survey Team and T.A. Rector (University of Alaska Anchorage)</Credits>
@@ -24168,6 +24351,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m33lgs_ubvIha/{1}/{3}/{3}_{2}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m33lgs_ubvIha"
     Xcxstatus="in:642762af975014bc743f16dc"
   >
     <Credits>Local Group Survey Team and T.A. Rector (University of Alaska Anchorage)</Credits>
@@ -24280,6 +24464,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m39/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m39"
     Xcxstatus="in:642762b1975014bc743f16e0"
   >
     <Credits>Heidi Schweiker/WIYN and NOIRLab/NSF/AURA</Credits>
@@ -24392,6 +24577,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m54/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m54"
     Xcxstatus="in:642762b3975014bc743f16e4"
   >
     <Credits>REU Program/NOIRLab/NSF/AURA</Credits>
@@ -24420,6 +24606,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m55/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m55"
     Xcxstatus="in:642762b3975014bc743f16e5"
   >
     <Credits>Hillary Mathis, REU Program/NOIRLab/NSF/AURA</Credits>
@@ -24448,6 +24635,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m58/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m58"
     Xcxstatus="in:642762b4975014bc743f16e6"
   >
     <Credits> NOIRLab/NSF/AURA/</Credits>
@@ -24476,6 +24664,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m60/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m60"
     Xcxstatus="in:642762b4975014bc743f16e7"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -24504,6 +24693,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m61/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m61"
     Xcxstatus="in:642762b5975014bc743f16e8"
   >
     <Credits>Hillary Mathis, N.A.Sharp/NOIRLab/NSF/AURA/</Credits>
@@ -24560,6 +24750,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m64/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m64"
     Xcxstatus="in:642762b6975014bc743f16ea"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -24616,6 +24807,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m65a66/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m65a66"
     Xcxstatus="in:642762b7975014bc743f16ec"
   >
     <Credits>REU program/NOIRLab/NSF/AURA/</Credits>
@@ -24644,6 +24836,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m66/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m66"
     Xcxstatus="in:642762b7975014bc743f16ed"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -24672,6 +24865,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m67pump/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m67pump"
     Xcxstatus="in:642762b8975014bc743f16ee"
   >
     <Credits>Nigel Sharp, Mark Hanna/NOIRLab/NSF/AURA</Credits>
@@ -24728,6 +24922,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m70/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m70"
     Xcxstatus="in:642762b9975014bc743f16f0"
   >
     <Credits>REU program/NOIRLab/NSF/AURA</Credits>
@@ -24756,6 +24951,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m73/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m73"
     Xcxstatus="in:642762b9975014bc743f16f1"
   >
     <Credits>REU program/NOIRLab/NSF/AURA</Credits>
@@ -24784,6 +24980,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m74/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m74"
     Xcxstatus="in:642762ba975014bc743f16f2"
   >
     <Credits>Todd Boroson/NOIRLab/NSF/AURA/</Credits>
@@ -24812,6 +25009,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m75/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m75"
     Xcxstatus="in:642762ba975014bc743f16f3"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -24868,6 +25066,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m78/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m78"
     Xcxstatus="in:642762bb975014bc743f16f5"
   >
     <Credits>T. A. Rector/University of Alaska Anchorage, H. Schweiker/WIYN and NOIRLab/NSF/AURA</Credits>
@@ -24924,6 +25123,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m79/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m79"
     Xcxstatus="in:642762bc975014bc743f16f7"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -24952,6 +25152,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m8-burrell-schmidt/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m8-burrell-schmidt"
     Xcxstatus="in:642762bd975014bc743f16f8"
   >
     <Credits>N.A.Sharp, REU program/NOIRLab/NSF/AURA</Credits>
@@ -25008,6 +25209,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m81/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m81"
     Xcxstatus="in:642762be975014bc743f16fa"
   >
     <Credits>N.A.Sharp/NOIRLab/NSF/AURA/</Credits>
@@ -25036,6 +25238,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m81m82/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m81m82"
     Xcxstatus="in:642762be975014bc743f16fb"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and NOIRLab/NSF/AURA/</Credits>
@@ -25064,6 +25267,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m82/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m82"
     Xcxstatus="in:642762be975014bc743f16fc"
   >
     <Credits> N.A.Sharp/NOIRLab/NSF/AURA/</Credits>
@@ -25092,6 +25296,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m84/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m84"
     Xcxstatus="in:642762bf975014bc743f16fd"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -25120,6 +25325,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m85/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m85"
     Xcxstatus="in:642762bf975014bc743f16fe"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -25148,6 +25354,7 @@
     TileLevels="1"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m87i/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m87i"
     Xcxstatus="in:642762c0975014bc743f16ff"
   >
     <Credits> NOIRLab/NSF/AURA/</Credits>
@@ -25204,6 +25411,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m90/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m9,noirlab|noao-m90"
     Xcxstatus="in:642762c1975014bc743f1701"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -25232,6 +25440,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m91/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m91"
     Xcxstatus="in:642762c1975014bc743f1702"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -25288,6 +25497,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m93/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m93"
     Xcxstatus="in:642762c2975014bc743f1704"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -25316,6 +25526,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m94/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m94"
     Xcxstatus="in:642762c3975014bc743f1705"
   >
     <Credits>Hillary Mathis, N.A.Sharp/NOIRLab/NSF/AURA/</Credits>
@@ -25344,6 +25555,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m95_2/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m95_2"
     Xcxstatus="in:642762c3975014bc743f1706"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -25372,6 +25584,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m98/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m98"
     Xcxstatus="in:642762c4975014bc743f1707"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -25400,6 +25613,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-m99/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-m99"
     Xcxstatus="in:642762c4975014bc743f1708"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -25456,6 +25670,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-mwp1/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-mwp1"
     Xcxstatus="in:642762c5975014bc743f170a"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -25484,6 +25699,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-n11lmc/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-n11lmc"
     Xcxstatus="in:642762c6975014bc743f170b"
   >
     <Credits>C. Aguilera, C. Smith and S. Points/NOIRLab/NSF/AURA/</Credits>
@@ -25512,6 +25728,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-n1999lg/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-n1999lg"
     Xcxstatus="in:642762c6975014bc743f170c"
   >
     <Credits>T.A.Rector, B.Wolpa and G.Jacoby (NOIRLab/NSF/AURA) and Hubble Heritage Team (STScI/AURA/NASA)</Credits>
@@ -25540,6 +25757,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-n2261a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-n2261a"
     Xcxstatus="in:642762c7975014bc743f170d"
   >
     <Credits>N.A.Sharp, J.McGaha/NOIRLab/NSF/AURA</Credits>
@@ -25568,6 +25786,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-n2685/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-n2685"
     Xcxstatus="in:642762c7975014bc743f170e"
   >
     <Credits>NOIRLab/AURA/NSF</Credits>
@@ -25624,6 +25843,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-n44/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-n44"
     Xcxstatus="in:642762c8975014bc743f1710"
   >
     <Credits>SSRO/PROMPT and NOIRLab/NSF/AURA</Credits>
@@ -25708,6 +25928,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc-253/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc-253"
     Xcxstatus="in:642762c9975014bc743f1713"
   >
     <Credits>SSRO/PROMPT/CTIO</Credits>
@@ -25736,6 +25957,7 @@
     TileLevels="1"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc1097/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc1097"
     Xcxstatus="in:642762ca975014bc743f1714"
   >
     <Credits>International Gemini Observatory/Abu Team/NOIRLab/NSF/AURA</Credits>
@@ -25764,6 +25986,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc1232/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc1232"
     Xcxstatus="in:642762ca975014bc743f1715"
   >
     <Credits>Hillary Mathis/NOIRLab/NSF/AURA</Credits>
@@ -25792,6 +26015,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc1300/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc1300"
     Xcxstatus="in:642762cb975014bc743f1716"
   >
     <Credits>Hillary Mathis/NOIRLab/NSF/AURA</Credits>
@@ -25820,6 +26044,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc1313/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc1313"
     Xcxstatus="in:642762cb975014bc743f1717"
   >
     <Credits>T.A. Rector/University of Alaska Anchorage, T. Abbott and NOIRLab/NSF/AURA</Credits>
@@ -25876,6 +26101,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc1532-31/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc1532-31"
     Xcxstatus="in:642762cc975014bc743f1719"
   >
     <Credits>International Gemini Observatory/Travis Rector, University of Alaska Anchorage</Credits>
@@ -25904,6 +26130,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc1788/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc1788"
     Xcxstatus="in:642762cd975014bc743f171a"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage), H. Schweiker (WIYN and NOIRLab/NSF/AURA) &amp;amp; S. Pakzad (NOIRLab/NSF/AURA)</Credits>
@@ -25932,6 +26159,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc206/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc206"
     Xcxstatus="in:642762cd975014bc743f171b"
   >
     <Credits>T.A. Rector and A. Strom (University of Alaska Anchorage) and WIYN</Credits>
@@ -25960,6 +26188,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc2442/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc2442"
     Xcxstatus="in:642762ce975014bc743f171c"
   >
     <Credits>SSRO/PROMPT and NOIRLab/NSF/AURA</Credits>
@@ -25988,6 +26217,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc253/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc253"
     Xcxstatus="in:642762ce975014bc743f171d"
   >
     <Credits>T.A. Rector/University of Alaska Anchorage, T. Abbott and NOIRLab/NSF/AURA/</Credits>
@@ -26016,6 +26246,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc281/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc281"
     Xcxstatus="in:642762cf975014bc743f171e"
   >
     <Credits>T.A. Rector/University of Alaska Anchorage and WIYN/AURA/NSF</Credits>
@@ -26044,6 +26275,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc3166/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc3166"
     Xcxstatus="in:642762cf975014bc743f171f"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -26072,6 +26304,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc3242/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc3242"
     Xcxstatus="in:642762cf975014bc743f1720"
   >
     <Credits>T.A. Rector/University of Alaska Anchorage, H. Schweiker/WIYN and NOIRLab/NSF/AURA/, L. Frattare and Z. Levay/STScI/AURA/NASA</Credits>
@@ -26100,6 +26333,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc3582/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc3582"
     Xcxstatus="in:642762d0975014bc743f1721"
   >
     <Credits>T.A. Rector/University of Alaska Anchorage, T. Abbott and NOIRLab/NSF/AURA</Credits>
@@ -26128,6 +26362,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc3628/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc3628"
     Xcxstatus="in:642762d0975014bc743f1722"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -26184,6 +26419,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc4214/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc4214"
     Xcxstatus="in:642762d1975014bc743f1724"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -26212,6 +26448,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc4395/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc4395"
     Xcxstatus="in:642762d2975014bc743f1725"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -26240,6 +26477,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc4490/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc4490"
     Xcxstatus="in:642762d2975014bc743f1726"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -26268,6 +26506,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc4656/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc4656"
     Xcxstatus="in:642762d3975014bc743f1727"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -26296,6 +26535,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc5364/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc5364"
     Xcxstatus="in:642762d3975014bc743f1728"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -26324,6 +26564,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc5474/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc5474"
     Xcxstatus="in:642762d4975014bc743f1729"
   >
     <Credits>T.A. Rector/University of Alaska Anchorage, H. Schweiker/WIYN and NOIRLab/NSF/AURA</Credits>
@@ -26352,6 +26593,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc5905/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc5905"
     Xcxstatus="in:642762d4975014bc743f172a"
   >
     <Credits>T.A. Rector/University of Alaska Anchorage, H. Schweiker/WIYN and NOIRLab/NSF/AURA</Credits>
@@ -26380,6 +26622,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc5982/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc5982"
     Xcxstatus="in:642762d5975014bc743f172b"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -26436,6 +26679,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc660kpno/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc660kpno"
     Xcxstatus="in:642762d6975014bc743f172d"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -26464,6 +26708,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc6820/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc6820"
     Xcxstatus="in:642762d6975014bc743f172e"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage)</Credits>
@@ -26492,6 +26737,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc6946/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc6946"
     Xcxstatus="in:642762d7975014bc743f172f"
   >
     <Credits>International Gemini Observatory/Travis Rector, University of Alaska Anchorage</Credits>
@@ -26520,6 +26766,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc6992/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc6992"
     Xcxstatus="in:642762d7975014bc743f1730"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and WIYN/NOIRLab/NSF/AURA</Credits>
@@ -26548,6 +26795,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc7000east/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc7000east"
     Xcxstatus="in:642762d7975014bc743f1731"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and NOIRLab/NSF/AURA</Credits>
@@ -26576,6 +26824,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc7023/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc7023"
     Xcxstatus="in:642762d8975014bc743f1732"
   >
     <Credits>T.A. Rector/University of Alaska Anchorage, H. Schweiker/WIYN and NOIRLab/NSF/AURA</Credits>
@@ -26604,6 +26853,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc7129/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc7129"
     Xcxstatus="in:642762d8975014bc743f1733"
   >
     <Credits>T. A. Rector/University of Alaska Anchorage, H. Schweiker/WIYN and NOIRLab/NSF/AURA</Credits>
@@ -26632,6 +26882,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc7380/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc7380"
     Xcxstatus="in:642762d9975014bc743f1734"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -26660,6 +26911,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-ngc7635podi/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-ngc7635podi"
     Xcxstatus="in:642762d9975014bc743f1735"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage), WIYN ODI team &amp;amp; WIYN/NOIRLab/NSF/AURA</Credits>
@@ -26688,6 +26940,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-noao-m17-09/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-noao-m17-09"
     Xcxstatus="in:642762da975014bc743f1736"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and WIYN</Credits>
@@ -26716,6 +26969,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-noao-m8/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-noao-m8"
     Xcxstatus="in:642762da975014bc743f1737"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage)</Credits>
@@ -26744,6 +26998,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-peg/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-peg"
     Xcxstatus="in:642762db975014bc743f1738"
   >
     <Credits>P. Massey/Lowell Observatory and K. Olsen/NOIRLab/NSF/AURA/</Credits>
@@ -26772,6 +27027,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-pvcep/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-pvcep"
     Xcxstatus="in:642762db975014bc743f1739"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -26800,6 +27056,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-q2237/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-q2237"
     Xcxstatus="in:642762dc975014bc743f173a"
   >
     <Credits>J.Rhoads, S.Malhotra, I.Dell&amp;#x27;Antonio (NOAO)/WIYN/NOIRLab/NSF</Credits>
@@ -26828,6 +27085,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-rosette/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-rosette"
     Xcxstatus="in:642762dc975014bc743f173b"
   >
     <Credits>N.A.Sharp/NOIRLab/NSF/AURA</Credits>
@@ -26856,6 +27114,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-sq2/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-sq2"
     Xcxstatus="in:642762dd975014bc743f173c"
   >
     <Credits>N.A.Sharp/NOIRLab/NSF/AURA</Credits>
@@ -26912,6 +27171,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-vdb141/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-vdb141"
     Xcxstatus="in:642762de975014bc743f173e"
   >
     <Credits>T.A. Rector/University of Alaska Anchorage, H. Schweiker/WIYN and NOIRLab/NSF/AURA</Credits>
@@ -26940,6 +27200,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-vdb141se/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-vdb141se"
     Xcxstatus="in:642762de975014bc743f173f"
   >
     <Credits>T.A. Rector/University of Alaska Anchorage, H. Schweiker/WIYN and NOIRLab/NSF/AURA</Credits>
@@ -26968,6 +27229,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-vdb152/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-vdb152"
     Xcxstatus="in:642762de975014bc743f1740"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -27024,6 +27286,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-veil-wiyn-0-9-m/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-veil-wiyn-0-9-m"
     Xcxstatus="in:642762df975014bc743f1742"
   >
     <Credits>T. A. Rector/University of Alaska Anchorage and WIYN/NOIRLab/NSF/AURA</Credits>
@@ -27052,6 +27315,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-veile/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-veile"
     Xcxstatus="in:642762e0975014bc743f1743"
   >
     <Credits>N.A.Sharp, REU program/NOIRLab/NSF/AURA</Credits>
@@ -27080,6 +27344,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-veilw/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-veilw"
     Xcxstatus="in:642762e0975014bc743f1744"
   >
     <Credits>N.A.Sharp, REU program/NOIRLab/NSF/AURA</Credits>
@@ -27108,6 +27373,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-virgo/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-virgo"
     Xcxstatus="in:642762e1975014bc743f1745"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -27136,6 +27402,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-wlm-dwarf/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-wlm,noirlab|noao-wlm-dwarf"
     Xcxstatus="in:642762e2975014bc743f1747"
   >
     <Credits>P. Massey/Lowell Observatory and K. Olsen/NOIRLab/NSF/AURA</Credits>
@@ -27192,6 +27459,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-wr134/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-wr134"
     Xcxstatus="in:642762e2975014bc743f1748"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -27220,6 +27488,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao-wr157/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao-wr157"
     Xcxstatus="in:642762e3975014bc743f1749"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -27248,6 +27517,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0101a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0101a"
     Xcxstatus="in:642762e3975014bc743f174a"
   >
     <Credits>B.Jannuzi, A.Dey, NDWFS team/NOIRLab/NSF/AURA/</Credits>
@@ -27276,6 +27546,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0102a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0102a"
     Xcxstatus="in:642762e4975014bc743f174b"
   >
     <Credits>WIYN/NOIRLab/NSF</Credits>
@@ -27304,6 +27575,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0103a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0103a"
     Xcxstatus="in:642762e4975014bc743f174c"
   >
     <Credits>N.A.Sharp, REU program/NOIRLab/NSF/AURA</Credits>
@@ -27332,6 +27604,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0104a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0104a"
     Xcxstatus="in:642762e5975014bc743f174d"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -27360,6 +27633,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0121a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0121a"
     Xcxstatus="in:642762e5975014bc743f174e"
   >
     <Credits>Michael Pierce, Robert Berrington (Indiana University), Nigel Sharp, Mark Hanna (NOAO)/WIYN/NSF</Credits>
@@ -27388,6 +27662,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0124a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0124a"
     Xcxstatus="in:642762e5975014bc743f174f"
   >
     <Credits>T.A.Rector and Monica Ramirez/NOIRLab/NSF/AURA/</Credits>
@@ -27416,6 +27691,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0126a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0126a"
     Xcxstatus="in:642762e6975014bc743f1750"
   >
     <Credits>T.A.Rector (NOIRLab/NSF/AURA) and Hubble Heritage Team (STScI/AURA/NASA)</Credits>
@@ -27444,6 +27720,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0136a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0136a"
     Xcxstatus="in:642762e6975014bc743f1751"
   >
     <Credits>Nathan Smith, University of Minnesota/NOIRLab/NSF/AURA</Credits>
@@ -27472,6 +27749,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0140a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0140a"
     Xcxstatus="in:642762e7975014bc743f1752"
   >
     <Credits>NOIRLab/AURA/NSF</Credits>
@@ -27500,6 +27778,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0149a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0149a"
     Xcxstatus="in:642762e7975014bc743f1753"
   >
     <Credits>P.Massey (Lowell), N.King (STScI), S.Holmes (Charleston), G.Jacoby (WIYN)/AURA/NSF</Credits>
@@ -27528,6 +27807,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0157a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0157a"
     Xcxstatus="in:642762e8975014bc743f1754"
   >
     <Credits>T.A.Rector and B.A.Wolpa/NOIRLab/NSF/AURA</Credits>
@@ -27556,6 +27836,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0202a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0202a"
     Xcxstatus="in:642762e8975014bc743f1755"
   >
     <Credits>Local Group Galaxies Survey Team/NOIRLab/NSF/AURA</Credits>
@@ -27584,6 +27865,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0203a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0203a"
     Xcxstatus="in:642762e9975014bc743f1756"
   >
     <Credits>WIYN/NOIRLab/NSF</Credits>
@@ -27612,6 +27894,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0307a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0307a"
     Xcxstatus="in:642762e9975014bc743f1757"
   >
     <Credits>NASA, NOAO, ESA, the Hubble Helix Nebula Team, M. Meixner (STScI), and T.A. Rector (NRAO)</Credits>
@@ -27640,6 +27923,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0308a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0308a"
     Xcxstatus="in:642762ea975014bc743f1758"
   >
     <Credits>University of Florida and NOIRLab/NSF/AURA</Credits>
@@ -27668,6 +27952,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0310a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0310a"
     Xcxstatus="in:642762ea975014bc743f1759"
   >
     <Credits>Karen Kwitter (Williams College), Ron Downes (STScI), You-Hua Chu (University of Illinois) and NOIRLab/NSF/AURA</Credits>
@@ -27696,6 +27981,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0311a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0311a"
     Xcxstatus="in:642762eb975014bc743f175a"
   >
     <Credits>Carnegie Observatories and NOIRLab/NSF/AURA</Credits>
@@ -27724,6 +28010,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0314a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0314a"
     Xcxstatus="in:642762eb975014bc743f175b"
   >
     <Credits>University of Colorado, University of Hawaii and NOIRLab/NSF/AURA</Credits>
@@ -27752,6 +28039,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0315a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0315a"
     Xcxstatus="in:642762ec975014bc743f175c"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -27780,6 +28068,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0315b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0315b"
     Xcxstatus="in:642762ec975014bc743f175d"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -27808,6 +28097,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0403a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0403a"
     Xcxstatus="in:642762ec975014bc743f175e"
   >
     <Credits>T. A. Rector/University of Alaska Anchorage, WIYN and NOIRLab/NSF/AURA</Credits>
@@ -27836,6 +28126,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0403c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0403c"
     Xcxstatus="in:642762ed975014bc743f175f"
   >
     <Credits>T. Rector/University of Alaska Anchorage, WIYN and NOAO/AURA/NSF</Credits>
@@ -27864,6 +28155,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0404a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0404a"
     Xcxstatus="in:642762ed975014bc743f1760"
   >
     <Credits>Mark Westmoquette (University College London), Jay Gallagher (University of Wisconsin-Madison), Linda Smith (University College London), WIYN//NSF, NASA/ESA</Credits>
@@ -27892,6 +28184,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0407a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0407a"
     Xcxstatus="in:642762ee975014bc743f1761"
   >
     <Credits>H.Crowl (Yale University) and WIYN/NOAO/AURA/NSF</Credits>
@@ -27920,6 +28213,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0601a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0601a"
     Xcxstatus="in:642762ee975014bc743f1762"
   >
     <Credits>F. Winkler/Middlebury College, the MCELS Team, and NOIRLab/NSF/AURA</Credits>
@@ -27948,6 +28242,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0601b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0601b"
     Xcxstatus="in:642762ef975014bc743f1763"
   >
     <Credits>C. Smith, S. Points, the MCELS Team and NOIRLab/NSF/AURA/</Credits>
@@ -27976,6 +28271,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0608a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0608a"
     Xcxstatus="in:642762ef975014bc743f1764"
   >
     <Credits>T.A. Rector/University of Alaska Anchorage, T. Abbott and NOIRLab/NSF/AURA/</Credits>
@@ -28004,6 +28300,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0702a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0702a"
     Xcxstatus="in:642762f0975014bc743f1765"
   >
     <Credits>T.A. Rector/University of Alaska Anchorage, H. Schweiker/WIYN and NOIRLab/NSF/AURA</Credits>
@@ -28032,6 +28329,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0702b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0702b"
     Xcxstatus="in:642762f0975014bc743f1766"
   >
     <Credits>T.A. Rector/University of Alaska Anchorage, H. Schweiker/WIYN and NOIRLab/NSF/AURA</Credits>
@@ -28060,6 +28358,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0703a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0703a"
     Xcxstatus="in:642762f1975014bc743f1767"
   >
     <Credits>T.A. Rector/University of Alaska Anchorage, H. Schweiker/WIYN and NOIRLab/NSF/AURA/</Credits>
@@ -28088,6 +28387,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0706b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0706b"
     Xcxstatus="in:642762f1975014bc743f1768"
   >
     <Credits>T.A. Rector/University of Alaska Anchorage, H. Schweiker/WIYN and NOIRLab/NSF/AURA</Credits>
@@ -28116,6 +28416,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0801a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0801a"
     Xcxstatus="in:642762f2975014bc743f1769"
   >
     <Credits>T.A. Rector/University of Alaska Anchorage, H. Schweiker/WIYN and NOIRLab/NSF/AURA</Credits>
@@ -28144,6 +28445,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0904a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0904a"
     Xcxstatus="in:642762f2975014bc743f176a"
   >
     <Credits>T. A. Rector/University of Alaska Anchorage, H. Schweiker/WIYN and NOIRLab/NSF/AURA</Credits>
@@ -28172,6 +28474,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao0906a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao0906a"
     Xcxstatus="in:642762f2975014bc743f176b"
   >
     <Credits>NOIRLab/NSF/AURA</Credits>
@@ -28200,6 +28503,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao1104a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao1104a"
     Xcxstatus="in:642762f3975014bc743f176c"
   >
     <Credits>Z. Levay (STScI/AURA/NASA), T.A. Rector (University of Alaska Anchorage) and H. Schweiker (NOIRLab/NSF/AURA)</Credits>
@@ -28228,6 +28532,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao1204b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao1204b"
     Xcxstatus="in:642762f3975014bc743f176d"
   >
     <Credits>Dark Energy Survey Collaboration</Credits>
@@ -28256,6 +28561,7 @@
     TileLevels="7"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao1207a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao1207a"
     Xcxstatus="in:642762f4975014bc743f176e"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage), WIYN ODI team &amp;amp; WIYN/NOIRLab/NSF/AURA</Credits>
@@ -28282,6 +28588,7 @@
     TileLevels="7"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao1209a/{1}/{3}/{3}_{2}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao1209a"
     Xcxstatus="in:642762f4975014bc743f176f"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and WIYN/NOIRLab/NSF/AURA</Credits>
@@ -28310,6 +28617,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao1301a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao1301a"
     Xcxstatus="in:642762f5975014bc743f1770"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -28338,6 +28646,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao1303a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao1303a"
     Xcxstatus="in:642762f5975014bc743f1771"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage), T. Allen (University of Toledo) and WIYN/NOIRLab/NSF/AURA</Credits>
@@ -28366,6 +28675,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao1308a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao1308a"
     Xcxstatus="in:642762f6975014bc743f1772"
   >
     <Credits>S. Willis (CfA+ISU); ESA/Herschel; NASA/JPL-Caltech/ Spitzer; CTIO/NOAO/AURA/NSF.</Credits>
@@ -28394,6 +28704,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao1309a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao1309a"
     Xcxstatus="in:642762f6975014bc743f1773"
   >
     <Credits>K. Rhode, M. Young and WIYN/NOIRLab/NSF/AURA/</Credits>
@@ -28422,6 +28733,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao1309b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao1309b"
     Xcxstatus="in:642762f7975014bc743f1774"
   >
     <Credits>K. Rhode, M. Young and WIYN/NOAO/AURA/NSF.</Credits>
@@ -28450,6 +28762,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao1310b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao1310b"
     Xcxstatus="in:642762f7975014bc743f1775"
   >
     <Credits>Dark Energy Survey</Credits>
@@ -28478,6 +28791,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao1507a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao1507a"
     Xcxstatus="in:642762f8975014bc743f1776"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -28506,6 +28820,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noao1601b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noao1601b"
     Xcxstatus="in:642762f8975014bc743f1777"
   >
     <Credits>Dustin Lang and SDSS Collaboration</Credits>
@@ -28534,6 +28849,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noaoann02008a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noaoann02008a"
     Xcxstatus="in:642762f9975014bc743f1778"
   >
     <Credits>Gemini Observatory / GMOS Image</Credits>
@@ -28590,6 +28906,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noaoann09007a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noaoann09007a"
     Xcxstatus="in:642762f9975014bc743f177a"
   >
     <Credits>T. A. Rector/University of Alaska Anchorage and NOIRLab/NSF/AURA</Credits>
@@ -28618,6 +28935,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noaoann09008a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noaoann09008a"
     Xcxstatus="in:642762fa975014bc743f177b"
   >
     <Credits>T. A. Rector/University of Alaska Anchorage and H. Schweiker/NOIRLab/NSF/AURA and NOIRLab/NSF/AURA</Credits>
@@ -28646,6 +28964,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noaoann09009a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noaoann09009a"
     Xcxstatus="in:642762fa975014bc743f177c"
   >
     <Credits>D. Riebel (JHU), M. Meixner (STScI) and NOIRLab/NSF/AURA</Credits>
@@ -28674,6 +28993,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/noaoann09014a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noaoann09014a"
     Xcxstatus="in:642762fb975014bc743f177d"
   >
     <Credits>G. Rothfuss, S. Byers, F. Haase and NOAO/AURA/NSF</Credits>
@@ -28702,6 +29022,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noaoann10014a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noaoann10014a"
     Xcxstatus="in:642762fb975014bc743f177e"
   >
     <Credits>SSRO/PROMPT/CTIO</Credits>
@@ -28730,6 +29051,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noaoann12008a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noaoann12008a"
     Xcxstatus="in:642762fc975014bc743f177f"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and N.S. van der Bliek (NOIRLab/NSF/AURA)</Credits>
@@ -28758,6 +29080,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noaoann13006a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noaoann13006a"
     Xcxstatus="in:642762fc975014bc743f1780"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and H. Schweiker (WIYN and NOIRLab/NSF/AURA)</Credits>
@@ -28786,6 +29109,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noaoann14003a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noaoann14003a"
     Xcxstatus="in:642762fd975014bc743f1781"
   >
     <Credits>D. Caminha &amp;amp; SOAR/NOAO/AURA/NSF</Credits>
@@ -28814,6 +29138,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noaoann14005a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noaoann14005a"
     Xcxstatus="in:642762fd975014bc743f1782"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage)</Credits>
@@ -28842,6 +29167,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noaoann15004a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noaoann15004a"
     Xcxstatus="in:642762fe975014bc743f1783"
   >
     <Credits>T.A. Rector (University of Alaska Anchorage) and NOIRLab/NSF/AURA</Credits>
@@ -28870,6 +29196,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noaoann16001a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noaoann16001a"
     Xcxstatus="in:642762fe975014bc743f1784"
   >
     <Credits>X-ray: NASA/CXC/Univ of Missouri/M.Brodwin et al; Optical: NASA/STScI; Infrared: JPL/CalTech</Credits>
@@ -28898,6 +29225,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noaoann16019a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noaoann16019a"
     Xcxstatus="in:642762ff975014bc743f1785"
   >
     <Credits>B. Saxton (NRAO/AUI/NSF); ALMA (ESO/NAOJ/NRAO); NASA/ESA Hubble</Credits>
@@ -28926,6 +29254,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noaoann16021a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noaoann16021a"
     Xcxstatus="in:642762ff975014bc743f1786"
   >
     <Credits>DECaLS</Credits>
@@ -28954,6 +29283,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noaoann18017a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noaoann18017a"
     Xcxstatus="in:64276300975014bc743f1787"
   >
     <Credits>DECaLS</Credits>
@@ -28982,6 +29312,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noaoann19007a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noaoann19007a"
     Xcxstatus="in:64276300975014bc743f1788"
   >
     <Credits>DESI Collaboration</Credits>
@@ -29010,6 +29341,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab1912a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab1912a"
     Xcxstatus="in:64276300975014bc743f1789"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA</Credits>
@@ -29038,6 +29370,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2002b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2002b"
     Xcxstatus="in:64276301975014bc743f178a"
   >
     <Credits>Gemini Observatory/NSF’s National Optical-Infrared Astronomy Research Laboratory/AURA</Credits>
@@ -29066,6 +29399,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2006a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2006a"
     Xcxstatus="in:64276301975014bc743f178b"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA</Credits>
@@ -29094,6 +29428,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2010a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2010a"
     Xcxstatus="in:64276302975014bc743f178c"
   >
     <Credits>CTIO/NOIRLab/NSF/AURA Acknowledgments: P. Massey (Lowell Obs.), G. Jacoby, K. Olsen, C. Smith (NOAO/AURA/NSF) &amp;amp; T.A. Rector (NRAO/AUI/NSF). Image processing: Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -29122,6 +29457,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2012a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2012a"
     Xcxstatus="in:64276302975014bc743f178d"
   >
     <Credits>CTIO/NOIRLab/NSF/AURA</Credits>
@@ -29150,6 +29486,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2012b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2012b"
     Xcxstatus="in:64276303975014bc743f178e"
   >
     <Credits>CTIO/NOIRLab/NSF/AURA</Credits>
@@ -29178,6 +29515,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2012c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2012c"
     Xcxstatus="in:64276303975014bc743f178f"
   >
     <Credits>NOIRLab</Credits>
@@ -29206,6 +29544,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2012d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2012d"
     Xcxstatus="in:64276304975014bc743f1790"
   >
     <Credits>CTIO/NOIRLab/NSF/AURA</Credits>
@@ -29234,6 +29573,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2013a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2013a"
     Xcxstatus="in:64276304975014bc743f1791"
   >
     <Credits>KPNO/NOIRLab/NSF/AURAData obtained and processed by: P. Massey (Lowell Obs.), G. Jacoby, K. Olsen, &amp;amp; C. Smith (NOAO/AURA/NSF)Image processing: Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -29262,6 +29602,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2014c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2014c"
     Xcxstatus="in:64276305975014bc743f1792"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA/T. Esposito (UC Berkeley)Image processing: Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -29290,6 +29631,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2014d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2014d"
     Xcxstatus="in:64276305975014bc743f1793"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA/T. Esposito (UC Berkeley)Image processing: Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -29318,6 +29660,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2014e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2014e"
     Xcxstatus="in:64276305975014bc743f1794"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA/T. Esposito (UC Berkeley)Image processing: Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -29346,6 +29689,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2014f/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2014f"
     Xcxstatus="in:64276306975014bc743f1795"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA/T. Esposito (UC Berkeley)Image processing: Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -29374,6 +29718,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2014g/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2014g"
     Xcxstatus="in:64276306975014bc743f1796"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA/T. Esposito (UC Berkeley)Image processing: Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -29402,6 +29747,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2014h/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2014h"
     Xcxstatus="in:64276307975014bc743f1797"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA/T. Esposito (UC Berkeley)Image processing: Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -29430,6 +29776,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2016a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2016a"
     Xcxstatus="in:64276307975014bc743f1798"
   >
     <Credits>KPNO/NOIRLab/NSF/AURA Acknowledgements:PI: M T. Patterson (New Mexico State University)Image processing: Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin  </Credits>
@@ -29458,6 +29805,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2016b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2016b"
     Xcxstatus="in:64276308975014bc743f1799"
   >
     <Credits>KPNO/NOIRLab/NSF/AURA Acknowledgements:PI: M T. Patterson (New Mexico State University)Image processing: Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin  </Credits>
@@ -29486,6 +29834,7 @@
     TileLevels="3"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2017c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2017c"
     Xcxstatus="in:64276308975014bc743f179a"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA/K. Paterson &amp;amp; W. Fong (Northwestern University)Image processing: Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin  </Credits>
@@ -29514,6 +29863,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2018e/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2018e"
     Xcxstatus="in:64276309975014bc743f179b"
   >
     <Credits>NOIRLab/NSF/AURA/Digitized Sky Survey 2</Credits>
@@ -29542,6 +29892,7 @@
     TileLevels="2"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2018l/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2018l"
     Xcxstatus="in:64276309975014bc743f179c"
   >
     <Credits>NOIRLab/NSF/AURA/Digitized Sky Survey 2</Credits>
@@ -29570,6 +29921,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2019d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2019d"
     Xcxstatus="in:6427630a975014bc743f179d"
   >
     <Credits>CTIO/SOAR/NOIRLab/NSF/AURA/Northwestern University/C. Kilpatrick/University of California Santa Cruz/NASA-ESA Hubble Space Telescope</Credits>
@@ -29598,6 +29950,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2025a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2025a"
     Xcxstatus="in:6427630b975014bc743f179e"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA Acknowledgment:  PI: Patrick Hartigan (Rice University) Image processing: Patrick Hartigan (Rice University), Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -29626,6 +29979,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2025d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2025d"
     Xcxstatus="in:6427630b975014bc743f179f"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURAAcknowledgment:  PI: Patrick Hartigan (Rice University) Image processing: Patrick Hartigan (Rice University), Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -29652,6 +30006,7 @@
     TileLevels="8"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2027a/{1}/{3}/{3}_{2}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2027a"
     Xcxstatus="in:6427630c975014bc743f17a0"
   >
     <Credits>CTIO/NOIRLab/DOE/NSF/AURA Acknowledgment: Image processing: W. Clarkson (UM-Dearborn), C. Johnson (STScI), and M. Rich (UCLA), Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin.</Credits>
@@ -29680,6 +30035,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2027b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2027b"
     Xcxstatus="in:6427630c975014bc743f17a1"
   >
     <Credits>CTIO/NOIRLab/DOE/NSF/AURA/STScI, W. Clarkson (UM-Dearborn), C. Johnson (STScI), and M. Rich (UCLA)</Credits>
@@ -29708,6 +30064,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2028c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2028c"
     Xcxstatus="in:6427630c975014bc743f17a2"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURA/H. Vedantham/UKIRT Hemisphere Survey</Credits>
@@ -29736,6 +30093,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2029a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2029a"
     Xcxstatus="in:6427630d975014bc743f17a3"
   >
     <Credits>International Gemini Observatory/NOIRLab/NSF/AURAImage processing: Travis Rector (University of Alaska Anchorage), Jen Miller (Gemini Observatory/NSF&amp;#x27;s NOIRLab), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -29764,6 +30122,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2029c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2029c"
     Xcxstatus="in:6427630d975014bc743f17a4"
   >
     <Credits>ESO/Digitized Sky Survey 2.Acknowledgment: Davide De Martin</Credits>
@@ -29792,6 +30151,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2030a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2030a"
     Xcxstatus="in:6427630e975014bc743f17a5"
   >
     <Credits>CTIO/NOIRLab/NSF/AURA/SMASH/D. Nidever (Montana State University) Acknowledgment: Image processing: Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -29820,6 +30180,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2030b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2030b"
     Xcxstatus="in:6427630e975014bc743f17a6"
   >
     <Credits>CTIO/NOIRLab/NSF/AURA/SMASH/D. Nidever (Montana State University) Acknowledgment: Image processing: Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -29848,6 +30209,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2101a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2101a"
     Xcxstatus="in:6427630f975014bc743f17a7"
   >
     <Credits>KPNO/NOIRLab/NSF/AURAAcknowledgments:PI: M T. Patterson (New Mexico State University)Image processing: Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -29876,6 +30238,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2101b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2101b"
     Xcxstatus="in:6427630f975014bc743f17a8"
   >
     <Credits>KPNO/NOIRLab/NSF/AURA</Credits>
@@ -29904,6 +30267,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2103a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2103a"
     Xcxstatus="in:64276310975014bc743f17a9"
   >
     <Credits>Credit: KPNO/CTIO/NOIRLab/NSF/AURA/Legacy Imaging Survey</Credits>
@@ -30044,6 +30408,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2106a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2106a"
     Xcxstatus="in:64276312975014bc743f17ae"
   >
     <Credits>DES/CTIO/NOIRLab/NSF/DOE/AURAAcknowledgments: Image processing: DES, Jen Miller (Gemini Observatory/NSF&amp;#x27;s NOIRLab), Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -30072,6 +30437,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2106b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2106b"
     Xcxstatus="in:64276312975014bc743f17af"
   >
     <Credits>DES/CTIO/NOIRLab/NSF/DOE/AURAAcknowledgments: Image processing: DES, Jen Miller (Gemini Observatory/NSF&amp;#x27;s NOIRLab), Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -30100,6 +30466,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2106c/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2106c"
     Xcxstatus="in:64276313975014bc743f17b0"
   >
     <Credits>DES/CTIO/NOIRLab/NSF/DOE/AURAAcknowledgments: Image processing: DES, Jen Miller (Gemini Observatory/NSF&amp;#x27;s NOIRLab), Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -30128,6 +30495,7 @@
     TileLevels="6"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2106d/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2106d"
     Xcxstatus="in:64276313975014bc743f17b1"
   >
     <Credits>DES/CTIO/NOIRLab/NSF/DOE/AURAAcknowledgments: Image processing: DES, Jen Miller (Gemini Observatory/NSF&amp;#x27;s NOIRLab), Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -30156,6 +30524,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2107a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2107a"
     Xcxstatus="in:64276315975014bc743f17b2"
   >
     <Credits>CTIO/NOIRLab/DOE/NSF/AURAAcknowledgment: M. Soraisam (University of Illinois)Image processing: Travis Rector (University of Alaska Anchorage), Mahdi Zamani &amp;amp; Davide de Martin</Credits>
@@ -30184,6 +30553,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2112a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2112a"
     Xcxstatus="in:64276315975014bc743f17b3"
   >
     <Credits>KPNO/NOIRLab/NSF/AURAAcknowledgment: PI: M.T. Patterson (New Mexico State University)Image processing: T.A. Rector (University of Alaska Anchorage), M. Zamani &amp;amp; D. de Martin</Credits>
@@ -30212,6 +30582,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2112b/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2112b"
     Xcxstatus="in:64276316975014bc743f17b4"
   >
     <Credits>KPNO/NOIRLab/NSF/AURAAcknowledgment: PI: M.T. Patterson (New Mexico State University)Image processing: T.A. Rector (University of Alaska Anchorage), M. Zamani &amp;amp; D. de Martin</Credits>
@@ -30240,6 +30611,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2115a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2115a"
     Xcxstatus="in:64276316975014bc743f17b5"
   >
     <Credits>KPNO/NOIRLab/NSF/AURAData obtained and processed by: P. Massey (Lowell Obs.), G. Jacoby, K. Olsen, &amp;amp; C. Smith (AURA/NSF) Image processing: T.A. Rector (University of Alaska Anchorage/NSF’s NOIRLab), M. Zamani (NSF’s NOIRLab) &amp;amp; D. de Martin (NSF’s NOIRLab)</Credits>
@@ -30268,6 +30640,7 @@
     TileLevels="5"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2118a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2118a"
     Xcxstatus="in:64276317975014bc743f17b6"
   >
     <Credits>Dark Energy Survey/DOE/FNAL/DECam/CTIO/NOIRLab/NSF/AURAAcknowledgments: T.A. Rector (University of Alaska Anchorage/NSF’s NOIRLab), M. Zamani (NSF’s NOIRLab) &amp;amp; D. de Martin (NSF’s NOIRLab)</Credits>
@@ -30296,6 +30669,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/noirlab2125a/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|noirlab2125a"
     Xcxstatus="in:64276317975014bc743f17b7"
   >
     <Credits>CTIO/NOIRLab/DOE/NSF/AURAAcknowledgments:PI: M. Soraisam (University of Illinois at Urbana-Champaign/NSF&amp;#x27;s NOIRLab)Image processing: T.A. Rector (University of Alaska Anchorage/NSF’s NOIRLab), M. Zamani (NSF’s NOIRLab) &amp;amp; D. de Martin (NSF’s NOIRLab) </Credits>
@@ -30324,6 +30698,7 @@
     TileLevels="4"
     Url="http://data1.wwtassets.org/feeds/noirlab/rubin-rubin-stills-0051/L{1}X{2}Y{3}.png"
     WidthFactor="2"
+    Xastropix_ids="noirlab|rubin-rubin-stills-0051"
     Xcxstatus="in:64276318975014bc743f17b8"
   >
     <Credits>M. Park/Inigo Films/Rubin Observatory/ NSF/ AURA</Credits>

--- a/imagesets/sky__xray.xml
+++ b/imagesets/sky__xray.xml
@@ -83,6 +83,7 @@
     TileLevels="4"
     Url="http://r{S:0}.ortho.tiles.virtualearth.net/tiles/wsa0000000100{Q}?g=131"
     WidthFactor="2"
+    Xastropix_ids="chandra|145"
     Xcxstatus="in:65394896b493728d11b82eb5"
   >
     <Credits>X-ray: NASA/UIUC/Y.Chu et al., Optical: NASA/HST</Credits>

--- a/places/sky_ra05.yml
+++ b/places/sky_ra05.yml
@@ -4105,8 +4105,10 @@ zoom_level: 4.0
 ---
 _uuid: 6492b213-8592-443a-9fcf-f57bb06925e3
 angular_size: 1.0
+astropix_id: stsci|2005-37a
 classification: SupernovaRemnant
 constellation: TAU
+cxstatus: in:66737c60643c1aaca06dfa44
 data_set_type: Sky
 dec_deg: 22.0166666666667
 foreground_image_set_url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001321{Q}?g=138

--- a/places/sky_ra05.yml
+++ b/places/sky_ra05.yml
@@ -4103,17 +4103,6 @@ name: Bow Shock Near Young Star LL Ori
 ra_hr: 5.58472222222222
 zoom_level: 4.0
 ---
-_uuid: 6a0c9089-27d4-4949-83f9-abb1badee694
-angular_size: 1.0
-classification: SupernovaRemnant
-constellation: TAU
-data_set_type: Sky
-dec_deg: 22.0166666666667
-foreground_image_set_url: http://r{S:1}.ortho.tiles.virtualearth.net/tiles/wsa0000001321{Q}?g=138
-name: Giant Hubble Mosaic of the Crab Nebula
-ra_hr: 5.575555555555546
-zoom_level: 1.0
----
 _uuid: 6492b213-8592-443a-9fcf-f57bb06925e3
 angular_size: 1.0
 classification: SupernovaRemnant


### PR DESCRIPTION
This records the results of the first pass of automated matching between AstroPix and WWT Constellations, with a little manual patching. The current situation is:

```
6336 images in the filtered AstroPix database
3346 images already linked
14 AstroPix IDs in the ignore list

publisher `esahubble` :  1197 unassociated images
publisher `stsci`     :  1000 unassociated images
publisher `noirlab`   :   365 unassociated images
publisher `eso`       :   230 unassociated images
publisher `spitzer`   :    38 unassociated images
publisher `nrao`      :    36 unassociated images
publisher `chandra`   :    32 unassociated images
publisher `nhsc`      :    32 unassociated images
publisher `nustar`    :    23 unassociated images
publisher `galex`     :    15 unassociated images
publisher `ensci`     :     4 unassociated images
publisher `wise`      :     3 unassociated images
publisher `planck`    :     1 unassociated images
```
